### PR TITLE
fix hyperparameter validations of dr-variants

### DIFF
--- a/obp/ope/estimators.py
+++ b/obp/ope/estimators.py
@@ -1098,10 +1098,12 @@ class SwitchDoublyRobust(DoublyRobust):
 
     def __post_init__(self) -> None:
         """Initialize Class."""
-        if not isinstance(self.tau, float):
+        if not isinstance(self.tau, (float, int)):
             raise ValueError(
-                f"switching hyperparameter must be float, but {self.tau} is given"
+                f"switching hyperparameter must be float or integer, but {self.tau} is given"
             )
+        if self.tau != self.tau:
+            raise ValueError("switching hyperparameter must not be nan")
         if self.tau < 0.0:
             raise ValueError(
                 f"switching hyperparameter must be larger than or equal to zero, but {self.tau} is given"
@@ -1221,10 +1223,12 @@ class DoublyRobustWithShrinkage(DoublyRobust):
 
     def __post_init__(self) -> None:
         """Initialize Class."""
-        if not isinstance(self.lambda_, float):
+        if not isinstance(self.lambda_, (float, int)):
             raise ValueError(
-                f"shrinkage hyperparameter must be float, but {self.lambda_} is given"
+                f"shrinkage hyperparameter must be float or integer, but {self.lambda_} is given"
             )
+        if self.lambda_ != self.lambda_:
+            raise ValueError("shrinkage hyperparameter must not be nan")
         if self.lambda_ < 0.0:
             raise ValueError(
                 f"shrinkage hyperparameter must be larger than or equal to zero, but {self.lambda_} is given"

--- a/tests/ope/test_dr_estimators.py
+++ b/tests/ope/test_dr_estimators.py
@@ -231,8 +231,9 @@ def test_dr_using_invalid_input_data(
 # switch-dr
 
 invalid_input_of_switch = [
-    ("a", "switching hyperparameter must be float"),
+    ("a", "switching hyperparameter must be float or integer"),
     (-1.0, "switching hyperparameter must be larger than or equal to zero"),
+    (np.nan, "switching hyperparameter must not be nan"),
 ]
 
 
@@ -245,10 +246,25 @@ def test_switch_using_invalid_input_data(tau: float, description: str) -> None:
         _ = SwitchDoublyRobust(tau=tau)
 
 
+valid_input_of_switch = [
+    (3.0, "float tau"),
+    (2, "integer tau"),
+]
+
+
+@pytest.mark.parametrize(
+    "tau, description",
+    valid_input_of_switch,
+)
+def test_switch_using_valid_input_data(tau: float, description: str) -> None:
+    _ = SwitchDoublyRobust(tau=tau)
+
+
 # dr-os
 invalid_input_of_shrinkage = [
-    ("a", "shrinkage hyperparameter must be float"),
+    ("a", "shrinkage hyperparameter must be float or integer"),
     (-1.0, "shrinkage hyperparameter must be larger than or equal to zero"),
+    (np.nan, "shrinkage hyperparameter must not be nan"),
 ]
 
 
@@ -259,6 +275,20 @@ invalid_input_of_shrinkage = [
 def test_shrinkage_using_invalid_input_data(lambda_: float, description: str) -> None:
     with pytest.raises(ValueError, match=f"{description}*"):
         _ = DoublyRobustWithShrinkage(lambda_=lambda_)
+
+
+valid_input_of_shrinkage = [
+    (3.0, "float lambda_"),
+    (2, "integer lambda_"),
+]
+
+
+@pytest.mark.parametrize(
+    "lambda_, description",
+    valid_input_of_shrinkage,
+)
+def test_shrinkage_using_valid_input_data(lambda_: float, description: str) -> None:
+    _ = DoublyRobustWithShrinkage(lambda_=lambda_)
 
 
 # dr variants


### PR DESCRIPTION
# Overview
- #74 


# Change points
- fix hyperparameter validations in `estimators.py`
  - allow interger
  - reject np.nan
- add several tests to check the validations