### PR TITLE
Add input validation to ope.meta.py and test the validation

### DIFF
--- a/obp/ope/meta.py
+++ b/obp/ope/meta.py
@@ -79,7 +79,7 @@ class OffPolicyEvaluation:
 
     def __post_init__(self) -> None:
         """Initialize class."""
-        for key_ in ["action", "position", "reward", "pscore", "context"]:
+        for key_ in ["action", "position", "reward", "pscore"]:
             if key_ not in self.bandit_feedback:
                 raise RuntimeError(f"Missing key of {key_} in 'bandit_feedback'.")
         self.ope_estimators_ = dict()
@@ -87,9 +87,25 @@ class OffPolicyEvaluation:
             self.ope_estimators_[estimator.estimator_name] = estimator
 
     def _create_estimator_inputs(
-        self, action_dist: np.ndarray, estimated_rewards_by_reg_model: np.ndarray
+        self,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[np.ndarray] = None,
     ) -> Dict[str, np.ndarray]:
         """Create input dictionary to estimate policy value by subclasses of `BaseOffPolicyEstimator`"""
+        if not isinstance(action_dist, np.ndarray):
+            raise ValueError("action_dist must be ndarray")
+        if action_dist.ndim != 3:
+            raise ValueError(
+                f"action_dist.ndim must be 3-dimensional, but {action_dist.ndim} is given"
+            )
+        if estimated_rewards_by_reg_model is None:
+            logger.warning(
+                "`estimated_rewards_by_reg_model` is not given; model dependent estimators such as DM or DR cannot be used."
+            )
+        elif estimated_rewards_by_reg_model.shape != action_dist.shape:
+            raise ValueError(
+                "estimated_rewards_by_reg_model.shape needs to be equal to action_dist.shape"
+            )
         estimator_inputs = {
             input_: self.bandit_feedback[input_]
             for input_ in ["reward", "action", "position", "pscore"]
@@ -123,13 +139,6 @@ class OffPolicyEvaluation:
             Dictionary containing estimated policy values by OPE estimators.
 
         """
-        assert isinstance(action_dist, np.ndarray), "action_dist must be ndarray"
-        assert action_dist.ndim == 3, "action_dist must be 3-dimensional"
-        if estimated_rewards_by_reg_model is None:
-            logger.warning(
-                "`estimated_rewards_by_reg_model` is not given; model dependent estimators such as DM or DR cannot be used."
-            )
-
         policy_value_dict = dict()
         estimator_inputs = self._create_estimator_inputs(
             action_dist=action_dist,
@@ -177,13 +186,6 @@ class OffPolicyEvaluation:
             using a nonparametric bootstrap procedure.
 
         """
-        assert isinstance(action_dist, np.ndarray), "action_dist must be ndarray"
-        assert action_dist.ndim == 3, "action_dist must be 3-dimensional"
-        if estimated_rewards_by_reg_model is None:
-            logger.warning(
-                "`estimated_rewards_by_reg_model` is not given; model dependent estimators such as DM or DR cannot be used."
-            )
-
         policy_value_interval_dict = dict()
         estimator_inputs = self._create_estimator_inputs(
             action_dist=action_dist,
@@ -233,9 +235,6 @@ class OffPolicyEvaluation:
             Estimated policy values and their confidence intervals by OPE estimators.
 
         """
-        assert isinstance(action_dist, np.ndarray), "action_dist must be ndarray"
-        assert action_dist.ndim == 3, "action_dist must be 3-dimensional"
-
         policy_value_df = DataFrame(
             self.estimate_policy_values(
                 action_dist=action_dist,
@@ -298,16 +297,10 @@ class OffPolicyEvaluation:
             Name of the bar figure.
 
         """
-        assert isinstance(action_dist, np.ndarray), "action_dist must be ndarray"
-        assert action_dist.ndim == 3, "action_dist must be 3-dimensional"
         if fig_dir is not None:
             assert isinstance(fig_dir, Path), "fig_dir must be a Path"
         if fig_name is not None:
             assert isinstance(fig_name, str), "fig_dir must be a string"
-        if estimated_rewards_by_reg_model is None:
-            logger.warning(
-                "`estimated_rewards_by_reg_model` is not given; model dependent estimators such as DM or DR cannot be used."
-            )
 
         estimated_round_rewards_dict = dict()
         estimator_inputs = self._create_estimator_inputs(
@@ -392,18 +385,18 @@ class OffPolicyEvaluation:
             Dictionary containing evaluation metric for evaluating the estimation performance of OPE estimators.
 
         """
-        assert isinstance(action_dist, np.ndarray), "action_dist must be ndarray"
-        assert action_dist.ndim == 3, "action_dist must be 3-dimensional"
-        assert isinstance(
-            ground_truth_policy_value, float
-        ), "ground_truth_policy_value must be a float"
-        assert metric in [
-            "relative-ee",
-            "se",
-        ], "metric must be either 'relative-ee' or 'se'"
-        if estimated_rewards_by_reg_model is None:
-            logger.warning(
-                "`estimated_rewards_by_reg_model` is not given; model dependent estimators such as DM or DR cannot be used."
+
+        if not isinstance(ground_truth_policy_value, float):
+            raise ValueError(
+                f"ground_truth_policy_value must be a float, but {ground_truth_policy_value} is given"
+            )
+        if metric not in ["relative-ee", "se"]:
+            raise ValueError(
+                f"metric must be either 'relative-ee' or 'se', but {metric} is given"
+            )
+        if metric == "relative-ee" and ground_truth_policy_value == 0.0:
+            raise ValueError(
+                "ground_truth_policy_value must be non-zero when metric is relative-ee"
             )
 
         eval_metric_ope_dict = dict()
@@ -454,13 +447,6 @@ class OffPolicyEvaluation:
             Evaluation metric for evaluating the estimation performance of OPE estimators.
 
         """
-        assert isinstance(action_dist, np.ndarray), "action_dist must be ndarray"
-        assert action_dist.ndim == 3, "action_dist must be 3-dimensional"
-        assert metric in [
-            "relative-ee",
-            "se",
-        ], "metric must be either 'relative-ee' or 'se'"
-
         eval_metric_ope_df = DataFrame(
             self.evaluate_performance_of_estimators(
                 ground_truth_policy_value=ground_truth_policy_value,

--- a/obp/ope/meta.py
+++ b/obp/ope/meta.py
@@ -14,6 +14,7 @@ import seaborn as sns
 
 from .estimators import BaseOffPolicyEstimator
 from ..types import BanditFeedback
+from ..utils import check_confidence_interval_arguments
 
 logger = getLogger(__name__)
 
@@ -96,7 +97,7 @@ class OffPolicyEvaluation:
             raise ValueError("action_dist must be ndarray")
         if action_dist.ndim != 3:
             raise ValueError(
-                f"action_dist.ndim must be 3-dimensional, but {action_dist.ndim} is given"
+                f"action_dist.ndim must be 3-dimensional, but is {action_dist.ndim}"
             )
         if estimated_rewards_by_reg_model is None:
             logger.warning(
@@ -104,7 +105,7 @@ class OffPolicyEvaluation:
             )
         elif estimated_rewards_by_reg_model.shape != action_dist.shape:
             raise ValueError(
-                "estimated_rewards_by_reg_model.shape needs to be equal to action_dist.shape"
+                "estimated_rewards_by_reg_model.shape must be the same as action_dist.shape"
             )
         estimator_inputs = {
             input_: self.bandit_feedback[input_]
@@ -186,6 +187,11 @@ class OffPolicyEvaluation:
             using a nonparametric bootstrap procedure.
 
         """
+        check_confidence_interval_arguments(
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
         policy_value_interval_dict = dict()
         estimator_inputs = self._create_estimator_inputs(
             action_dist=action_dist,

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -11,6 +11,44 @@ from sklearn.utils import check_random_state
 from sklearn.utils.validation import _deprecate_positional_args
 
 
+def check_confidence_interval_arguments(
+    alpha: float = 0.05,
+    n_bootstrap_samples: int = 10000,
+    random_state: Optional[int] = None,
+) -> None:
+    """Check confidence interval arguments.
+
+    Parameters
+    ----------
+    alpha: float, default=0.05
+        Significant level of confidence intervals.
+
+    n_bootstrap_samples: int, default=10000
+        Number of resampling performed in the bootstrap procedure.
+
+    random_state: int, default=None
+        Controls the random seed in bootstrap sampling.
+
+    Returns
+    ----------
+    estimated_confidence_interval: Dict[str, float]
+        Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+    """
+    if not (isinstance(alpha, float) and (0.0 < alpha < 1.0)):
+        raise ValueError(
+            f"alpha must be a positive float (< 1.0), but {alpha} is given"
+        )
+    if not (isinstance(n_bootstrap_samples, int) and n_bootstrap_samples > 0):
+        raise ValueError(
+            f"n_bootstrap_samples must be a positive integer, but {n_bootstrap_samples} is given"
+        )
+    if random_state is not None and not isinstance(random_state, int):
+        raise ValueError(
+            f"random_state must be an integer, but {random_state} is given"
+        )
+
+
 def estimate_confidence_interval_by_bootstrap(
     samples: np.ndarray,
     alpha: float = 0.05,
@@ -25,7 +63,7 @@ def estimate_confidence_interval_by_bootstrap(
         Empirical observed samples to be used to estimate cumulative distribution function.
 
     alpha: float, default=0.05
-        P-value.
+        Significant level of confidence intervals.
 
     n_bootstrap_samples: int, default=10000
         Number of resampling performed in the bootstrap procedure.
@@ -39,12 +77,9 @@ def estimate_confidence_interval_by_bootstrap(
         Dictionary storing the estimated mean and upper-lower confidence bounds.
 
     """
-    assert (0.0 < alpha < 1.0) and isinstance(
-        alpha, float
-    ), f"alpha must be a positive float, but {alpha} is given"
-    assert (n_bootstrap_samples > 0) and isinstance(
-        n_bootstrap_samples, int
-    ), f"n_bootstrap_samples must be a positive integer, but {n_bootstrap_samples} is given"
+    check_confidence_interval_arguments(
+        alpha=alpha, n_bootstrap_samples=n_bootstrap_samples, random_state=random_state
+    )
 
     boot_samples = list()
     random_ = check_random_state(random_state)

--- a/tests/ope/test_meta.py
+++ b/tests/ope/test_meta.py
@@ -250,7 +250,7 @@ invalid_input_of_create_estimator_inputs = [
     (
         np.zeros((2, 3, 4)),
         np.zeros((2, 3, 3)),
-        "estimated_rewards_by_reg_model.shape needs to be equal to action_dist.shape",
+        "estimated_rewards_by_reg_model.shape must be the same as action_dist.shape",
     ),
     (np.zeros((2, 3)), None, "action_dist.ndim must be 3-dimensional"),
     ("3", None, "action_dist must be ndarray"),
@@ -289,7 +289,7 @@ def test_meta_create_estimator_inputs_using_invalid_input_data(
             action_dist=action_dist,
             estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
         )
-    # _create_estimator_inputs function is called in other functions
+    # _create_estimator_inputs function is called in the following functions
     with pytest.raises(ValueError, match=f"{description}*"):
         _ = ope_.estimate_policy_values(
             action_dist=action_dist,
@@ -349,7 +349,7 @@ def test_meta_create_estimator_inputs_using_valid_input_data(
             "estimated_rewards_by_reg_model",
         ]
     ), f"Invalid response of _create_estimator_inputs (test case: {description})"
-    # _create_estimator_inputs function is called in other functions
+    # _create_estimator_inputs function is called in the following functions
     _ = ope_.estimate_policy_values(
         action_dist=action_dist,
         estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,

--- a/tests/ope/test_meta.py
+++ b/tests/ope/test_meta.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional
 from dataclasses import dataclass
+import itertools
 
 import pytest
 import numpy as np
@@ -8,6 +9,7 @@ from pandas.testing import assert_frame_equal
 
 from obp.types import BanditFeedback
 from obp.ope import OffPolicyEvaluation, BaseOffPolicyEstimator
+from obp.utils import check_confidence_interval_arguments
 
 
 mock_policy_value = 0.5
@@ -96,6 +98,11 @@ class DirectMethodMock(BaseOffPolicyEstimator):
         mock_confidence_interval: Dict[str, float]
             Dictionary storing the estimated mean and upper-lower confidence bounds.
         """
+        check_confidence_interval_arguments(
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
         return mock_confidence_interval
 
 
@@ -207,45 +214,9 @@ ipw2 = InverseProbabilityWeightingMock(eps=0.02)
 ipw3 = InverseProbabilityWeightingMock(estimator_name="ipw3")
 
 
-def test_meta_estimation_format(
-    synthetic_bandit_feedback: BanditFeedback, random_action_dist: np.ndarray
-) -> None:
+def test_meta_post_init(synthetic_bandit_feedback: BanditFeedback) -> None:
     """
-    Test the response format of OffPolicyEvaluation
-    """
-    # single ope estimator
-    ope_ = OffPolicyEvaluation(
-        bandit_feedback=synthetic_bandit_feedback, ope_estimators=[dm]
-    )
-    assert ope_.estimate_policy_values(random_action_dist) == {
-        "dm": mock_policy_value
-    }, "OffPolicyEvaluation.estimate_policy_values ([DirectMethod]) returns a wrong value"
-    assert ope_.estimate_intervals(random_action_dist) == {
-        "dm": mock_confidence_interval
-    }, "OffPolicyEvaluation.estimate_intervals ([DirectMethod]) returns a wrong value"
-    with pytest.raises(AssertionError, match=r"action_dist must be 3-dimensional.*"):
-        ope_.estimate_policy_values(
-            random_action_dist[:, :, 0]
-        ), "action_dist must be 3-dimensional when using OffPolicyEvaluation"
-    # multiple ope estimators
-    ope_ = OffPolicyEvaluation(
-        bandit_feedback=synthetic_bandit_feedback, ope_estimators=[dm, ipw]
-    )
-    assert ope_.estimate_policy_values(random_action_dist) == {
-        "dm": mock_policy_value,
-        "ipw": mock_policy_value + ipw.eps,
-    }, "OffPolicyEvaluation.estimate_policy_values ([DirectMethod, IPW]) returns a wrong value"
-    assert ope_.estimate_intervals(random_action_dist) == {
-        "dm": mock_confidence_interval,
-        "ipw": {k: v + ipw.eps for k, v in mock_confidence_interval.items()},
-    }, "OffPolicyEvaluation.estimate_intervals ([DirectMethod]) returns a wrong value"
-
-
-def test_meta_post_init_format(
-    synthetic_bandit_feedback: BanditFeedback, random_action_dist: np.ndarray
-) -> None:
-    """
-    Test the post init format of OffPolicyEvaluation
+    Test the __post_init__ function
     """
     # __post_init__ saves the latter estimator when the same estimator name is used
     ope_ = OffPolicyEvaluation(
@@ -260,22 +231,115 @@ def test_meta_post_init_format(
         "ipw": ipw,
         "ipw3": ipw3,
     }, "__post_init__ returns a wrong value"
+    # __post__init__ raises RuntimeError when necessary_keys are not included in the bandit_feedback
+    necessary_keys = ["action", "position", "reward", "pscore"]
+    for i in range(len(necessary_keys)):
+        for deleted_keys in itertools.combinations(necessary_keys, i + 1):
+            invalid_bandit_feedback_dict = {key: "_" for key in necessary_keys}
+            # delete
+            for k in deleted_keys:
+                del invalid_bandit_feedback_dict[k]
+            with pytest.raises(RuntimeError, match=r"Missing key*"):
+                _ = OffPolicyEvaluation(
+                    bandit_feedback=invalid_bandit_feedback_dict, ope_estimators=[ipw]
+                )
 
 
-def test_meta_create_estimator_inputs_format(
-    synthetic_bandit_feedback: BanditFeedback, random_action_dist: np.ndarray
+# action_dist, estimated_rewards_by_reg_model, description
+invalid_input_of_create_estimator_inputs = [
+    (
+        np.zeros((2, 3, 4)),
+        np.zeros((2, 3, 3)),
+        "estimated_rewards_by_reg_model.shape needs to be equal to action_dist.shape",
+    ),
+    (np.zeros((2, 3)), None, "action_dist.ndim must be 3-dimensional"),
+    ("3", None, "action_dist must be ndarray"),
+    (None, None, "action_dist must be ndarray"),
+]
+
+valid_input_of_create_estimator_inputs = [
+    (
+        np.zeros((2, 3, 4)),
+        np.zeros((2, 3, 4)),
+        "same shape",
+    ),
+    (np.zeros((2, 3, 1)), None, "estimated_rewards_by_reg_model is None"),
+]
+
+
+@pytest.mark.parametrize(
+    "action_dist, estimated_rewards_by_reg_model, description",
+    invalid_input_of_create_estimator_inputs,
+)
+def test_meta_create_estimator_inputs_using_invalid_input_data(
+    action_dist,
+    estimated_rewards_by_reg_model,
+    description: str,
+    synthetic_bandit_feedback: BanditFeedback,
 ) -> None:
     """
-    Test the _create_estimator_inputs format of OffPolicyEvaluation
+    Test the _create_estimator_inputs using valid data
     """
-    # __post_init__ saves the latter estimator when the same estimator name is used
     ope_ = OffPolicyEvaluation(
         bandit_feedback=synthetic_bandit_feedback, ope_estimators=[ipw]
     )
-    inputs = ope_._create_estimator_inputs(
-        action_dist=None, estimated_rewards_by_reg_model=None
+    # raise ValueError when the shape of two arrays are different
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_._create_estimator_inputs(
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+    # _create_estimator_inputs function is called in other functions
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_.estimate_policy_values(
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_.estimate_intervals(
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_.summarize_off_policy_estimates(
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_.evaluate_performance_of_estimators(
+            ground_truth_policy_value=0.1,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_.summarize_estimators_comparison(
+            ground_truth_policy_value=0.1,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+
+
+@pytest.mark.parametrize(
+    "action_dist, estimated_rewards_by_reg_model, description",
+    valid_input_of_create_estimator_inputs,
+)
+def test_meta_create_estimator_inputs_using_valid_input_data(
+    action_dist,
+    estimated_rewards_by_reg_model,
+    description: str,
+    synthetic_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the _create_estimator_inputs using invalid data
+    """
+    ope_ = OffPolicyEvaluation(
+        bandit_feedback=synthetic_bandit_feedback, ope_estimators=[ipw]
     )
-    assert set(inputs.keys()) == set(
+    estimator_inputs = ope_._create_estimator_inputs(
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+    assert set(estimator_inputs.keys()) == set(
         [
             "reward",
             "action",
@@ -284,16 +348,208 @@ def test_meta_create_estimator_inputs_format(
             "action_dist",
             "estimated_rewards_by_reg_model",
         ]
-    ), "Invalid response format of _create_estimator_inputs"
+    ), f"Invalid response of _create_estimator_inputs (test case: {description})"
+    # _create_estimator_inputs function is called in other functions
+    _ = ope_.estimate_policy_values(
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+    _ = ope_.estimate_intervals(
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+    _ = ope_.summarize_off_policy_estimates(
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+    _ = ope_.evaluate_performance_of_estimators(
+        ground_truth_policy_value=0.1,
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+    _ = ope_.summarize_estimators_comparison(
+        ground_truth_policy_value=0.1,
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
 
 
-def test_meta_summarize_off_policy_estimates(
-    synthetic_bandit_feedback: BanditFeedback, random_action_dist: np.ndarray
+@pytest.mark.parametrize(
+    "action_dist, estimated_rewards_by_reg_model, description",
+    valid_input_of_create_estimator_inputs,
+)
+def test_meta_estimate_policy_values_using_valid_input_data(
+    action_dist,
+    estimated_rewards_by_reg_model,
+    description: str,
+    synthetic_bandit_feedback: BanditFeedback,
 ) -> None:
+    """
+    Test the response of estimate_policy_values using valid data
+    """
+    # single ope estimator
+    ope_ = OffPolicyEvaluation(
+        bandit_feedback=synthetic_bandit_feedback, ope_estimators=[dm]
+    )
+    assert ope_.estimate_policy_values(
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    ) == {
+        "dm": mock_policy_value
+    }, "OffPolicyEvaluation.estimate_policy_values ([DirectMethod]) returns a wrong value"
+    # multiple ope estimators
+    ope_ = OffPolicyEvaluation(
+        bandit_feedback=synthetic_bandit_feedback, ope_estimators=[dm, ipw]
+    )
+    assert ope_.estimate_policy_values(
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    ) == {
+        "dm": mock_policy_value,
+        "ipw": mock_policy_value + ipw.eps,
+    }, "OffPolicyEvaluation.estimate_policy_values ([DirectMethod, IPW]) returns a wrong value"
+
+
+# alpha, n_bootstrap_samples, random_state, description
+invalid_input_of_estimate_intervals = [
+    (0.05, 100, "s", "random_state must be an integer"),
+    (0.05, -1, 1, "n_bootstrap_samples must be a positive integer"),
+    (0.05, "s", 1, "n_bootstrap_samples must be a positive integer"),
+    (0.0, 1, 1, "alpha must be a positive float (< 1)"),
+    (1.0, 1, 1, "alpha must be a positive float (< 1)"),
+    ("0", 1, 1, "alpha must be a positive float (< 1)"),
+]
+
+valid_input_of_estimate_intervals = [
+    (0.05, 100, 1, "random_state is 1"),
+    (0.05, 1, 1, "n_bootstrap_samples is 1"),
+]
+
+
+@pytest.mark.parametrize(
+    "action_dist, estimated_rewards_by_reg_model, description_1",
+    valid_input_of_create_estimator_inputs,
+)
+@pytest.mark.parametrize(
+    "alpha, n_bootstrap_samples, random_state, description_2",
+    invalid_input_of_estimate_intervals,
+)
+def test_meta_estimate_intervals_using_invalid_input_data(
+    action_dist,
+    estimated_rewards_by_reg_model,
+    description_1: str,
+    alpha,
+    n_bootstrap_samples,
+    random_state,
+    description_2: str,
+    synthetic_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the response of estimate_intervals using invalid data
+    """
+    ope_ = OffPolicyEvaluation(
+        bandit_feedback=synthetic_bandit_feedback, ope_estimators=[dm]
+    )
+    with pytest.raises(ValueError, match=f"{description_2}*"):
+        _ = ope_.estimate_intervals(
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+    # estimate_intervals function is called in summarize_off_policy_estimates
+    with pytest.raises(ValueError, match=f"{description_2}*"):
+        _ = ope_.summarize_off_policy_estimates(
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@pytest.mark.parametrize(
+    "action_dist, estimated_rewards_by_reg_model, description_1",
+    valid_input_of_create_estimator_inputs,
+)
+@pytest.mark.parametrize(
+    "alpha, n_bootstrap_samples, random_state, description_2",
+    valid_input_of_estimate_intervals,
+)
+def test_meta_estimate_intervals_using_valid_input_data(
+    action_dist,
+    estimated_rewards_by_reg_model,
+    description_1: str,
+    alpha: float,
+    n_bootstrap_samples: int,
+    random_state: int,
+    description_2: str,
+    synthetic_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the response of estimate_intervals using valid data
+    """
+    # single ope estimator
+    ope_ = OffPolicyEvaluation(
+        bandit_feedback=synthetic_bandit_feedback, ope_estimators=[dm]
+    )
+    assert ope_.estimate_intervals(
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        alpha=alpha,
+        n_bootstrap_samples=n_bootstrap_samples,
+        random_state=random_state,
+    ) == {
+        "dm": mock_confidence_interval
+    }, "OffPolicyEvaluation.estimate_intervals ([DirectMethod]) returns a wrong value"
+    # multiple ope estimators
+    ope_ = OffPolicyEvaluation(
+        bandit_feedback=synthetic_bandit_feedback, ope_estimators=[dm, ipw]
+    )
+    assert ope_.estimate_intervals(
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        alpha=alpha,
+        n_bootstrap_samples=n_bootstrap_samples,
+        random_state=random_state,
+    ) == {
+        "dm": mock_confidence_interval,
+        "ipw": {k: v + ipw.eps for k, v in mock_confidence_interval.items()},
+    }, "OffPolicyEvaluation.estimate_intervals ([DirectMethod, IPW]) returns a wrong value"
+
+
+@pytest.mark.parametrize(
+    "action_dist, estimated_rewards_by_reg_model, description_1",
+    valid_input_of_create_estimator_inputs,
+)
+@pytest.mark.parametrize(
+    "alpha, n_bootstrap_samples, random_state, description_2",
+    valid_input_of_estimate_intervals,
+)
+def test_meta_summarize_off_policy_estimates(
+    action_dist,
+    estimated_rewards_by_reg_model,
+    description_1: str,
+    alpha: float,
+    n_bootstrap_samples: int,
+    random_state: int,
+    description_2: str,
+    synthetic_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the response of summarize_off_policy_estimates using valid data
+    """
     ope_ = OffPolicyEvaluation(
         bandit_feedback=synthetic_bandit_feedback, ope_estimators=[ipw, ipw3]
     )
-    value, interval = ope_.summarize_off_policy_estimates(random_action_dist)
+    value, interval = ope_.summarize_off_policy_estimates(
+        action_dist=action_dist,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        alpha=alpha,
+        n_bootstrap_samples=n_bootstrap_samples,
+        random_state=random_state,
+    )
     expected_value = pd.DataFrame(
         {
             "ipw": mock_policy_value + ipw.eps,
@@ -311,40 +567,120 @@ def test_meta_summarize_off_policy_estimates(
     assert_frame_equal(interval, expected_interval), "Invalid summarization (interval)"
 
 
-def test_meta_evaluate_performance_of_estimators(
-    synthetic_bandit_feedback: BanditFeedback, random_action_dist: np.ndarray
+invalid_input_of_evaluation_performance = [
+    ("foo", 0.3, "metric must be either 'relative-ee' or 'se'"),
+    ("se", 1, "ground_truth_policy_value must be a float"),
+    ("se", "a", "ground_truth_policy_value must be a float"),
+    (
+        "relative-ee",
+        0.0,
+        "ground_truth_policy_value must be non-zero when metric is relative-ee",
+    ),
+]
+
+valid_input_of_evaluation_performance = [
+    ("se", 0.0, "metric is se and ground_truth_policy_value is 0.0"),
+    ("relative-ee", 1.0, "metric is relative-ee and ground_truth_policy_value is 1.0"),
+]
+
+
+@pytest.mark.parametrize(
+    "action_dist, estimated_rewards_by_reg_model, description_1",
+    valid_input_of_create_estimator_inputs,
+)
+@pytest.mark.parametrize(
+    "metric, ground_truth_policy_value, description_2",
+    invalid_input_of_evaluation_performance,
+)
+def test_meta_evaluate_performance_of_estimators_using_invalid_input_data(
+    action_dist,
+    estimated_rewards_by_reg_model,
+    description_1: str,
+    metric,
+    ground_truth_policy_value,
+    description_2: str,
+    synthetic_bandit_feedback: BanditFeedback,
 ) -> None:
-    gt = 0.5
-    # calculate relative-ee
-    eval_metric_ope_dict = {
-        "ipw": np.abs((mock_policy_value + ipw.eps - gt) / gt),
-        "ipw3": np.abs((mock_policy_value + ipw3.eps - gt) / gt),
-    }
+    """
+    Test the response of evaluate_performance_of_estimators using invalid data
+    """
+    ope_ = OffPolicyEvaluation(
+        bandit_feedback=synthetic_bandit_feedback, ope_estimators=[dm]
+    )
+    with pytest.raises(ValueError, match=f"{description_2}*"):
+        _ = ope_.evaluate_performance_of_estimators(
+            ground_truth_policy_value=ground_truth_policy_value,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            action_dist=action_dist,
+            metric=metric,
+        )
+    # estimate_intervals function is called in summarize_off_policy_estimates
+    with pytest.raises(ValueError, match=f"{description_2}*"):
+        _ = ope_.summarize_estimators_comparison(
+            ground_truth_policy_value=ground_truth_policy_value,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            action_dist=action_dist,
+            metric=metric,
+        )
+
+
+@pytest.mark.parametrize(
+    "action_dist, estimated_rewards_by_reg_model, description_1",
+    valid_input_of_create_estimator_inputs,
+)
+@pytest.mark.parametrize(
+    "metric, ground_truth_policy_value, description_2",
+    valid_input_of_evaluation_performance,
+)
+def test_meta_evaluate_performance_of_estimators_using_valid_input_data(
+    action_dist,
+    estimated_rewards_by_reg_model,
+    description_1: str,
+    metric,
+    ground_truth_policy_value,
+    description_2: str,
+    synthetic_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the response of evaluate_performance_of_estimators using valid data
+    """
+    if metric == "relative-ee":
+        # calculate relative-ee
+        eval_metric_ope_dict = {
+            "ipw": np.abs(
+                (mock_policy_value + ipw.eps - ground_truth_policy_value)
+                / ground_truth_policy_value
+            ),
+            "ipw3": np.abs(
+                (mock_policy_value + ipw3.eps - ground_truth_policy_value)
+                / ground_truth_policy_value
+            ),
+        }
+    else:
+        # calculate se
+        eval_metric_ope_dict = {
+            "ipw": (mock_policy_value + ipw.eps - ground_truth_policy_value) ** 2,
+            "ipw3": (mock_policy_value + ipw3.eps - ground_truth_policy_value) ** 2,
+        }
     # check performance estimators
     ope_ = OffPolicyEvaluation(
         bandit_feedback=synthetic_bandit_feedback, ope_estimators=[ipw, ipw3]
     )
     performance = ope_.evaluate_performance_of_estimators(
-        ground_truth_policy_value=gt,
-        action_dist=random_action_dist,
-        metric="relative-ee",
+        ground_truth_policy_value=ground_truth_policy_value,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        action_dist=action_dist,
+        metric=metric,
     )
     for k, v in performance.items():
         assert k in eval_metric_ope_dict, "Invalid key of performance response"
         assert v == eval_metric_ope_dict[k], "Invalid value of performance response"
-    # zero division error when using relative-ee
-    with pytest.raises(ZeroDivisionError, match=r"float division by zero"):
-        _ = ope_.evaluate_performance_of_estimators(
-            ground_truth_policy_value=0.0,
-            action_dist=random_action_dist,
-            metric="relative-ee",
-        )
-    # check summarization
     performance_df = ope_.summarize_estimators_comparison(
-        ground_truth_policy_value=gt,
-        action_dist=random_action_dist,
-        metric="relative-ee",
+        ground_truth_policy_value=ground_truth_policy_value,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        action_dist=action_dist,
+        metric=metric,
     )
     assert_frame_equal(
-        performance_df, pd.DataFrame(eval_metric_ope_dict, index=["relative-ee"]).T
+        performance_df, pd.DataFrame(eval_metric_ope_dict, index=[metric]).T
     ), "Invalid summarization (performance)"

--- a/tests/ope/test_meta.py
+++ b/tests/ope/test_meta.py
@@ -295,7 +295,10 @@ def test_meta_summarize_off_policy_estimates(
     )
     value, interval = ope_.summarize_off_policy_estimates(random_action_dist)
     expected_value = pd.DataFrame(
-        {"ipw": mock_policy_value + ipw.eps, "ipw3": mock_policy_value + ipw3.eps,},
+        {
+            "ipw": mock_policy_value + ipw.eps,
+            "ipw3": mock_policy_value + ipw3.eps,
+        },
         index=["estimated_policy_value"],
     ).T
     expected_interval = pd.DataFrame(


### PR DESCRIPTION
# Overview
- fix validation of ope.meta.py
- fix test_meta.py to check the validation

# Testing plan
- assert -> ValueError
- parametrize invalid data and valid data
- add test