### PR TITLE
Add calc_ground_truth_policy_value to SyntheticBanditDataset

### DIFF
--- a/obp/dataset/synthetic.py
+++ b/obp/dataset/synthetic.py
@@ -201,7 +201,8 @@ class SyntheticBanditDataset(BaseSyntheticBanditDataset):
             action = np.array(
                 [
                     self.random_.choice(
-                        np.arange(self.n_actions), p=behavior_policy_[i],
+                        np.arange(self.n_actions),
+                        p=behavior_policy_[i],
                     )
                     for i in np.arange(n_rounds)
                 ]
@@ -289,7 +290,9 @@ class SyntheticBanditDataset(BaseSyntheticBanditDataset):
 
 
 def logistic_reward_function(
-    context: np.ndarray, action_context: np.ndarray, random_state: Optional[int] = None,
+    context: np.ndarray,
+    action_context: np.ndarray,
+    random_state: Optional[int] = None,
 ) -> np.ndarray:
     """Logistic mean reward function for synthetic bandit datasets.
 
@@ -328,7 +331,9 @@ def logistic_reward_function(
 
 
 def linear_reward_function(
-    context: np.ndarray, action_context: np.ndarray, random_state: Optional[int] = None,
+    context: np.ndarray,
+    action_context: np.ndarray,
+    random_state: Optional[int] = None,
 ) -> np.ndarray:
     """Linear mean reward function for synthetic bandit datasets.
 
@@ -367,7 +372,9 @@ def linear_reward_function(
 
 
 def linear_behavior_policy(
-    context: np.ndarray, action_context: np.ndarray, random_state: Optional[int] = None,
+    context: np.ndarray,
+    action_context: np.ndarray,
+    random_state: Optional[int] = None,
 ) -> np.ndarray:
     """Linear contextual behavior policy for synthetic bandit datasets.
 

--- a/obp/dataset/synthetic.py
+++ b/obp/dataset/synthetic.py
@@ -248,6 +248,39 @@ class SyntheticBanditDataset(BaseSyntheticBanditDataset):
             pscore=pscore,
         )
 
+    def calc_ground_truth_policy_value(self, expected_reward: np.ndarray, action_dist: np.ndarray) -> float:
+        """Calculate the policy value of given action distribution on the given expected_reward.
+
+        Parameters
+        -----------
+        expected_reward: array-like, shape (n_rounds, n_actions)
+            Expected reward given context (:math:`x`) and action (:math:`a`), i.e., :math:`q(x,a):=\\mathbb{E}[r|x,a]`.
+            This is often the expected_reward of the test set of logged bandit feedback data.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        Returns
+        ----------
+        policy_value: float
+            The policy value of the given action distribution on the given bandit feedback data.
+
+        """
+        if not isinstance(expected_reward, np.ndarray):
+            raise ValueError("expected_reward must be ndarray")
+        if not isinstance(action_dist, np.ndarray):
+            raise ValueError("action_dist must be ndarray")
+        if action_dist.ndim != 3:
+            raise ValueError(
+                f"action_dist must be 3-dimensional, but is {action_dist.ndim}."
+            )
+        if (expected_reward.shape[0] != action_dist.shape[0]):
+            raise ValueError("the size of axis 0 of expected_reward must be the same as that of action_dist")
+        if (expected_reward.shape[1] != action_dist.shape[1]):
+            raise ValueError("the size of axis 1 of expected_reward must be the same as that of action_dist")
+
+        return np.average(expected_reward, weights=action_dist[:, :, 0], axis=1).mean()
+
 
 def logistic_reward_function(
     context: np.ndarray, action_context: np.ndarray, random_state: Optional[int] = None,

--- a/obp/dataset/synthetic.py
+++ b/obp/dataset/synthetic.py
@@ -248,7 +248,9 @@ class SyntheticBanditDataset(BaseSyntheticBanditDataset):
             pscore=pscore,
         )
 
-    def calc_ground_truth_policy_value(self, expected_reward: np.ndarray, action_dist: np.ndarray) -> float:
+    def calc_ground_truth_policy_value(
+        self, expected_reward: np.ndarray, action_dist: np.ndarray
+    ) -> float:
         """Calculate the policy value of given action distribution on the given expected_reward.
 
         Parameters
@@ -274,10 +276,14 @@ class SyntheticBanditDataset(BaseSyntheticBanditDataset):
             raise ValueError(
                 f"action_dist must be 3-dimensional, but is {action_dist.ndim}."
             )
-        if (expected_reward.shape[0] != action_dist.shape[0]):
-            raise ValueError("the size of axis 0 of expected_reward must be the same as that of action_dist")
-        if (expected_reward.shape[1] != action_dist.shape[1]):
-            raise ValueError("the size of axis 1 of expected_reward must be the same as that of action_dist")
+        if expected_reward.shape[0] != action_dist.shape[0]:
+            raise ValueError(
+                "the size of axis 0 of expected_reward must be the same as that of action_dist"
+            )
+        if expected_reward.shape[1] != action_dist.shape[1]:
+            raise ValueError(
+                "the size of axis 1 of expected_reward must be the same as that of action_dist"
+            )
 
         return np.average(expected_reward, weights=action_dist[:, :, 0], axis=1).mean()
 

--- a/tests/dataset/test_synthetic.py
+++ b/tests/dataset/test_synthetic.py
@@ -90,6 +90,62 @@ def test_synthetic_obtain_batch_bandit_feedback():
     )
 
 
+# expected_reward, action_dist, description
+invalid_input_of_calc_policy_value = [
+    (
+        np.ones((2, 3)),
+        np.ones((3, 3, 3)),
+        "the size of axis 0 of expected_reward must be the same as that of action_dist",
+    ),
+    (
+        np.ones((2, 3)),
+        np.ones((2, 2, 3)),
+        "the size of axis 1 of expected_reward must be the same as that of action_dist",
+    ),
+    ("3", np.ones((2, 2, 3)), "expected_reward must be ndarray"),
+    (None, np.ones((2, 2, 3)), "expected_reward must be ndarray"),
+    (np.ones((2, 3)), np.ones((2, 3)), "action_dist must be 3-dimensional, but is 2."),
+    (np.ones((2, 3)), "3", "action_dist must be ndarray"),
+    (np.ones((2, 3)), None, "action_dist must be ndarray"),
+]
+
+valid_input_of_calc_policy_value = [
+    (np.ones((2, 3)), np.ones((2, 3, 1)), "valid shape",),
+]
+
+
+@pytest.mark.parametrize(
+    "expected_reward, action_dist, description", invalid_input_of_calc_policy_value,
+)
+def test_synthetic_calc_policy_value_using_invalid_inputs(
+    expected_reward, action_dist, description,
+):
+    n_actions = 10
+    dataset = SyntheticBanditDataset(n_actions=n_actions)
+
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = dataset.calc_ground_truth_policy_value(
+            expected_reward=expected_reward, action_dist=action_dist
+        )
+
+
+@pytest.mark.parametrize(
+    "expected_reward, action_dist, description", valid_input_of_calc_policy_value,
+)
+def test_synthetic_calc_policy_value_using_valid_inputs(
+    expected_reward, action_dist, description,
+):
+    n_actions = 10
+    dataset = SyntheticBanditDataset(n_actions=n_actions)
+
+    policy_value = dataset.calc_ground_truth_policy_value(
+        expected_reward=expected_reward, action_dist=action_dist
+    )
+    assert isinstance(
+        policy_value, float
+    ), "Invalid response of calc_ground_truth_policy_value"
+
+
 def test_synthetic_logistic_reward_function():
     # context
     with pytest.raises(ValueError):

--- a/tests/dataset/test_synthetic.py
+++ b/tests/dataset/test_synthetic.py
@@ -110,15 +110,22 @@ invalid_input_of_calc_policy_value = [
 ]
 
 valid_input_of_calc_policy_value = [
-    (np.ones((2, 3)), np.ones((2, 3, 1)), "valid shape",),
+    (
+        np.ones((2, 3)),
+        np.ones((2, 3, 1)),
+        "valid shape",
+    ),
 ]
 
 
 @pytest.mark.parametrize(
-    "expected_reward, action_dist, description", invalid_input_of_calc_policy_value,
+    "expected_reward, action_dist, description",
+    invalid_input_of_calc_policy_value,
 )
 def test_synthetic_calc_policy_value_using_invalid_inputs(
-    expected_reward, action_dist, description,
+    expected_reward,
+    action_dist,
+    description,
 ):
     n_actions = 10
     dataset = SyntheticBanditDataset(n_actions=n_actions)
@@ -130,10 +137,13 @@ def test_synthetic_calc_policy_value_using_invalid_inputs(
 
 
 @pytest.mark.parametrize(
-    "expected_reward, action_dist, description", valid_input_of_calc_policy_value,
+    "expected_reward, action_dist, description",
+    valid_input_of_calc_policy_value,
 )
 def test_synthetic_calc_policy_value_using_valid_inputs(
-    expected_reward, action_dist, description,
+    expected_reward,
+    action_dist,
+    description,
 ):
     n_actions = 10
     dataset = SyntheticBanditDataset(n_actions=n_actions)


### PR DESCRIPTION
## Overview
add `calc_ground_truth_synthetic` method to `SyntheticBanditDataset` class in the dataset module
This will ease the calculation of the ground-truth policy value of evaluation policies when we use synthetic bandit data to conduct the evaluation of OPE experiments

### Before
<img width="1407" alt="スクリーンショット 2021-02-01 8 34 26" src="https://user-images.githubusercontent.com/32621707/106401750-26c94380-6469-11eb-90e5-5e07fd8ac42b.png">


### After
<img width="1417" alt="スクリーンショット 2021-02-01 8 34 50" src="https://user-images.githubusercontent.com/32621707/106401747-216bf900-6469-11eb-9151-0decc3ec39ca.png">


codes from https://github.com/st-tech/zr-obp/blob/master/examples/quickstart/synthetic.ipynb

## Review points
- `SyntheticBanditDataset.calc_ground_truth_synthetic`
- Testing structure (test_synthetic.py)
- Testing code (test_synthetic.py)