### PR TITLE
Fix: minor refactoring and docstring polishing

### DIFF
--- a/obp/dataset/real.py
+++ b/obp/dataset/real.py
@@ -4,13 +4,14 @@
 """Dataset Class for Real-World Logged Bandit Feedback."""
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 from scipy.stats import rankdata
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_random_state
+
 from .base import BaseRealBanditDataset
 from ..types import BanditFeedback
 
@@ -21,13 +22,13 @@ class OpenBanditDataset(BaseRealBanditDataset):
 
     Note
     -----
-    Users are free to implement their own feature engineering by overriding `pre_process` method.
+    Users are free to implement their own feature engineering by overriding the `pre_process` method.
 
     Parameters
     -----------
     behavior_policy: str
         Name of the behavior policy that generated the logged bandit feedback data.
-        Must be 'random' or 'bts'.
+        Must be either 'random' or 'bts'.
 
     campaign: str
         One of the three possible campaigns considered in ZOZOTOWN, "all", "men", and "women".
@@ -61,7 +62,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
             "men",
             "women",
         ], f"campaign must be one of 'all', 'men', and 'women', but {self.campaign} is given"
-        assert isinstance(self.data_path, Path), f"data_path must be a Path"
+        assert isinstance(self.data_path, Path), f"data_path must be a Path type"
 
         self.data_path = self.data_path / self.behavior_policy / self.campaign
         self.raw_data_file = f"{self.campaign}.csv"
@@ -71,7 +72,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
 
     @property
     def n_rounds(self) -> int:
-        """Total number of rounds in the logged bandit dataset."""
+        """Total number of rounds contained in the logged bandit dataset."""
         return self.data.shape[0]
 
     @property
@@ -81,7 +82,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
 
     @property
     def dim_context(self) -> int:
-        """Number of dimensions of context vectors."""
+        """Dimensions of context vectors."""
         return self.context.shape[1]
 
     @property
@@ -104,7 +105,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
         ----------
         behavior_policy: str
             Name of the behavior policy that generated the log data.
-            Must be 'random' or 'bts'.
+            Must be either 'random' or 'bts'.
 
         campaign: str
             One of the three possible campaigns considered in ZOZOTOWN (i.e., "all", "men", and "women").
@@ -121,7 +122,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
         Returns
         ---------
         on_policy_policy_value_estimate: float
-            Estimated on-policy policy value of behavior policy, i.e., :math:`\\mathbb{E}_{\\mathcal{D}} [r_t]`.
+            Policy value of the behavior policy estimated by on-policy estimation, i.e., :math:`\\mathbb{E}_{\\mathcal{D}} [r_t]`.
             where :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
             This parameter is used as a ground-truth policy value in the evaluation of OPE estimators.
 
@@ -170,43 +171,52 @@ class OpenBanditDataset(BaseRealBanditDataset):
 
     def obtain_batch_bandit_feedback(
         self, test_size: float = 0.3, is_timeseries_split: bool = False
-    ) -> BanditFeedback:
+    ) -> Union[BanditFeedback, Tuple[BanditFeedback, BanditFeedback]]:
         """Obtain batch logged bandit feedback.
 
         Parameters
         -----------
         test_size: float, default=0.3
-            If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the test split.
+            If float, should be between 0.0 and 1.0 and represent the proportion of
+            the dataset to include in the evaluation split.
 
         is_timeseries_split: bool, default=False
             If true, split the original logged badnit feedback data by time series.
 
         Returns
         --------
-        bandit_feedback: BanditFeedback
-            Batch logged bandit feedback collected by the behavior policy.
+        bandit_feedback: tuple or BanditFeedback
+            Batch logged bandit feedback collected by a behavior policy.
+            When `is_timeseries_split` is true, this method returns a tuple of
+            train and evaluation sets of bandit feedback, (bandit_feedback_train, bandit_feedback_eval)
 
         """
         if is_timeseries_split:
             assert isinstance(test_size, float) & (
                 0 < test_size < 1
-            ), f"test_size must be a float between 0 and 1, but {test_size} is given"
+            ), f"test_size must be a float in the (0,1) interval, but {test_size} is given"
             n_rounds_train = np.int(self.n_rounds * (1.0 - test_size))
