### PR TITLE
add test multiclass

### DIFF
--- a/obp/dataset/multiclass.py
+++ b/obp/dataset/multiclass.py
@@ -149,12 +149,13 @@ class MultiClassToBanditReduction(BaseSyntheticBanditDataset):
 
     def __post_init__(self) -> None:
         """Initialize Class."""
-        assert is_classifier(
-            self.base_classifier_b
-        ), f"base_classifier_b must be a classifier"
-        assert (0.0 <= self.alpha_b < 1.0) and isinstance(
-            self.alpha_b, float
-        ), f"alpha_b must be a float in the [0,1) interval, but {self.alpha_b} is given"
+        if not is_classifier(self.base_classifier_b):
+            raise ValueError(f"base_classifier_b must be a classifier")
+        if not isinstance(self.alpha_b, float) or not (0.0 <= self.alpha_b < 1.0):
+            raise ValueError(
+                f"alpha_b must be a float in the [0,1) interval, but {self.alpha_b} is given"
+            )
+
         self.X, y = check_X_y(X=self.X, y=self.y, ensure_2d=True, multi_output=False)
         self.y = (rankdata(y, "dense") - 1).astype(int)  # re-index action
         # fully observed labels
@@ -282,9 +283,10 @@ class MultiClassToBanditReduction(BaseSyntheticBanditDataset):
             axis 2 represents the length of list; it is always 1 in the current implementation.
 
         """
-        assert (0.0 <= alpha_e <= 1.0) and isinstance(
-            alpha_e, float
-        ), f"alpha_e must be a float in the [0,1] interval, but {alpha_e} is given"
+        if not isinstance(alpha_e, float) or not (0.0 <= alpha_e <= 1.0):
+            raise ValueError(
+                f"alpha_e must be a float in the [0,1] interval, but {alpha_e} is given"
+            )
         # train a base ML classifier
         if base_classifier_e is None:
             base_clf_e = clone(self.base_classifier_b)
@@ -320,10 +322,10 @@ class MultiClassToBanditReduction(BaseSyntheticBanditDataset):
             policy value of a given action distribution (mostly evaluation policy).
 
         """
-        assert action_dist.ndim == 3 and isinstance(
-            action_dist, np.ndarray
-        ), f"action_dist must be a 3-D np.ndarray"
-        assert (
-            action_dist.shape[0] == self.n_rounds_ev
-        ), "the size of axis 0 of action_dist must be the same as the number of samples in the evaluation set"
+        if not isinstance(action_dist, np.ndarray) or action_dist.ndim != 3:
+            raise ValueError(f"action_dist must be a 3-D np.ndarray")
+        if action_dist.shape[0] != self.n_rounds_ev:
+            raise ValueError(
+                "the size of axis 0 of action_dist must be the same as the number of samples in the evaluation set"
+            )
         return action_dist[np.arange(self.n_rounds_ev), self.y_ev].mean()

