### PR TITLE
add test dataset synthetic

### DIFF
--- a/obp/dataset/synthetic.py
+++ b/obp/dataset/synthetic.py
@@ -132,16 +132,21 @@ class SyntheticBanditDataset(BaseSyntheticBanditDataset):
 
     def __post_init__(self) -> None:
         """Initialize Class."""
-        assert self.n_actions > 1 and isinstance(
-            self.n_actions, int
-        ), f"n_actions must be an integer larger than 1, but {self.n_actions} is given"
-        assert self.dim_context > 0 and isinstance(
-            self.dim_context, int
-        ), f"dim_context must be a positive integer, but {self.dim_context} is given"
-        assert self.reward_type in [
+        if not isinstance(self.n_actions, int) or self.n_actions <= 1:
+            raise ValueError(
+                f"n_actions must be an integer larger than 1, but {self.n_actions} is given"
+            )
+        if not isinstance(self.dim_context, int) or self.dim_context <= 0:
+            raise ValueError(
+                f"dim_context must be a positive integer, but {self.dim_context} is given"
+            )
+        if self.reward_type not in [
             "binary",
             "continuous",
-        ], f"reward_type must be either 'binary' or 'continuous, but {self.reward_type} is given.'"
+        ]:
+            raise ValueError(
+                f"reward_type must be either 'binary' or 'continuous, but {self.reward_type} is given.'"
+            )
 
         self.random_ = check_random_state(self.random_state)
         if self.reward_function is None:
@@ -174,9 +179,10 @@ class SyntheticBanditDataset(BaseSyntheticBanditDataset):
             Generated synthetic bandit feedback dataset.
 
         """
-        assert n_rounds > 0 and isinstance(
-            n_rounds, int
-        ), f"n_rounds must be a positive integer, but {n_rounds} is given"
+        if not isinstance(n_rounds, int) or n_rounds <= 0:
+            raise ValueError(
+                f"n_rounds must be a positive integer, but {n_rounds} is given"
+            )
 
         context = self.random_.normal(size=(n_rounds, self.dim_context))
         # sample actions for each round based on the behavior policy
@@ -227,6 +233,9 @@ class SyntheticBanditDataset(BaseSyntheticBanditDataset):
             expected_reward_ = truncnorm.stats(
                 a=a, b=b, loc=mean, scale=std, moments="m"
             )
+        else:
+            raise NotImplementedError
+
         return dict(
             n_rounds=n_rounds,
             n_actions=self.n_actions,
@@ -264,12 +273,11 @@ def logistic_reward_function(
         Expected reward given context (:math:`x`) and action (:math:`a`), i.e., :math:`q(x,a):=\\mathbb{E}[r|x,a]`.
 
     """
-    assert (
-        isinstance(context, np.ndarray) and context.ndim == 2
-    ), "context must be 2-dimensional ndarray"
-    assert (
-        isinstance(action_context, np.ndarray) and action_context.ndim == 2
-    ), "action_context must be 2-dimensional ndarray"
+    if not isinstance(context, np.ndarray) or context.ndim != 2:
+        raise ValueError("context must be 2-dimensional ndarray")
+
+    if not isinstance(action_context, np.ndarray) or action_context.ndim != 2:
+        raise ValueError("action_context must be 2-dimensional ndarray")
 
     random_ = check_random_state(random_state)
     logits = np.zeros((context.shape[0], action_context.shape[0]))