-            return dict(
+            bandit_feedback_train = dict(
                 n_rounds=n_rounds_train,
                 n_actions=self.n_actions,
                 action=self.action[:n_rounds_train],
-                action_test=self.action[n_rounds_train:],
                 position=self.position[:n_rounds_train],
-                position_test=self.position[n_rounds_train:],
                 reward=self.reward[:n_rounds_train],
-                reward_test=self.reward[n_rounds_train:],
                 pscore=self.pscore[:n_rounds_train],
-                pscore_test=self.pscore[n_rounds_train:],
                 context=self.context[:n_rounds_train],
-                context_test=self.context[n_rounds_train:],
                 action_context=self.action_context,
             )
+            bandit_feedback_eval = dict(
+                n_rounds=np.int(self.n_rounds - n_rounds_train),
+                n_actions=self.n_actions,
+                action=self.action[n_rounds_train:],
+                position=self.position[n_rounds_train:],
+                reward=self.reward[n_rounds_train:],
+                pscore=self.pscore[n_rounds_train:],
+                context=self.context[n_rounds_train:],
+                action_context=self.action_context,
+            )
+            return bandit_feedback_train, bandit_feedback_eval
         else:
             return dict(
                 n_rounds=self.n_rounds,
@@ -225,32 +235,50 @@ class OpenBanditDataset(BaseRealBanditDataset):
         test_size: float = 0.3,
         is_timeseries_split: bool = False,
         random_state: Optional[int] = None,
-    ) -> BanditFeedback:
-        """Sample bootstrap logged bandit feedback.
+    ) -> Union[BanditFeedback, Tuple[BanditFeedback, BanditFeedback]]:
+        """Obtain bootstrap logged bandit feedback.
 
         Parameters
         -----------
         test_size: float, default=0.3
-            If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the test split.
+            If float, should be between 0.0 and 1.0 and represent the proportion of
+            the dataset to include in the evaluation split.
 
         is_timeseries_split: bool, default=False
             If true, split the original logged badnit feedback data by time series.
 
         random_state: int, default=None
-            Controls the random seed in sampling logged bandit dataset.
+            Controls the random seed in bootstrap sampling.
 
         Returns
         --------
-        bootstrap_bandit_feedback: BanditFeedback
-            Bootstrapped logged bandit feedback independently sampled from the original data with replacement.
+        bandit_feedback: BanditFeedback
+            Logged bandit feedback sampled independently from the original data with replacement.
+            When `is_timeseries_split` is true, this method returns a tuple of
+            train and evaluation sets of bandit feedback, (bandit_feedback_train, bandit_feedback_eval)
+            where the train set is sampled independently from the original train data with replacement.
 
         """
-        bandit_feedback = self.obtain_batch_bandit_feedback(
-            test_size=test_size, is_timeseries_split=is_timeseries_split
-        )
-        n_rounds = bandit_feedback["n_rounds"]
-        random_ = check_random_state(random_state)
-        bootstrap_idx = random_.choice(np.arange(n_rounds), size=n_rounds, replace=True)
-        for key_ in ["action", "position", "reward", "pscore", "context"]:
-            bandit_feedback[key_] = bandit_feedback[key_][bootstrap_idx]
-        return bandit_feedback
+        if is_timeseries_split:
+            (
+                bandit_feedback_train,
+                bandit_feedback_eval,
+            ) = self.obtain_batch_bandit_feedback(
+                test_size=test_size, is_timeseries_split=is_timeseries_split
+            )
+            n_rounds = bandit_feedback_train["n_rounds"]
+            random_ = check_random_state(random_state)
+            bootstrap_idx = random_.choice(n_rounds, size=n_rounds, replace=True)
+            for key_ in ["action", "position", "reward", "pscore", "context"]:
+                bandit_feedback_train[key_] = bandit_feedback_train[key_][bootstrap_idx]
+            return bandit_feedback_train, bandit_feedback_eval
+        else:
+            bandit_feedback = self.obtain_batch_bandit_feedback(
+                test_size=test_size, is_timeseries_split=is_timeseries_split
+            )
+            n_rounds = bandit_feedback["n_rounds"]
+            random_ = check_random_state(random_state)
+            bootstrap_idx = random_.choice(n_rounds, size=n_rounds, replace=True)
+            for key_ in ["action", "position", "reward", "pscore", "context"]:
+                bandit_feedback[key_] = bandit_feedback[key_][bootstrap_idx]
+            return bandit_feedback

--- a/obp/ope/estimators.py
+++ b/obp/ope/estimators.py
@@ -13,7 +13,7 @@ from ..utils import estimate_confidence_interval_by_bootstrap
 
 @dataclass
 class BaseOffPolicyEstimator(metaclass=ABCMeta):
-    """Base class for off-policy estimators."""
+    """Base class for OPE estimators."""
 
     @abstractmethod
     def _estimate_round_rewards(self) -> np.ndarray:
@@ -35,6 +35,8 @@ class BaseOffPolicyEstimator(metaclass=ABCMeta):
 class ReplayMethod(BaseOffPolicyEstimator):
     """Estimate the policy value by Relpay Method (RM).
 
+    Note
+    -------
     Replay Method (RM) estimates the policy value of a given evaluation policy :math:`\\pi_e` by
 
     .. math::
@@ -42,9 +44,9 @@ class ReplayMethod(BaseOffPolicyEstimator):
         \\hat{V}_{\\mathrm{RM}} (\\pi_e; \\mathcal{D}) :=
         \\frac{\\mathbb{E}_{\\mathcal{D}}[\\mathbb{I} \\{ \\pi_e (x_t) = a_t \\} r_t ]}{\\mathbb{E}_{\\mathcal{D}}[\\mathbb{I} \\{ \\pi_e (x_t) = a_t \\}]},
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by :math:`\\pi_b`.
-    :math:`\\pi_e: \\mathcal{X} \\rightarrow \\mathcal{A}` is the function
-    representing the deterministic action choices by the evaluation policy during the offline bandit simulation.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by
+    a behavior policy :math:`\\pi_b`. :math:`\\pi_e: \\mathcal{X} \\rightarrow \\mathcal{A}` is the function
+    representing action choices by the evaluation policy realized during offline bandit simulation.
     :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
 
     Parameters
@@ -74,10 +76,10 @@ class ReplayMethod(BaseOffPolicyEstimator):
         Parameters
         ------------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
@@ -109,10 +111,10 @@ class ReplayMethod(BaseOffPolicyEstimator):
         Parameters
         ------------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
@@ -143,10 +145,10 @@ class ReplayMethod(BaseOffPolicyEstimator):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
@@ -181,18 +183,20 @@ class ReplayMethod(BaseOffPolicyEstimator):
 class InverseProbabilityWeighting(BaseOffPolicyEstimator):
     """Estimate the policy value by Inverse Probability Weighting (IPW).
 
+    Note
+    -------
     Inverse Probability Weighting (IPW) estimates the policy value of a given evaluation policy :math:`\\pi_e` by
 
     .. math::
 
         \\hat{V}_{\\mathrm{IPW}} (\\pi_e; \\mathcal{D}) := \\mathbb{E}_{\\mathcal{D}} [ w(x_t,a_t) r_t],
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by :math:`\\pi_b`.
-    :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by
+    a behavior policy :math:`\\pi_b`. :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
     :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
 
     IPW re-weights the rewards by the ratio of the evaluation policy and behavior policy (importance weight).
-    When the behavior policy is known, the IPW estimator is unbiased and consistent for the policy value.
+    When the behavior policy is known, IPW is unbiased and consistent for the true policy value.
     However, it can have a large variance, especially when the evaluation policy significantly deviates from the behavior policy.
 
     Parameters
@@ -226,16 +230,16 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         Returns
         ----------
@@ -260,19 +264,19 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         Returns
         ----------
@@ -305,20 +309,20 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities
-            by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities
+            by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         alpha: float, default=0.05
             P-value.
@@ -354,6 +358,8 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
 class SelfNormalizedInverseProbabilityWeighting(InverseProbabilityWeighting):
     """Estimate the policy value by Self-Normalized Inverse Probability Weighting (SNIPW).
 
+    Note
+    -------
     Self-Normalized Inverse Probability Weighting (SNIPW) estimates the policy value of a given evaluation policy :math:`\\pi_e` by
 
     .. math::
@@ -361,13 +367,13 @@ class SelfNormalizedInverseProbabilityWeighting(InverseProbabilityWeighting):
         \\hat{V}_{\\mathrm{SNIPW}} (\\pi_e; \\mathcal{D}) :=
         \\frac{\\mathbb{E}_{\\mathcal{D}} [w(x_t,a_t) r_t]}{ \\mathbb{E}_{\\mathcal{D}} [w(x_t,a_t)]},
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by :math:`\\pi_b`.
-    :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by
+    a behavior policy :math:`\\pi_b`. :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
     :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
 
     SNIPW re-weights the observed rewards by the self-normalized importance weihgt.
     This estimator is not unbiased even when the behavior policy is known.
-    However, it is still consistent for the policy value and increases the stability in some senses.
+    However, it is still consistent for the true policy value and increases the stability in some senses.
     See the references for the detailed discussions.
 
     Parameters
@@ -401,19 +407,19 @@ class SelfNormalizedInverseProbabilityWeighting(InverseProbabilityWeighting):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         Returns
         ----------
@@ -429,6 +435,8 @@ class SelfNormalizedInverseProbabilityWeighting(InverseProbabilityWeighting):
 class DirectMethod(BaseOffPolicyEstimator):
     """Estimate the policy value by Direct Method (DM).
 
+    Note
+    -------
     DM first learns a supervised machine learning model, such as ridge regression and gradient boosting,
     to estimate the mean reward function (:math:`q(x,a) = \\mathbb{E}[r|x,a]`).
     It then uses it to estimate the policy value as follows.
@@ -436,15 +444,16 @@ class DirectMethod(BaseOffPolicyEstimator):
     .. math::
 
         \\hat{V}_{\\mathrm{DM}} (\\pi_e; \\mathcal{D}, \\hat{q})
-        :=  \\mathbb{E}_{\\mathcal{D}}[\\hat{q} (x_t,\\pi_e)],
+        &:= \\mathbb{E}_{\\mathcal{D}} \\left[ \\sum_{a \\in \\mathcal{A}} \\hat{q} (x_t,a) \\pi_e(a|x_t) \\right],    \\\\
+        & =  \\mathbb{E}_{\\mathcal{D}}[\\hat{q} (x_t,\\pi_e)],
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by :math:`\\pi_b`.
-    :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by
+    a behavior policy :math:`\\pi_b`. :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
     :math:`\\hat{q} (x,a)` is an estimated expected reward given :math:`x` and :math:`a`.
     :math:`\\hat{q} (x_t,\\pi):= \\mathbb{E}_{a \\sim \\pi(a|x)}[\\hat{q}(x,a)]` is the expectation of the estimated reward function over :math:`\\pi`.
     To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`, which supports several fitting methods specific to OPE.
 
-    If the regression model is a good approximation to the mean reward function,
+    If the regression model (:math:`\\hat{q}`) is a good approximation to the true mean reward function,
     this estimator accurately estimates the policy value of the evaluation policy.
     If the regression function fails to approximate the mean reward function well,
     however, the final estimator is no longer consistent.
@@ -481,10 +490,10 @@ class DirectMethod(BaseOffPolicyEstimator):
             Positions of each round in the given logged bandit feedback.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated rewards for each round, action, and position by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -514,10 +523,10 @@ class DirectMethod(BaseOffPolicyEstimator):
             Positions of each round in the given logged bandit feedback.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated rewards for each round, action, and position by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -549,10 +558,10 @@ class DirectMethod(BaseOffPolicyEstimator):
             Positions of each round in the given logged bandit feedback.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated rewards for each round, action, and position by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         alpha: float, default=0.05
             P-value.
@@ -586,6 +595,8 @@ class DirectMethod(BaseOffPolicyEstimator):
 class DoublyRobust(InverseProbabilityWeighting):
     """Estimate the policy value by Doubly Robust (DR).
 
+    Note
+    -------
     Similar to DM, DR first learns a supervised machine learning model, such as ridge regression and gradient boosting,
     to estimate the mean reward function (:math:`q(x,a) = \\mathbb{E}[r|x,a]`).
     It then uses it to estimate the policy value as follows.
@@ -595,11 +606,13 @@ class DoublyRobust(InverseProbabilityWeighting):
         \\hat{V}_{\\mathrm{DR}} (\\pi_e; \\mathcal{D}, \\hat{q})
         := \\mathbb{E}_{\\mathcal{D}}[\\hat{q}(x_t,\\pi_e) +  w(x_t,a_t) (r_t - \\hat{q}(x_t,a_t))],
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by :math:`\\pi_b`.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by
+    a behavior policy :math:`\\pi_b`.
     :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
     :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
     :math:`\\hat{q} (x,a)` is an estimated expected reward given :math:`x` and :math:`a`.
     :math:`\\hat{q} (x_t,\\pi):= \\mathbb{E}_{a \\sim \\pi(a|x)}[\\hat{q}(x,a)]` is the expectation of the estimated reward function over :math:`\\pi`.
+
     To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`,
     which supports several fitting methods specific to OPE such as *more robust doubly robust*.
 
@@ -641,22 +654,22 @@ class DoublyRobust(InverseProbabilityWeighting):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated rewards for each round, action, and position by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -693,22 +706,22 @@ class DoublyRobust(InverseProbabilityWeighting):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated rewards for each round, action, and position by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -743,22 +756,22 @@ class DoublyRobust(InverseProbabilityWeighting):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated rewards for each round, action, and position by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         alpha: float, default=0.05
             P-value.
@@ -795,6 +808,8 @@ class DoublyRobust(InverseProbabilityWeighting):
 class SelfNormalizedDoublyRobust(DoublyRobust):
     """Estimate the policy value by Self-Normalized Doubly Robust (SNDR).
 
+    Note
+    -------
     Self-Normalized Doubly Robust estimates the policy value of a given evaluation policy :math:`\\pi_e` by
 
     .. math::
@@ -802,13 +817,12 @@ class SelfNormalizedDoublyRobust(DoublyRobust):
         \\hat{V}_{\\mathrm{SNDR}} (\\pi_e; \\mathcal{D}, \\hat{q}) :=
         \\frac{\\mathbb{E}_{\\mathcal{D}}[\\hat{q}(x_t,\\pi_e) +  w(x_t,a_t) (r_t - \\hat{q}(x_t,a_t))]}{\\mathbb{E}_{\\mathcal{D}}[ w(x_t,a_t) ]},
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by :math:`\\pi_b`.
-    :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by
+    a behavior policy :math:`\\pi_b`. :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
     :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
     :math:`\\hat{q} (x,a)` is an estimated expected reward given :math:`x` and :math:`a`.
     :math:`\\hat{q} (x_t,\\pi):= \\mathbb{E}_{a \\sim \\pi(a|x)}[\\hat{q}(x,a)]` is the expectation of the estimated reward function over :math:`\\pi`.
-    To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`,
-    which supports several fitting methods specific to OPE such as *more robust doubly robust*.
+    To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`.
 
     Similar to Self-Normalized Inverse Probability Weighting, SNDR estimator applies the self-normalized importance weighting technique to
     increase the stability of the original Doubly Robust estimator.
@@ -845,22 +859,22 @@ class SelfNormalizedDoublyRobust(DoublyRobust):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated rewards for each round, action, and position by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -888,21 +902,22 @@ class SelfNormalizedDoublyRobust(DoublyRobust):
 class SwitchInverseProbabilityWeighting(DoublyRobust):
     """Estimate the policy value by Switch Inverse Probability Weighting (Switch-IPW).
 
-    Switch-IPW aims to reduce the variance of the Inverse Probability Weighting estimator by using direct method instead
+    Note
+    -------
+    Switch-IPW aims to reduce the variance of the IPW estimator by using direct method
     when the importance weight is large. This estimator estimates the policy value of a given evaluation policy :math:`\\pi_e` by
 
     .. math::
 
-        \\hat{V}_{\\mathrm{SwitchIPW}} (\\pi_e; \\mathcal{D}, \\tau)
-        := \\mathbb{E}_{\\mathcal{D}} \\left[ \\sum_{a \\in \\mathcal{A}} \\hat{q} (x_t, a) \\pi_e (a|x_t) \\mathbb{I} \\{ w(x_t, a) > \\tau \\}
+        & \\hat{V}_{\\mathrm{SwitchIPW}} (\\pi_e; \\mathcal{D}, \\tau) \\\\
+        & := \\mathbb{E}_{\\mathcal{D}} \\left[ \\sum_{a \\in \\mathcal{A}} \\hat{q} (x_t, a) \\pi_e (a|x_t) \\mathbb{I} \\{ w(x_t, a) > \\tau \\}
          + w(x_t,a_t) r_t \\mathbb{I} \\{ w(x_t,a_t) \\le \\tau \\} \\right],
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by :math:`\\pi_b`.
-    :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by
+    a behavior policy :math:`\\pi_b`. :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
     :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
     :math:`\\tau (\\ge 0)` is a switching hyperparameter, which decides the threshold for the importance weight.
-    To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`,
-    which supports several fitting methods specific to OPE such as *more robust doubly robust*.
+    To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`.
 
     Parameters
     ----------
@@ -930,7 +945,7 @@ class SwitchInverseProbabilityWeighting(DoublyRobust):
         """Initialize Class."""
         assert (
             self.tau >= 0.0
-        ), f"switching hyperparameter should be larger than 1. but {self.tau} is given"
+        ), f"switching hyperparameter should be larger than 1, but {self.tau} is given"
 
     def _estimate_round_rewards(
         self,
@@ -947,22 +962,22 @@ class SwitchInverseProbabilityWeighting(DoublyRobust):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated rewards for each round, action, and position by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -988,7 +1003,9 @@ class SwitchInverseProbabilityWeighting(DoublyRobust):
 class SwitchDoublyRobust(DoublyRobust):
     """Estimate the policy value by Switch Doubly Robust (Switch-DR).
 
-    Switch-DR aims to reduce the variance of the Doubly Robust estimator by using direct method instead of doubly robust
+    Note
+    -------
+    Switch-DR aims to reduce the variance of the DR estimator by using direct method
     when the importance weight is large. This estimator estimates the policy value of a given evaluation policy :math:`\\pi_e` by
 
     .. math::
@@ -996,20 +1013,19 @@ class SwitchDoublyRobust(DoublyRobust):
         \\hat{V}_{\\mathrm{SwitchDR}} (\\pi_e; \\mathcal{D}, \\hat{q}, \\tau)
         := \\mathbb{E}_{\\mathcal{D}} [\\hat{q}(x_t,\\pi_e) +  w(x_t,a_t) (r_t - \\hat{q}(x_t,a_t)) \\mathbb{I} \\{ w(x_t,a_t) \\le \\tau \\}],
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by :math:`\\pi_b`.
-    :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by
+    a behavior policy :math:`\\pi_b`. :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
     :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
     :math:`\\tau (\\ge 0)` is a switching hyperparameter, which decides the threshold for the importance weight.
     :math:`\\hat{q} (x,a)` is an estimated expected reward given :math:`x` and :math:`a`.
     :math:`\\hat{q} (x_t,\\pi):= \\mathbb{E}_{a \\sim \\pi(a|x)}[\\hat{q}(x,a)]` is the expectation of the estimated reward function over :math:`\\pi`.
-    To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`,
-    which supports several fitting methods specific to OPE such as *more robust doubly robust*.
+    To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`.
 
     Parameters
     ----------
     tau: float, default=1
         Switching hyperparameter. When importance weight is larger than this parameter, the DM estimator is applied, otherwise the DR estimator is applied.
-        This hyperparameter should be larger than 0., otherwise it is meaningless.
+        This hyperparameter should be larger than or equal to 0., otherwise it is meaningless.
 
     estimator_name: str, default='switch-dr'.
         Name of off-policy estimator.
@@ -1048,22 +1064,22 @@ class SwitchDoublyRobust(DoublyRobust):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated rewards for each round, action, and position by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -1092,7 +1108,9 @@ class SwitchDoublyRobust(DoublyRobust):
 class DoublyRobustWithShrinkage(DoublyRobust):
     """Estimate the policy value by Doubly Robust with optimistic shrinkage (DRos).
 
-    DR with shrinkage replaces the importance weight in the original DR estimator with a new weight mapping
+    Note
+    ------
+    DR with (optimistic) shrinkage replaces the importance weight in the original DR estimator with a new weight mapping
     found by directly optimizing sharp bounds on the resulting MSE.
 
     .. math::
@@ -1100,13 +1118,13 @@ class DoublyRobustWithShrinkage(DoublyRobust):
         \\hat{V}_{\\mathrm{DRos}} (\\pi_e; \\mathcal{D}, \\hat{q}, \\lambda)
         := \\mathbb{E}_{\\mathcal{D}} [\\hat{q}(x_t,\\pi_e) +  w_o(x_t,a_t;\\lambda) (r_t - \\hat{q}(x_t,a_t))],
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by :math:`\\pi_b`.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by
+    a behavior policy :math:`\\pi_b`.
     :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
     :math:`\\hat{q} (x_t,\\pi):= \\mathbb{E}_{a \\sim \\pi(a|x)}[\\hat{q}(x,a)]` is the expectation of the estimated reward function over :math:`\\pi`.
     :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
     :math:`\\hat{q} (x,a)` is an estimated expected reward given :math:`x` and :math:`a`.
-    To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`,
-    which supports several fitting methods specific to OPE such as *more robust doubly robust*.
+    To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`.
 
     :math:`w_{o} (x_t,a_t;\\lambda)` is a new weight by the shrinkage technique which is defined as
 
@@ -1117,15 +1135,13 @@ class DoublyRobustWithShrinkage(DoublyRobust):
     When :math:`\\lambda=0`, we have :math:`w_{o} (x,a;\\lambda)=0` corresponding to the DM estimator.
     In contrast, as :math:`\\lambda \\rightarrow \\infty`, :math:`w_{o} (x,a;\\lambda)` increases and in the limit becomes equal to
     the original importance weight, corresponding to the standard DR estimator.
-    Note that there is the other kind of the shrinkage technique called *pessimistic shrinkage*.
-    DR with pessimistic shrinkage can be achieved by controlling the clipping hyperparameter of the original DR estimator
-    (i.e., obp.ope.DoublyRobust), and thus is not implemented in this class.
 
 
     Parameters
     ----------
     lambda_: float
-        Shrinkage hyperparameter. This hyperparameter should be larger than 0., otherwise it is meaningless.
+        Shrinkage hyperparameter.
+        This hyperparameter should be larger than or equal to 0., otherwise it is meaningless.
 
     estimator_name: str, default='dr-os'.
         Name of off-policy estimator.
@@ -1164,22 +1180,22 @@ class DoublyRobustWithShrinkage(DoublyRobust):
         Parameters
         ----------
         reward: array-like, shape (n_rounds,)
-            Observed reward (or outcome) of each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
             Positions of each round in the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a|x)`.
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated rewards for each round, action, and position by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------

--- a/obp/ope/regression_model.py
+++ b/obp/ope/regression_model.py
@@ -29,7 +29,7 @@ class RegressionModel(BaseEstimator):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     action_context: array-like, shape (n_actions, dim_action_context), default=None
@@ -96,7 +96,7 @@ class RegressionModel(BaseEstimator):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -112,7 +112,7 @@ class RegressionModel(BaseEstimator):
             When `len_list` > 1, this position argument has to be set.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic).
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
             When either of 'iw' or 'mrdr' is used as the 'fitting_method' argument, then `action_dist` must be given.
 
         """
@@ -235,7 +235,7 @@ class RegressionModel(BaseEstimator):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -251,7 +251,7 @@ class RegressionModel(BaseEstimator):
             When `len_list` > 1, this position argument has to be set.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Distribution over actions or the action choice probabilities by the evaluation policy (can be deterministic).
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
             When either of 'iw' or 'mrdr' is used as the 'fitting_method' argument, then `action_dist` must be given.
 
         n_folds: int, default=1
@@ -348,7 +348,7 @@ class RegressionModel(BaseEstimator):
             Context vectors in the training logged bandit feedback.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         action_context: array-like, shape shape (n_actions, dim_action_context)
             Context vector characterizing each action, vector representation of each action.

--- a/obp/policy/base.py
+++ b/obp/policy/base.py
@@ -20,7 +20,7 @@ class BaseContextFreePolicy(metaclass=ABCMeta):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1
@@ -93,7 +93,7 @@ class BaseContextualPolicy(metaclass=ABCMeta):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1
@@ -175,7 +175,7 @@ class BaseOfflinePolicyLearner(metaclass=ABCMeta):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     """
@@ -199,7 +199,7 @@ class BaseOfflinePolicyLearner(metaclass=ABCMeta):
 
     @abstractmethod
     def fit(self,) -> None:
-        """Fits the offline bandit policy according to the given logged bandit feedback data."""
+        """Fits an offline bandit policy using the given logged bandit feedback data."""
         raise NotImplementedError
 
     @abstractmethod
@@ -213,8 +213,8 @@ class BaseOfflinePolicyLearner(metaclass=ABCMeta):
 
         Returns
         -----------
-        action_dist: array-like, shape (n_rounds_of_new_data, n_actions, len_list)
-            Predicted best actions for new data.
+        action: array-like, shape (n_rounds_of_new_data, n_actions, len_list)
+            Action choices by a policy trained by calling the `fit` method.
 
         """
         raise NotImplementedError

--- a/obp/policy/contextfree.py
+++ b/obp/policy/contextfree.py
@@ -31,7 +31,7 @@ class EpsilonGreedy(BaseContextFreePolicy):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1
@@ -106,7 +106,7 @@ class Random(EpsilonGreedy):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1
@@ -158,7 +158,7 @@ class BernoulliTS(BaseContextFreePolicy):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1

--- a/obp/policy/linear.py
+++ b/obp/policy/linear.py
@@ -22,7 +22,7 @@ class LinEpsilonGreedy(BaseContextualPolicy):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1
@@ -141,7 +141,7 @@ class LinUCB(BaseContextualPolicy):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1
@@ -258,7 +258,7 @@ class LinTS(BaseContextualPolicy):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1

--- a/obp/policy/logistic.py
+++ b/obp/policy/logistic.py
@@ -26,7 +26,7 @@ class LogisticEpsilonGreedy(BaseContextualPolicy):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1
@@ -132,7 +132,7 @@ class LogisticUCB(BaseContextualPolicy):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1
@@ -245,7 +245,7 @@ class LogisticTS(BaseContextualPolicy):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     batch_size: int, default=1

--- a/obp/policy/offline.py
+++ b/obp/policy/offline.py
@@ -26,7 +26,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
         Number of actions.
 
     len_list: int, default=1
-        Length of a list of recommended actions in each impression.
+        Length of a list of actions recommended in each impression.
         When Open Bandit Dataset is used, 3 should be set.
 
     base_classifier: ClassifierMixin
@@ -73,7 +73,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -122,13 +122,13 @@ class IPWLearner(BaseOfflinePolicyLearner):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
 
         pscore: array-like, shape (n_rounds,), default=None
-            Propensity scores or the action choice probabilities by behavior policy, i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         position: array-like, shape (n_rounds,), default=None
             Positions of each round in the given logged bandit feedback.

--- a/obp/simulator/simulator.py
+++ b/obp/simulator/simulator.py
@@ -26,7 +26,7 @@ def run_bandit_simulation(
     Returns
     --------
     action_dist: array-like, shape (n_rounds, n_actions, len_list)
-        Distribution over actions or the action choice probabilities (can be deterministic).
+        Action choice probabilities (can be deterministic).
 
     """
     for key_ in ["action", "position", "reward", "pscore", "context"]:

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -74,7 +74,7 @@ def convert_to_action_dist(n_actions: int, selected_actions: np.ndarray,) -> np.
     Returns
     ----------
     action_dist: array-like, shape (n_rounds, n_actions, len_list)
-        Distribution over actions or the action choice probabilities (can be deterministic).
+        Action choice probabilities (can be deterministic).
 
     """
     n_rounds, len_list = selected_actions.shape
@@ -174,7 +174,7 @@ def check_bandit_feedback_inputs(
         Context vectors in each round, i.e., :math:`x_t`.
 
     action: array-like, shape (n_rounds,)
-        Sampled (realized) actions by behavior policy in each round, i.e., :math:`a_t`.
+        Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
     reward: array-like, shape (n_rounds,)
         Observed rewards (or outcome) in each round, i.e., :math:`r_t`.


### PR DESCRIPTION
- polish docstrings
- fix output of obtain_batch_bandit_feedabck and sample_bootstrap_bandit_feedback of `OpenBanditDataset`
    - specifically, divided the train and evaluation sets of logged bandit feedback when `is_timeseries_split=True`