### PR TITLE
Fix policy_name for epsilon_greedy

### DIFF
--- a/obp/policy/contextfree.py
+++ b/obp/policy/contextfree.py
@@ -49,13 +49,14 @@ class EpsilonGreedy(BaseContextFreePolicy):
     """
 
     epsilon: float = 1.0
-    policy_name: str = f"egreedy_{epsilon}"
 
     def __post_init__(self) -> None:
         """Initialize Class."""
         assert (
             0 <= self.epsilon <= 1
         ), f"epsilon must be between 0 and 1, but {self.epsilon} is given"
+        self.policy_name = f"egreedy_{self.epsilon}"
+
         super().__post_init__()
 
     def select_action(self) -> np.ndarray:


### PR DESCRIPTION
For EpsilonGreedy, the policy name doesn't get set correctly because one line needed to be moved to post_init.

before:
```
In [1]: from obp.policy import EpsilonGreedy

In [2]: eps_05 = EpsilonGreedy(epsilon=0.5, n_actions=12)

In [3]: eps_05.policy_name
Out[3]: 'egreedy_1.0' # oops!
```

after:
```
In [1]: from obp.policy import EpsilonGreedy

In [2]: eps_05 = EpsilonGreedy(epsilon=0.5, n_actions=12)

In [3]: eps_05.policy_name
Out[3]: 'egreedy_0.5' # yay!
```