@@ -306,12 +314,11 @@ def linear_reward_function(
         Expected reward given context (:math:`x`) and action (:math:`a`), i.e., :math:`q(x,a):=\\mathbb{E}[r|x,a]`.
 
     """
-    assert (
-        isinstance(context, np.ndarray) and context.ndim == 2
-    ), "context must be 2-dimensional ndarray"
-    assert (
-        isinstance(action_context, np.ndarray) and action_context.ndim == 2
-    ), "action_context must be 2-dimensional ndarray"
+    if not isinstance(context, np.ndarray) or context.ndim != 2:
+        raise ValueError("context must be 2-dimensional ndarray")
+
+    if not isinstance(action_context, np.ndarray) or action_context.ndim != 2:
+        raise ValueError("action_context must be 2-dimensional ndarray")
 
     random_ = check_random_state(random_state)
     expected_reward = np.zeros((context.shape[0], action_context.shape[0]))
@@ -348,12 +355,11 @@ def linear_behavior_policy(
         Action choice probabilities given context (:math:`x`), i.e., :math:`\\pi: \\mathcal{X} \\rightarrow \\Delta(\\mathcal{A})`.
 
     """
-    assert (
-        isinstance(context, np.ndarray) and context.ndim == 2
-    ), "context must be 2-dimensional ndarray"
-    assert (
-        isinstance(action_context, np.ndarray) and action_context.ndim == 2
-    ), "action_context must be 2-dimensional ndarray"
+    if not isinstance(context, np.ndarray) or context.ndim != 2:
+        raise ValueError("context must be 2-dimensional ndarray")
+
+    if not isinstance(action_context, np.ndarray) or action_context.ndim != 2:
+        raise ValueError("action_context must be 2-dimensional ndarray")
 
     random_ = check_random_state(random_state)
     logits = np.zeros((context.shape[0], action_context.shape[0]))

--- a/test/dataset/test_synthetic.py
+++ b/test/dataset/test_synthetic.py
@@ -1,0 +1,187 @@
+import pytest
+import numpy as np
+
+from obp.dataset import SyntheticBanditDataset
+from obp.dataset.synthetic import (
+    logistic_reward_function,
+    linear_reward_function,
+    linear_behavior_policy,
+)
+
+
+def test_synthetic_init():
+    # n_actions
+    with pytest.raises(ValueError):
+        SyntheticBanditDataset(n_actions=1)
+
+    with pytest.raises(ValueError):
+        SyntheticBanditDataset(n_actions="3")
+
+    # dim_context
+    with pytest.raises(ValueError):
+        SyntheticBanditDataset(n_actions=2, dim_context=0)
+
+    with pytest.raises(ValueError):
+        SyntheticBanditDataset(n_actions=2, dim_context="2")
+
+    # reward_type
+    with pytest.raises(ValueError):
+        SyntheticBanditDataset(n_actions=2, reward_type="aaa")
+
+    # when reward_function is None, expected_reward is randomly sampled in [0, 1]
+    # this check includes the test of `sample_contextfree_expected_reward` function
+    dataset = SyntheticBanditDataset(n_actions=2)
+    assert len(dataset.expected_reward) == 2
+    assert np.all(0 <= dataset.expected_reward) and np.all(dataset.expected_reward <= 1)
+
+    # when behavior_policy_function is None, behavior_policy is set to uniform one
+    uniform_policy = np.array([0.5, 0.5])
+    assert np.allclose(dataset.behavior_policy, uniform_policy)
+
+    # action_context
+    ohe = np.eye(2, dtype=int)
+    assert np.allclose(dataset.action_context, ohe)
+
+
+def test_synthetic_obtain_batch_bandit_feedback():
+    # n_rounds
+    with pytest.raises(ValueError):
+        dataset = SyntheticBanditDataset(n_actions=2)
+        dataset.obtain_batch_bandit_feedback(n_rounds=0)
+
+    with pytest.raises(ValueError):
+        dataset = SyntheticBanditDataset(n_actions=2)
+        dataset.obtain_batch_bandit_feedback(n_rounds="3")
+
+    # bandit feedback
+    n_rounds = 10
+    n_actions = 5
+    dataset = SyntheticBanditDataset(n_actions=n_actions)
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
+    assert bandit_feedback["n_rounds"] == n_rounds
+    assert bandit_feedback["n_actions"] == n_actions
+    assert (
+        bandit_feedback["context"].shape[0] == n_rounds  # n_rounds
+        and bandit_feedback["context"].shape[1] == 1  # default dim_context
+    )
+    assert (
+        bandit_feedback["action_context"].shape[0] == n_actions
+        and bandit_feedback["action_context"].shape[1] == n_actions
+    )
+    assert (
+        bandit_feedback["action"].ndim == 1
+        and len(bandit_feedback["action"]) == n_rounds
+    )
+    assert (
+        bandit_feedback["position"].ndim == 1
+        and len(bandit_feedback["position"]) == n_rounds
+    )
+    assert (
+        bandit_feedback["reward"].ndim == 1
+        and len(bandit_feedback["reward"]) == n_rounds
+    )
+    assert (
+        bandit_feedback["expected_reward"].shape[0] == n_rounds
+        and bandit_feedback["expected_reward"].shape[1] == n_actions
+    )
+    assert (
+        bandit_feedback["pscore"].ndim == 1
+        and len(bandit_feedback["pscore"]) == n_rounds
+    )
+
+
+def test_synthetic_logistic_reward_function():
+    # context
+    with pytest.raises(ValueError):
+        context = np.array([1.0, 1.0])
+        logistic_reward_function(context=context, action_context=np.ones([2, 2]))
+
+    with pytest.raises(ValueError):
+        context = [1.0, 1.0]
+        logistic_reward_function(context=context, action_context=np.ones([2, 2]))
+
+    # action_context
+    with pytest.raises(ValueError):
+        action_context = np.array([1.0, 1.0])
+        logistic_reward_function(context=np.ones([2, 2]), action_context=action_context)
+
+    with pytest.raises(ValueError):
+        action_context = [1.0, 1.0]
+        logistic_reward_function(context=np.ones([2, 2]), action_context=action_context)
+
+    # expected_reward
+    n_rounds = 10
+    dim_context = dim_action_context = 3
+    n_actions = 5
+    context = np.ones([n_rounds, dim_context])
+    action_context = np.ones([n_actions, dim_action_context])
+    expected_reward = logistic_reward_function(
+        context=context, action_context=action_context
+    )
+    assert (
+        expected_reward.shape[0] == n_rounds and expected_reward.shape[1] == n_actions
+    )
+    assert np.all(0 <= expected_reward) and np.all(expected_reward <= 1)
+
+
+def test_synthetic_linear_reward_function():
+    # context
+    with pytest.raises(ValueError):
+        context = np.array([1.0, 1.0])
+        linear_reward_function(context=context, action_context=np.ones([2, 2]))
+
+    with pytest.raises(ValueError):
+        context = [1.0, 1.0]
+        linear_reward_function(context=context, action_context=np.ones([2, 2]))
+
+    # action_context
+    with pytest.raises(ValueError):
+        action_context = np.array([1.0, 1.0])
+        linear_reward_function(context=np.ones([2, 2]), action_context=action_context)
+
+    with pytest.raises(ValueError):
+        action_context = [1.0, 1.0]
+        linear_reward_function(context=np.ones([2, 2]), action_context=action_context)
+
+    # expected_reward
+    n_rounds = 10
+    dim_context = dim_action_context = 3
+    n_actions = 5
+    context = np.ones([n_rounds, dim_context])
+    action_context = np.ones([n_actions, dim_action_context])
+    expected_reward = linear_reward_function(
+        context=context, action_context=action_context
+    )
+    assert (
+        expected_reward.shape[0] == n_rounds and expected_reward.shape[1] == n_actions
+    )
+
+
+def test_synthetic_linear_behavior_policy():
+    # context
+    with pytest.raises(ValueError):
+        context = np.array([1.0, 1.0])
+        linear_behavior_policy(context=context, action_context=np.ones([2, 2]))
+
+    with pytest.raises(ValueError):
+        context = [1.0, 1.0]
+        linear_behavior_policy(context=context, action_context=np.ones([2, 2]))
+
+    # action_context
+    with pytest.raises(ValueError):
+        action_context = np.array([1.0, 1.0])
+        linear_behavior_policy(context=np.ones([2, 2]), action_context=action_context)
+
+    with pytest.raises(ValueError):
+        action_context = [1.0, 1.0]
+        linear_behavior_policy(context=np.ones([2, 2]), action_context=action_context)
+
+    # expected_reward
+    n_rounds = 10
+    dim_context = dim_action_context = 3
+    n_actions = 5
+    context = np.ones([n_rounds, dim_context])
+    action_context = np.ones([n_actions, dim_action_context])
+    action_prob = linear_behavior_policy(context=context, action_context=action_context)
+    assert action_prob.shape[0] == n_rounds and action_prob.shape[1] == n_actions
+    assert np.all(0 <= action_prob) and np.all(action_prob <= 1)


### PR DESCRIPTION
## Overview

Add several tests for the dataset **synthetic** module.

```
$ pytest -s

============================= test session starts ==============================
platform darwin -- Python 3.7.1, pytest-6.2.1, py-1.10.0, pluggy-0.13.1 -- /Users/a14752/Documents/research/OPE/code/zr-obp/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/a14752/Documents/research/OPE/code/zr-obp
collecting ... collected 5 items

test/dataset/test_synthetic.py::test_synthetic_init PASSED               [ 20%]
test/dataset/test_synthetic.py::test_synthetic_obtain_batch_bandit_feedback PASSED [ 40%]
test/dataset/test_synthetic.py::test_synthetic_logistic_reward_function PASSED [ 60%]
test/dataset/test_synthetic.py::test_synthetic_linear_reward_function PASSED [ 80%]
test/dataset/test_synthetic.py::test_synthetic_linear_behavior_policy PASSED [100%]

```

## Review points
* Testing structure
* Testing code

## Remark
* This test has verified the behavior of the algorithm, but not the performance.
