### PR TITLE
Split bandit_feedback to train and test when is_timeseries_split=True

### DIFF
--- a/obp/dataset/real.py
+++ b/obp/dataset/real.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from logging import getLogger, basicConfig, INFO
 from pathlib import Path
 from typing import Optional
+from typing import Union
+from typing import Tuple
 
 import numpy as np
 import pandas as pd
@@ -191,7 +193,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
 
     def obtain_batch_bandit_feedback(
         self, test_size: float = 0.3, is_timeseries_split: bool = False
-    ) -> BanditFeedback:
+    ) -> Union[BanditFeedback, Tuple[BanditFeedback, BanditFeedback]]:
         """Obtain batch logged bandit feedback.
 
         Parameters
@@ -225,21 +227,26 @@ class OpenBanditDataset(BaseRealBanditDataset):
                     f"test_size must be a float in the (0,1) interval, but {test_size} is given"
                 )
             n_rounds_train = np.int(self.n_rounds * (1.0 - test_size))
-            return dict(
+            bandit_feedback_train = dict(
                 n_rounds=n_rounds_train,
                 n_actions=self.n_actions,
                 action=self.action[:n_rounds_train],
-                action_test=self.action[n_rounds_train:],
                 position=self.position[:n_rounds_train],
-                position_test=self.position[n_rounds_train:],
                 reward=self.reward[:n_rounds_train],
-                reward_test=self.reward[n_rounds_train:],
                 pscore=self.pscore[:n_rounds_train],
-                pscore_test=self.pscore[n_rounds_train:],
                 context=self.context[:n_rounds_train],
-                context_test=self.context[n_rounds_train:],
                 action_context=self.action_context,
             )
+            bandit_feedback_test = dict(
+                n_actions=self.n_actions,
+                action=self.action[n_rounds_train:],
+                position=self.position[n_rounds_train:],
+                reward=self.reward[n_rounds_train:],
+                pscore=self.pscore[n_rounds_train:],
+                context=self.context[n_rounds_train:],
+                action_context=self.action_context,
+            )
+            return bandit_feedback_train, bandit_feedback_test
         else:
             return dict(
                 n_rounds=self.n_rounds,

--- a/obp/dataset/real.py
+++ b/obp/dataset/real.py
@@ -149,13 +149,16 @@ class OpenBanditDataset(BaseRealBanditDataset):
             This parameter is used as a ground-truth policy value in the evaluation of OPE estimators.
 
         """
