### PR TITLE
Enable to use different estimated_rewards_by_reg_model values for different OPE estimators

### DIFF
--- a/obp/ope/meta.py
+++ b/obp/ope/meta.py
@@ -107,7 +107,7 @@ class OffPolicyEvaluation:
             )
         elif isinstance(estimated_rewards_by_reg_model, dict):
             for estimator_name, value in estimated_rewards_by_reg_model.items():
-                if value is None:
+                if not isinstance(value, np.ndarray):
                     raise ValueError(
                         f"estimated_rewards_by_reg_model[{estimator_name}] must be ndarray"
                     )

--- a/tests/ope/test_meta.py
+++ b/tests/ope/test_meta.py
@@ -320,14 +320,13 @@ invalid_input_of_create_estimator_inputs = [
     (
         np.zeros((2, 3, 4)),
         {"dm": np.zeros((2, 3, 3))},
-        "estimated_rewards_by_reg_model\[dm\].shape must be the same as action_dist.shape",
+        r"estimated_rewards_by_reg_model\[dm\].shape must be the same as action_dist.shape",
     ),
     (
         np.zeros((2, 3, 4)),
         {"dm": None},
-        "estimated_rewards_by_reg_model\[dm\] must be ndarray",
+        r"estimated_rewards_by_reg_model\[dm\] must be ndarray",
     ),
-    (np.zeros((2, 3)), None, "action_dist.ndim must be 3-dimensional"),
     (np.zeros((2, 3)), None, "action_dist.ndim must be 3-dimensional"),
     ("3", None, "action_dist must be ndarray"),
     (None, None, "action_dist must be ndarray"),

--- a/tests/ope/test_meta.py
+++ b/tests/ope/test_meta.py
@@ -317,6 +317,17 @@ invalid_input_of_create_estimator_inputs = [
         np.zeros((2, 3, 3)),
         "estimated_rewards_by_reg_model.shape must be the same as action_dist.shape",
     ),
+    (
+        np.zeros((2, 3, 4)),
+        {"dm": np.zeros((2, 3, 3))},
+        "estimated_rewards_by_reg_model\[dm\].shape must be the same as action_dist.shape",
+    ),
+    (
+        np.zeros((2, 3, 4)),
+        {"dm": None},
+        "estimated_rewards_by_reg_model\[dm\] must be ndarray",
+    ),
+    (np.zeros((2, 3)), None, "action_dist.ndim must be 3-dimensional"),
     (np.zeros((2, 3)), None, "action_dist.ndim must be 3-dimensional"),
     ("3", None, "action_dist must be ndarray"),
     (None, None, "action_dist must be ndarray"),
@@ -326,6 +337,11 @@ valid_input_of_create_estimator_inputs = [
     (
         np.zeros((2, 3, 4)),
         np.zeros((2, 3, 4)),
+        "same shape",
+    ),
+    (
+        np.zeros((2, 3, 4)),
+        {"dm": np.zeros((2, 3, 4))},
         "same shape",
     ),
     (np.zeros((2, 3, 1)), None, "estimated_rewards_by_reg_model is None"),
@@ -404,7 +420,8 @@ def test_meta_create_estimator_inputs_using_valid_input_data(
         action_dist=action_dist,
         estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
     )
-    assert set(estimator_inputs.keys()) == set(
+    assert set(estimator_inputs.keys()) == set(["ipw"])
+    assert set(estimator_inputs["ipw"].keys()) == set(
         [
             "reward",
             "action",


### PR DESCRIPTION
Enable to use different `estimated_rewards_by_reg_model` values for different OPE estimators when the type of `estimated_rewards_by_reg_model` is `Dict[str, np.ndarray]` in `OffPolicyEvaluation`.