### PR TITLE
refactor base dataset class

### DIFF
--- a/obp/dataset/base.py
+++ b/obp/dataset/base.py
@@ -5,7 +5,16 @@
 from abc import ABCMeta, abstractmethod
 
 
-class BaseRealBanditDataset(metaclass=ABCMeta):
+class BaseBanditDataset(metaclass=ABCMeta):
+    """Base Class for Synthetic Bandit Dataset."""
+
+    @abstractmethod
+    def obtain_batch_bandit_feedback(self) -> None:
+        """Obtain batch logged bandit feedback."""
+        raise NotImplementedError
+
+
+class BaseRealBanditDataset(BaseBanditDataset):
     """Base Class for Real-World Bandit Dataset."""
 
     @abstractmethod
@@ -16,18 +25,4 @@ class BaseRealBanditDataset(metaclass=ABCMeta):
     @abstractmethod
     def pre_process(self) -> None:
         """Preprocess raw dataset."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def obtain_batch_bandit_feedback(self) -> None:
-        """Obtain batch logged bandit feedback."""
-        raise NotImplementedError
-
-
-class BaseSyntheticBanditDataset(metaclass=ABCMeta):
-    """Base Class for Synthetic Bandit Dataset."""
-
-    @abstractmethod
-    def obtain_batch_bandit_feedback(self) -> None:
-        """Obtain batch logged bandit feedback."""
         raise NotImplementedError

--- a/obp/dataset/multiclass.py
+++ b/obp/dataset/multiclass.py
@@ -11,12 +11,12 @@ from sklearn.base import ClassifierMixin, is_classifier, clone
 from sklearn.model_selection import train_test_split
 from sklearn.utils import check_random_state, check_X_y
 
-from .base import BaseSyntheticBanditDataset
+from .base import BaseBanditDataset
 from ..types import BanditFeedback
 
 
 @dataclass
-class MultiClassToBanditReduction(BaseSyntheticBanditDataset):
+class MultiClassToBanditReduction(BaseBanditDataset):
     """Class for handling multi-class classification data as logged bandit feedback data.
 
     Note

--- a/obp/dataset/synthetic.py
+++ b/obp/dataset/synthetic.py
@@ -9,13 +9,13 @@ import numpy as np
 from scipy.stats import truncnorm
 from sklearn.utils import check_random_state
 
-from .base import BaseSyntheticBanditDataset
+from .base import BaseBanditDataset
 from ..types import BanditFeedback
 from ..utils import sigmoid, softmax
 
 
 @dataclass
-class SyntheticBanditDataset(BaseSyntheticBanditDataset):
+class SyntheticBanditDataset(BaseBanditDataset):
     """Class for generating synthetic bandit dataset.
 
     Note


### PR DESCRIPTION
## Overview

In the current implementation, `BaseSyntheticBanditDataset` and `BaseRealBanditDataset` are defined independently, despite the fact that the functions of `BaseRealBanditDataset` include that of `BaseSyntheticBanditDataset`.
This PR renames the `BaseSyntheticBanditDataset` to `BaseBanditDataset`, and let `BaseRealBanditDataset` inherit `BaseBanditDataset`.

## Review Points
Please check whether inheritance relation is rational and valid.
