### PR TITLE
fix type check issues in Windows

### DIFF
--- a/obp/dataset/synthetic.py
+++ b/obp/dataset/synthetic.py
@@ -239,7 +239,7 @@ class SyntheticBanditDataset(BaseBanditDataset):
             raise ValueError(
                 "the size of axis 0 of context must be the same as that of action"
             )
-        if not np.issubdtype(int, action.dtype):
+        if not np.issubdtype(action.dtype, np.integer):
             raise ValueError("the dtype of action must be a subdtype of int")
 
         expected_reward_ = self.calc_expected_reward(context)

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -173,7 +173,7 @@ def check_bandit_feedback_inputs(
         raise ValueError("reward must be ndarray")
     if reward.ndim != 1:
         raise ValueError("reward must be 1-dimensional")
-    if not (action.dtype == int and action.min() >= 0):
+    if not (np.issubdtype(action.dtype, np.integer) and action.min() >= 0):
         raise ValueError("action elements must be non-negative integers")
 
     if expected_reward is not None:
@@ -219,7 +219,7 @@ def check_bandit_feedback_inputs(
             raise ValueError(
                 "context, action, reward, and position must be the same size."
             )
-        if not (position.dtype == int and position.min() >= 0):
+        if not (np.issubdtype(position.dtype, np.integer) and position.min() >= 0):
             raise ValueError("position elements must be non-negative integers")
     else:
         if not (context.shape[0] == action.shape[0] == reward.shape[0]):
@@ -287,7 +287,7 @@ def check_ope_inputs(
             raise ValueError(
                 "the first dimension of position and the first dimension of action_dist must be the same"
             )
-        if not (position.dtype == int and position.min() >= 0):
+        if not (np.issubdtype(position.dtype, np.integer) and position.min() >= 0):
             raise ValueError("position elements must be non-negative integers")
         if position.max() >= action_dist.shape[2]:
             raise ValueError(
@@ -319,7 +319,7 @@ def check_ope_inputs(
             raise ValueError("reward must be 1-dimensional")
         if not (action.shape[0] == reward.shape[0]):
             raise ValueError("action and reward must be the same size.")
-        if not (action.dtype == int and action.min() >= 0):
+        if not (np.issubdtype(action.dtype, np.integer) and action.min() >= 0):
             raise ValueError("action elements must be non-negative integers")
         if action.max() >= action_dist.shape[1]:
             raise ValueError(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ print(__version__)
 with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-package_data_list = ["obp/policy/conf/prior_bts.yaml", "obp/dataset/obd/"]
+package_data_list = ["obp/policy/conf/prior_bts.yaml", "obp/dataset/obd"]
 
 setup(
     name="obp",


### PR DESCRIPTION
Related to #87 

To check if the dtype is integer, `np.issubdtype(x.dtype, np.integer)` should be used instead of `np.issubdtype(int, x.dtype)` and `x.dtype == int`.
Otherwise, the type check result depends on OS.

In addition, 
`python setup.py install` does not work in Windows due to the following:
```
package_data_list = ["obp/policy/conf/prior_bts.yaml", "obp/dataset/obd/"]
```
This should be
```
package_data_list = ["obp/policy/conf/prior_bts.yaml", "obp/dataset/obd"]
```