--- a/tests/dataset/test_multiclass.py
+++ b/tests/dataset/test_multiclass.py
@@ -1,0 +1,116 @@
+import pytest
+import numpy as np
+from sklearn.datasets import load_digits
+from sklearn.linear_model import LogisticRegression
+
+from typing import Tuple
+
+from obp.dataset import MultiClassToBanditReduction
+
+
+@pytest.fixture(scope="session")
+def raw_data() -> Tuple[np.ndarray, np.ndarray]:
+    X, y = load_digits(return_X_y=True)
+    return X, y
+
+
+def test_invalid_initialization(raw_data):
+    X, y = raw_data
+
+    # invalid alpha_b
+    with pytest.raises(ValueError):
+        MultiClassToBanditReduction(
+            X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=-0.3
+        )
+
+    with pytest.raises(ValueError):
+        MultiClassToBanditReduction(
+            X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=1.3
+        )
+
+    # invalid classifier
+    with pytest.raises(ValueError):
+        from sklearn.tree import DecisionTreeRegressor
+
+        MultiClassToBanditReduction(X=X, y=y, base_classifier_b=DecisionTreeRegressor)
+
+
+def test_split_train_eval(raw_data):
+    X, y = raw_data
+
+    eval_size = 1000
+    mcbr = MultiClassToBanditReduction(
+        X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=0.3
+    )
+    mcbr.split_train_eval(eval_size=eval_size)
+
+    assert eval_size == mcbr.n_rounds_ev
+
+
+def test_obtain_batch_bandit_feedback(raw_data):
+    X, y = raw_data
+
+    mcbr = MultiClassToBanditReduction(
+        X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=0.3
+    )
+    mcbr.split_train_eval()
+    bandit_feedback = mcbr.obtain_batch_bandit_feedback()
+
+    assert "n_actions" in bandit_feedback.keys()
+    assert "n_rounds" in bandit_feedback.keys()
+    assert "context" in bandit_feedback.keys()
+    assert "action" in bandit_feedback.keys()
+    assert "reward" in bandit_feedback.keys()
+    assert "position" in bandit_feedback.keys()
+    assert "pscore" in bandit_feedback.keys()
+
+
+def test_obtain_action_dist_by_eval_policy(raw_data):
+    X, y = raw_data
+
+    eval_size = 1000
+    mcbr = MultiClassToBanditReduction(
+        X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=0.3
+    )
+    mcbr.split_train_eval(eval_size=eval_size)
+
+    # invalid alpha_e
+    with pytest.raises(ValueError):
+        mcbr.obtain_action_dist_by_eval_policy(alpha_e=-0.3)
+
+    with pytest.raises(ValueError):
+        mcbr.obtain_action_dist_by_eval_policy(alpha_e=1.3)
+
+    # valid type
+    action_dist = mcbr.obtain_action_dist_by_eval_policy()
+
+    assert action_dist.shape[0] == eval_size
+    n_actions = np.unique(y).shape[0]
+    assert action_dist.shape[1] == n_actions
+    assert action_dist.shape[2] == 1
+
+
+def test_calc_ground_truth_policy_value(raw_data):
+    X, y = raw_data
+
+    eval_size = 1000
+    mcbr = MultiClassToBanditReduction(
+        X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=0.3
+    )
+    mcbr.split_train_eval(eval_size=eval_size)
+
+    with pytest.raises(ValueError):
+        invalid_action_dist = np.zeros(eval_size)
+        mcbr.calc_ground_truth_policy_value(action_dist=invalid_action_dist)
+
+    with pytest.raises(ValueError):
+        reshaped_action_dist = mcbr.obtain_action_dist_by_eval_policy().reshape(
+            1, -1, 1
+        )
+        mcbr.calc_ground_truth_policy_value(action_dist=reshaped_action_dist)
+
+    action_dist = mcbr.obtain_action_dist_by_eval_policy()
+    ground_truth_policy_value = mcbr.calc_ground_truth_policy_value(
+        action_dist=action_dist
+    )
+    assert isinstance(ground_truth_policy_value, float)


### PR DESCRIPTION
## Overview

Add several tests for the dataset **multiclass** module.

```
$ pytest -s

============================= test session starts ==============================
platform darwin -- Python 3.7.1, pytest-6.2.1, py-1.10.0, pluggy-0.13.1 -- /Users/a14752/Documents/research/OPE/code/zr-obp/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/a14752/Documents/research/OPE/code/zr-obp
collecting ... collected 5 items

tests/dataset/test_multiclass.py::test_invalid_initialization 
tests/dataset/test_multiclass.py::test_split_train_eval 
tests/dataset/test_multiclass.py::test_obtain_batch_bandit_feedback 
tests/dataset/test_multiclass.py::test_obtain_action_dist_by_eval_policy 
tests/dataset/test_multiclass.py::test_calc_ground_truth_policy_value 
```

## Review points
* Testing structure
* Testing code

## Remark
* This test has verified the behavior of the algorithm, but not the performance.