-        return (
-            cls(behavior_policy=behavior_policy, campaign=campaign, data_path=data_path)
-            .obtain_batch_bandit_feedback(
-                test_size=test_size, is_timeseries_split=is_timeseries_split
-            )["reward_test"]
-            .mean()
+        bandit_feedback = cls(
+            behavior_policy=behavior_policy, campaign=campaign, data_path=data_path
+        ).obtain_batch_bandit_feedback(
+            test_size=test_size, is_timeseries_split=is_timeseries_split
         )
+        if is_timeseries_split:
+            bandit_feedback_test = bandit_feedback[1]
+        else:
+            bandit_feedback_test = bandit_feedback
+        return bandit_feedback_test["reward"].mean()
 
     def load_raw_data(self) -> None:
         """Load raw open bandit dataset."""
@@ -238,6 +241,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
                 action_context=self.action_context,
             )
             bandit_feedback_test = dict(
+                n_rounds=n_rounds_train,
                 n_actions=self.n_actions,
                 action=self.action[n_rounds_train:],
                 position=self.position[n_rounds_train:],
@@ -254,7 +258,6 @@ class OpenBanditDataset(BaseRealBanditDataset):
                 action=self.action,
                 position=self.position,
                 reward=self.reward,
-                reward_test=self.reward,
                 pscore=self.pscore,
                 context=self.context,
                 action_context=self.action_context,

--- a/obp/dataset/real.py
+++ b/obp/dataset/real.py
@@ -299,9 +299,14 @@ class OpenBanditDataset(BaseRealBanditDataset):
             - action_context: item-related context vectors
 
         """
-        bandit_feedback = self.obtain_batch_bandit_feedback(
-            test_size=test_size, is_timeseries_split=is_timeseries_split
-        )
+        if is_timeseries_split:
+            bandit_feedback = self.obtain_batch_bandit_feedback(
+                test_size=test_size, is_timeseries_split=is_timeseries_split
+            )[0]
+        else:
+            bandit_feedback = self.obtain_batch_bandit_feedback(
+                test_size=test_size, is_timeseries_split=is_timeseries_split
+            )
         n_rounds = bandit_feedback["n_rounds"]
         random_ = check_random_state(random_state)
         bootstrap_idx = random_.choice(np.arange(n_rounds), size=n_rounds, replace=True)

--- a/tests/dataset/test_real.py
+++ b/tests/dataset/test_real.py
@@ -72,7 +72,7 @@ def test_obtain_batch_bandit_feedback():
     bandit_feedback_train = bandit_feedback_timeseries[0]
     bandit_feedback_test = bandit_feedback_timeseries[1]
 
-    bf_train_elems = {
+    bf_elems = {
         "n_rounds",
         "n_actions",
         "action",
@@ -82,9 +82,8 @@ def test_obtain_batch_bandit_feedback():
         "context",
         "action_context",
     }
-    bf_test_elems = bf_train_elems - {"n_rounds"}
-    assert all(k in bandit_feedback_train.keys() for k in bf_train_elems)
-    assert all(k in bandit_feedback_test.keys() for k in bf_test_elems)
+    assert all(k in bandit_feedback_train.keys() for k in bf_elems)
+    assert all(k in bandit_feedback_test.keys() for k in bf_elems)
 
 
 def test_calc_on_policy_policy_value_estimate():

--- a/tests/dataset/test_real.py
+++ b/tests/dataset/test_real.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 
 from typing import Tuple
+from typing import Dict
 
 from obp.dataset import OpenBanditDataset
 
@@ -98,8 +99,15 @@ def test_sample_bootstrap_bandit_feedback():
     bandit_feedback = dataset.obtain_batch_bandit_feedback()
     bootstrap_bf = dataset.sample_bootstrap_bandit_feedback()
 
-    assert len(bandit_feedback["action"]) == len(bootstrap_bf["action"])
-    assert len(bandit_feedback["position"]) == len(bootstrap_bf["position"])
-    assert len(bandit_feedback["reward"]) == len(bootstrap_bf["reward"])
-    assert len(bandit_feedback["pscore"]) == len(bootstrap_bf["pscore"])
-    assert len(bandit_feedback["context"]) == len(bootstrap_bf["context"])
+    bf_keys = {"action", "position", "reward", "pscore", "context"}
+    for k in bf_keys:
+        assert len(bandit_feedback[k]) == len(bootstrap_bf[k])
+
+    bandit_feedback_timeseries: Dict = dataset.obtain_batch_bandit_feedback(
+        is_timeseries_split=True
+    )[0]
+    bootstrap_bf_timeseries = dataset.sample_bootstrap_bandit_feedback(
+        is_timeseries_split=True
+    )
+    for k in bf_keys:
+        assert len(bandit_feedback_timeseries[k]) == len(bootstrap_bf_timeseries[k])

--- a/tests/dataset/test_real.py
+++ b/tests/dataset/test_real.py
@@ -2,6 +2,8 @@ import pytest
 import numpy as np
 import pandas as pd
 
+from typing import Tuple
+
 from obp.dataset import OpenBanditDataset
 
 
@@ -63,22 +65,26 @@ def test_obtain_batch_bandit_feedback():
     assert "action_context" in bandit_feedback.keys()
 
     # is_timeseries_split=True
-    dataset2 = OpenBanditDataset(behavior_policy="random", campaign="all")
-    bandit_feedback2 = dataset2.obtain_batch_bandit_feedback(is_timeseries_split=True)
+    bandit_feedback_timeseries = dataset.obtain_batch_bandit_feedback(
+        is_timeseries_split=True
+    )
+    assert isinstance(bandit_feedback_timeseries, Tuple)
+    bandit_feedback_train = bandit_feedback_timeseries[0]
+    bandit_feedback_test = bandit_feedback_timeseries[1]
 
-    assert "n_rounds" in bandit_feedback2.keys()
-    assert "n_actions" in bandit_feedback2.keys()
-    assert "action" in bandit_feedback2.keys()
-    assert "action_test" in bandit_feedback2.keys()
-    assert "position" in bandit_feedback2.keys()
-    assert "position_test" in bandit_feedback2.keys()
-    assert "reward" in bandit_feedback2.keys()
-    assert "reward_test" in bandit_feedback2.keys()
-    assert "pscore" in bandit_feedback2.keys()
-    assert "pscore_test" in bandit_feedback2.keys()
-    assert "context" in bandit_feedback2.keys()
-    assert "context_test" in bandit_feedback2.keys()
-    assert "action_context" in bandit_feedback2.keys()
+    bf_train_elems = {
+        "n_rounds",
+        "n_actions",
+        "action",
+        "position",
+        "reward",
+        "pscore",
+        "context",
+        "action_context",
+    }
+    bf_test_elems = bf_train_elems - {"n_rounds"}
+    assert all(k in bandit_feedback_train.keys() for k in bf_train_elems)
+    assert all(k in bandit_feedback_test.keys() for k in bf_test_elems)
 
 
 def test_calc_on_policy_policy_value_estimate():


### PR DESCRIPTION
## Overview
This PR modifies the output of the `obtain_batch_bandit_feedback` function in `obp/dataset/real.py`.
In the current implementation, even if `is_timeseries_split=True`, one dict containing the key such as `..._test` was returned.
In this PR, if `is_timeseries_split=True`, split to create two dict and return them to users.

## Note
The modifications due to the changes in this PR  are limited to the scope of `test` module.
Therefore, for example, for the following file, it is expected that execution will result in an **error** due to this PR.

https://github.com/st-tech/zr-obp/blob/c870a20c3bb6f3a7d1b42bf1ebed01a5f2239aa6/benchmark/ope/train_regression_model.py#L48