### PR TITLE
Review: SyntheticSlateBanditDataset

### DIFF
--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -368,9 +368,9 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                 # calculate marginal pscore
                 if return_pscore_item_position:
                     if return_exact_uniform_pscore_item_position:
-                        pscore_item_position[i * self.len_list + position_] = (
-                            self.len_list / self.n_unique_action
-                        )
+                        pscore_item_position_i_l = self.len_list / self.n_unique_action
+                    elif position_ == 0:
+                        pscore_item_position_i_l = pscore_i
                     else:
                         pscore_item_position_i_l = 0.0
                         for action_list in permutations(
@@ -384,9 +384,9 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                                     i : i + 1
                                 ],
                             )
-                        pscore_item_position[
-                            i * self.len_list + position_
-                        ] = pscore_item_position_i_l
+                    pscore_item_position[
+                        i * self.len_list + position_
+                    ] = pscore_item_position_i_l
             # impute joint pscore
             start_idx = i * self.len_list
             end_idx = start_idx + self.len_list

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -352,9 +352,9 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                 if return_exact_uniform_pscore_item_position:
                     score_ = 1 / self.n_unique_action
                 else:
-                    score_ = softmax(behavior_policy_logit_[i : i + 1, unique_action_set])[
-                        0
-                    ]
+                    score_ = softmax(
+                        behavior_policy_logit_[i : i + 1, unique_action_set]
+                    )[0]
                 sampled_action = self.random_.choice(
                     unique_action_set, p=score_, replace=False
                 )

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -349,12 +349,9 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
             unique_action_set = np.arange(self.n_unique_action)
             pscore_i = 1.0
             for position_ in np.arange(self.len_list):
-                if return_exact_uniform_pscore_item_position and position_ == 0:
-                    score_ = 1 / self.n_unique_action
-                else:
-                    score_ = softmax(
-                        behavior_policy_logit_[i : i + 1, unique_action_set]
-                    )[0]
+                score_ = softmax(behavior_policy_logit_[i : i + 1, unique_action_set])[
+                    0
+                ]
                 sampled_action = self.random_.choice(
                     unique_action_set, p=score_, replace=False
                 )

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -376,7 +376,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                         for action_list in permutations(
                             np.arange(self.n_unique_action), self.len_list
                         ):
-                            if sampled_action_index not in action_list:
+                            if sampled_action_index != action_list[position_]:
                                 continue
                             pscore_item_position_i_l += self.calc_item_position_pscore(
                                 action_list=action_list,

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -777,7 +777,7 @@ def action_interaction_exponential_reward_function(
         "continuous",
     ]:
         raise ValueError(
-            f"reward_type must be either 'binary' or 'continuous', but {reward_type} is given.'"
+            f"reward_type must be either 'binary' or 'continuous', but {reward_type} is given."
         )
     if action_interaction_matrix.shape[0] * context.shape[0] != action.shape[0]:
         raise ValueError(

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -349,9 +349,12 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
             unique_action_set = np.arange(self.n_unique_action)
             pscore_i = 1.0
             for position_ in np.arange(self.len_list):
-                score_ = softmax(behavior_policy_logit_[i : i + 1, unique_action_set])[
-                    0
-                ]
+                if return_exact_uniform_pscore_item_position:
+                    score_ = 1 / self.n_unique_action
+                else:
+                    score_ = softmax(behavior_policy_logit_[i : i + 1, unique_action_set])[
+                        0
+                    ]
                 sampled_action = self.random_.choice(
                     unique_action_set, p=score_, replace=False
                 )
@@ -368,7 +371,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                 # calculate marginal pscore
                 if return_pscore_item_position:
                     if return_exact_uniform_pscore_item_position:
-                        pscore_item_position_i_l = self.len_list / self.n_unique_action
+                        pscore_item_position_i_l = 1 / self.n_unique_action
                     elif position_ == 0:
                         pscore_item_position_i_l = pscore_i
                     else:

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -376,7 +376,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                         for action_list in permutations(
                             np.arange(self.n_unique_action), self.len_list
                         ):
-                            if sampled_action_index != action_list[position_]:
+                            if sampled_action != action_list[position_]:
                                 continue
                             pscore_item_position_i_l += self.calc_item_position_pscore(
                                 action_list=action_list,

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -349,7 +349,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
             unique_action_set = np.arange(self.n_unique_action)
             pscore_i = 1.0
             for position_ in np.arange(self.len_list):
-                if return_exact_uniform_pscore_item_position:
+                if return_exact_uniform_pscore_item_position and position_ == 0:
                     score_ = 1 / self.n_unique_action
                 else:
                     score_ = softmax(

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -229,13 +229,13 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
             # generate exponential action interaction matrix of (len_list, len_list)
             if self.reward_structure == "standard_exponential":
                 self.action_interaction_weight_matrix = (
-                    self.obtain_standard_exponential_action_interaction_matrix(
+                    self.obtain_standard_exponential_action_interaction_weight_matrix(
                         self.len_list
                     )
                 )
             elif self.reward_structure == "cascade_exponential":
                 self.action_interaction_weight_matrix = (
-                    self.obtain_cascade_exponential_action_interaction_matrix(
+                    self.obtain_cascade_exponential_action_interaction_weight_matrix(
                         self.len_list
                     )
                 )
@@ -266,7 +266,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
     @staticmethod
     def obtain_cascade_exponential_action_interaction_weight_matrix(len_list) -> np.ndarray:
         """Obtain action interaction matrix for cascade exponential reward structure (upper triangular matrix)"""
-        action_interaction_matrix = np.identity(len_list)
+        action_interaction_weight_matrix = np.identity(len_list)
         for position_ in np.arange(len_list):
             action_interaction_weight_matrix[:, position_] = -1 / np.exp(
                 np.abs(np.arange(len_list) - position_)
@@ -659,7 +659,7 @@ def action_interaction_additive_reward_function(
         action_context.shape[0],
     ):
         raise ValueError(
-            f"the shape of action_interaction_weight_matrix must be (action_context.shape[0], action_context.shape[0]), but {action_interaction_matrix.shape}"
+            f"the shape of action_interaction_weight_matrix must be (action_context.shape[0], action_context.shape[0]), but {action_interaction_weight_matrix.shape}"
         )
 
     if reward_type not in [
@@ -769,7 +769,7 @@ def action_interaction_exponential_reward_function(
             "the size of axis 0 of action_interaction_weight_matrix multiplied by that of context must be the same as that of action"
         )
     # action_2d: array-like, shape (n_rounds, len_list)
-    action_2d = action.reshape((context.shape[0], action_interaction_matrix.shape[0]))
+    action_2d = action.reshape((context.shape[0], action_interaction_weight_matrix.shape[0]))
     # action_3d: array-like, shape (n_rounds, n_unique_action, len_list)
     action_3d = np.identity(action_context.shape[0])[action_2d].transpose(0, 2, 1)
     # expected_reward: array-like, shape (n_rounds, n_unique_action)
@@ -783,7 +783,7 @@ def action_interaction_exponential_reward_function(
         expected_reward, (action_interaction_weight_matrix.shape[0], 1, 1)
     ).transpose(1, 2, 0)
     # action_interaction_weight: array-like, shape (n_rounds, n_unique_action, len_list)
-    action_interaction_weight = action_3d @ action_interaction_matrix
+    action_interaction_weight = action_3d @ action_interaction_weight_matrix
     # weighted_expected_reward: array-like, shape (n_rounds, n_unique_action, len_list)
     weighted_expected_reward = action_interaction_weight * expected_reward_3d
     # expected_reward_factual: list, shape (n_rounds, len_list)

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -56,8 +56,8 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
             'independent': :math:`q_k(x, a) = f(x, a(k))`
             'standard_additive': :math:`q_k(x, a) = g(g^{-1}(f(x, a(k))) + \\sum_{j \\neq k} W(a(k), a(j)))`.
             'standard_exponential': :math:`q_k(x, a) = g(g^{-1}(f(x, a(k))) - \\sum_{j \\neq k} g^{-1}(f(x, a(j))) / \\exp(|k-j|))`.
-        When reward_type is 'continous', transform function is the identity function.
-        When reward_type is 'binray', transform function is the logit function.
+        When reward_type is 'continuos', transform function is the identity function.
+        When reward_type is 'binary', transform function is the logit function.
 
     click_model: str, default=None
         Type of click model, which must be one of None, 'pbm', or 'cascade'.

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -56,7 +56,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
             'independent': :math:`q_k(x, a) = f(x, a(k))`
             'standard_additive': :math:`q_k(x, a) = g(g^{-1}(f(x, a(k))) + \\sum_{j \\neq k} W(a(k), a(j)))`.
             'standard_exponential': :math:`q_k(x, a) = g(g^{-1}(f(x, a(k))) - \\sum_{j \\neq k} g^{-1}(f(x, a(j))) / \\exp(|k-j|))`.
-        When reward_type is 'continuos', transform function is the identity function.
+        When reward_type is 'continuous', transform function is the identity function.
         When reward_type is 'binary', transform function is the logit function.
 
     click_model: str, default=None
@@ -190,7 +190,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
             "continuous",
         ]:
             raise ValueError(
-                f"reward_type must be either 'binary' or 'continuous', but {self.reward_type} is given.'"
+                f"reward_type must be either 'binary' or 'continuous', but {self.reward_type} is given."
             )
         if self.reward_structure not in [
             "cascade_additive",
@@ -467,11 +467,11 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
 
         return_pscore_item_position: bool, default=True
             A boolean parameter whether `pscore_item_position` is returned or not.
-            When `n_unique_action` and `len_list` are large, this parameter should be set to False because of the computational time
+            When `n_unique_action` and `len_list` are large, this parameter should be set to False because of the computational time.
 
         return_exact_uniform_pscore_item_position: bool, default=False
             A boolean parameter whether `pscore_item_position` of uniform random policy is returned or not.
-            When using uniform random policy, this parameter should be set to True
+            When using uniform random policy, this parameter should be set to True.
 
 
         Returns
@@ -622,7 +622,7 @@ def action_interaction_additive_reward_function(
 
     action: array-like, shape (n_unique_action * len_list)
         Sampled action.
-        Action list of slate `i` is stored in action[`i` * `len_list`: (`i + 1`) * `len_list`]
+        Action list of slate `i` is stored in action[`i` * `len_list`: (`i + 1`) * `len_list`].
 
     base_reward_function: Callable[[np.ndarray, np.ndarray], np.ndarray]], default=None
         Function generating expected reward for each given action-context pair,
@@ -642,7 +642,7 @@ def action_interaction_additive_reward_function(
         When Open Bandit Dataset is used, 3 should be set.
 
     is_cascade: bool
-        Whether reward structure is cascade-type or not
+        Whether reward structure is cascade-type or not.
 
     random_state: int, default=None
         Controls the random seed in sampling dataset.
@@ -650,9 +650,9 @@ def action_interaction_additive_reward_function(
     Returns
     ---------
     expected_reward_factual: array-like, shape (n_rounds, len_list)
-        Expected rewards given factual actions
-        When is_cascade is true, :math:`q_k(x, a) = g(g^{-1}(f(x, a(k))) + \\sum_{j < k} W(a(k), a(j)))`.
-        When is_cascade is false, :math:`q_k(x, a) = g(g^{-1}(f(x, a(k))) + \\sum_{j \\neq k} W(a(k), a(j)))`.
+        Expected rewards given factual actions.
+        When is_cascade is True, :math:`q_k(x, a) = g(g^{-1}(f(x, a(k))) + \\sum_{j < k} W(a(k), a(j)))`.
+        When is_cascade is False, :math:`q_k(x, a) = g(g^{-1}(f(x, a(k))) + \\sum_{j \\neq k} W(a(k), a(j)))`.
 
     """
     if not isinstance(context, np.ndarray) or context.ndim != 2:
@@ -682,7 +682,7 @@ def action_interaction_additive_reward_function(
         "continuous",
     ]:
         raise ValueError(
-            f"reward_type must be either 'binary' or 'continuous', but {reward_type} is given.'"
+            f"reward_type must be either 'binary' or 'continuous', but {reward_type} is given."
         )
 
     # action_2d: array-like, shape (n_rounds, len_list)
@@ -739,7 +739,7 @@ def action_interaction_exponential_reward_function(
 
     action: array-like, shape (n_unique_action * len_list)
         Sampled action.
-        Action list of slate `i` is stored in action[`i` * `len_list`: (`i + 1`) * `len_list`]
+        Action list of slate `i` is stored in action[`i` * `len_list`: (`i + 1`) * `len_list`].
 
     base_reward_function: Callable[[np.ndarray, np.ndarray], np.ndarray]], default=None
         Function generating expected reward for each given action-context pair,
@@ -760,7 +760,7 @@ def action_interaction_exponential_reward_function(
     Returns
     ---------
     expected_reward_factual: array-like, shape (n_rounds, len_list)
-        Expected rewards given factual actions (:math:`q_k(x, a) = g(g^{-1}(f(x, a(k))) + \\sum_{j \\neq k} g^{-1}(f(x, a(j))) * W(k, j)`)
+        Expected rewards given factual actions (:math:`q_k(x, a) = g(g^{-1}(f(x, a(k))) + \\sum_{j \\neq k} g^{-1}(f(x, a(j))) * W(k, j)`).
 
     """
     if not isinstance(context, np.ndarray) or context.ndim != 2:
@@ -781,7 +781,7 @@ def action_interaction_exponential_reward_function(
         )
     if action_interaction_matrix.shape[0] * context.shape[0] != action.shape[0]:
         raise ValueError(
-            "the size of axis 0 of action_interaction_matrix muptiplied by that of context must be the same as that of action"
+            "the size of axis 0 of action_interaction_matrix multiplied by that of context must be the same as that of action"
         )
     # action_2d: array-like, shape (n_rounds, len_list)
     action_2d = action.reshape((context.shape[0], action_interaction_matrix.shape[0]))

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -217,7 +217,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                 "continuous reward type is unavailable when click model is given"
             )
         if self.reward_structure in ["cascade_additive", "standard_additive"]:
-            # generate additive action interaction matrix of (n_unique_action, n_unique_action)
+            # generate additive action interaction weight matrix of (n_unique_action, n_unique_action)
             self.action_interaction_weight_matrix = generate_symmetric_matrix(
                 n_unique_action=self.n_unique_action, random_state=self.random_state
             )
@@ -226,7 +226,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         else:
             if self.base_reward_function is not None:
                 self.reward_function = action_interaction_exponential_reward_function
-            # generate exponential action interaction matrix of (len_list, len_list)
+            # generate exponential action interaction weight matrix of (len_list, len_list)
             if self.reward_structure == "standard_exponential":
                 self.action_interaction_weight_matrix = (
                     self.obtain_standard_exponential_action_interaction_weight_matrix(
@@ -256,7 +256,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
     def obtain_standard_exponential_action_interaction_weight_matrix(
         len_list,
     ) -> np.ndarray:
-        """Obtain action interaction matrix for standard exponential reward structure (symmetric matrix)"""
+        """Obtain action interaction weight matrix for standard exponential reward structure (symmetric matrix)"""
         action_interaction_weight_matrix = np.identity(len_list)
         for position_ in np.arange(len_list):
             action_interaction_weight_matrix[:, position_] = -1 / np.exp(
@@ -269,7 +269,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
     def obtain_cascade_exponential_action_interaction_weight_matrix(
         len_list,
     ) -> np.ndarray:
-        """Obtain action interaction matrix for cascade exponential reward structure (upper triangular matrix)"""
+        """Obtain action interaction weight matrix for cascade exponential reward structure (upper triangular matrix)"""
         action_interaction_weight_matrix = np.identity(len_list)
         for position_ in np.arange(len_list):
             action_interaction_weight_matrix[:, position_] = -1 / np.exp(

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -253,7 +253,9 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         self.action_context = np.eye(self.n_unique_action, dtype=int)
 
     @staticmethod
-    def obtain_standard_exponential_action_interaction_weight_matrix(len_list) -> np.ndarray:
+    def obtain_standard_exponential_action_interaction_weight_matrix(
+        len_list,
+    ) -> np.ndarray:
         """Obtain action interaction matrix for standard exponential reward structure (symmetric matrix)"""
         action_interaction_weight_matrix = np.identity(len_list)
         for position_ in np.arange(len_list):
@@ -264,7 +266,9 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         return action_interaction_weight_matrix
 
     @staticmethod
-    def obtain_cascade_exponential_action_interaction_weight_matrix(len_list) -> np.ndarray:
+    def obtain_cascade_exponential_action_interaction_weight_matrix(
+        len_list,
+    ) -> np.ndarray:
         """Obtain action interaction matrix for cascade exponential reward structure (upper triangular matrix)"""
         action_interaction_weight_matrix = np.identity(len_list)
         for position_ in np.arange(len_list):
@@ -769,7 +773,9 @@ def action_interaction_exponential_reward_function(
             "the size of axis 0 of action_interaction_weight_matrix multiplied by that of context must be the same as that of action"
         )
     # action_2d: array-like, shape (n_rounds, len_list)
-    action_2d = action.reshape((context.shape[0], action_interaction_weight_matrix.shape[0]))
+    action_2d = action.reshape(
+        (context.shape[0], action_interaction_weight_matrix.shape[0])
+    )
     # action_3d: array-like, shape (n_rounds, n_unique_action, len_list)
     action_3d = np.identity(action_context.shape[0])[action_2d].transpose(0, 2, 1)
     # expected_reward: array-like, shape (n_rounds, n_unique_action)

--- a/tests/dataset/test_synthetic_slate.py
+++ b/tests/dataset/test_synthetic_slate.py
@@ -226,9 +226,9 @@ def test_synthetic_slate_obtain_batch_bandit_feedback_using_uniform_random_behav
     for column in ["slate_id", "position", "action"] + pscore_columns:
         bandit_feedback_df[column] = bandit_feedback[column]
     # check pscore marginal
-    pscore_item_position = float(1 / n_unique_action)
+    pscore_item_position = 1 / n_unique_action
     assert np.allclose(
-        bandit_feedback_df["pscore_item_position"].unique(), [pscore_item_position]
+        bandit_feedback_df["pscore_item_position"].unique(), pscore_item_position
     ), f"pscore_item_position must be [{pscore_item_position}], but {bandit_feedback_df['pscore_item_position'].unique()}"
     # check pscore joint
     pscore_cascade = []
@@ -266,9 +266,9 @@ def test_synthetic_slate_obtain_batch_bandit_feedback_using_uniform_random_behav
     # check slate bandit feedback (common test)
     check_slate_bandit_feedback(bandit_feedback=bandit_feedback)
     # check pscore marginal
-    pscore_item_position = float(1 / n_unique_action)
+    pscore_item_position = 1 / n_unique_action
     assert np.allclose(
-        np.unique(bandit_feedback["pscore_item_position"]), [pscore_item_position]
+        np.unique(bandit_feedback["pscore_item_position"]), pscore_item_position
     ), f"pscore_item_position must be [{pscore_item_position}], but {np.unique(bandit_feedback['pscore_item_position'])}"
 
 

--- a/tests/dataset/test_synthetic_slate.py
+++ b/tests/dataset/test_synthetic_slate.py
@@ -160,17 +160,17 @@ def check_slate_bandit_feedback(bandit_feedback: BanditFeedback):
     if "pscore_cascade" in pscore_columns and "pscore" in pscore_columns:
         assert (
             bandit_feedback_df["pscore_cascade"] < bandit_feedback_df["pscore"]
-        ).sum() == 0, "pscore_cascade must be larger than or equal to pscore"
+        ).sum() == 0, "pscore must be smaller than or equal to pscore_cascade"
     if "pscore_item_position" in pscore_columns and "pscore" in pscore_columns:
         assert (
             bandit_feedback_df["pscore_item_position"] < bandit_feedback_df["pscore"]
-        ).sum() == 0, "pscore must be larger than or equal to pscore_item_position"
+        ).sum() == 0, "pscore must be smaller than or equal to pscore_item_position"
     if "pscore_item_position" in pscore_columns and "pscore_cascade" in pscore_columns:
         assert (
             bandit_feedback_df["pscore_item_position"]
             < bandit_feedback_df["pscore_cascade"]
         ).sum() == 0, (
-            "pscore_cascade must be larger than or equal to pscore_item_position"
+            "pscore_cascade must be smaller than or equal to pscore_item_position"
         )
     if "pscore_cascade" in pscore_columns:
         previous_minimum_pscore_cascade = (
@@ -226,7 +226,7 @@ def test_synthetic_slate_obtain_batch_bandit_feedback_using_uniform_random_behav
     for column in ["slate_id", "position", "action"] + pscore_columns:
         bandit_feedback_df[column] = bandit_feedback[column]
     # check pscore marginal
-    pscore_item_position = float(len_list / n_unique_action)
+    pscore_item_position = float(1 / n_unique_action)
     assert np.allclose(
         bandit_feedback_df["pscore_item_position"].unique(), [pscore_item_position]
     ), f"pscore_item_position must be [{pscore_item_position}], but {bandit_feedback_df['pscore_item_position'].unique()}"
@@ -266,7 +266,7 @@ def test_synthetic_slate_obtain_batch_bandit_feedback_using_uniform_random_behav
     # check slate bandit feedback (common test)
     check_slate_bandit_feedback(bandit_feedback=bandit_feedback)
     # check pscore marginal
-    pscore_item_position = float(len_list / n_unique_action)
+    pscore_item_position = float(1 / n_unique_action)
     assert np.allclose(
         np.unique(bandit_feedback["pscore_item_position"]), [pscore_item_position]
     ), f"pscore_item_position must be [{pscore_item_position}], but {np.unique(bandit_feedback['pscore_item_position'])}"

--- a/tests/dataset/test_synthetic_slate.py
+++ b/tests/dataset/test_synthetic_slate.py
@@ -260,9 +260,7 @@ def test_synthetic_slate_obtain_batch_bandit_feedback_using_uniform_random_behav
         random_state=random_state,
     )
     # obtain feedback
-    bandit_feedback = dataset.obtain_batch_bandit_feedback(
-        n_rounds=n_rounds, return_exact_uniform_pscore_item_position=True
-    )
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
     # check slate bandit feedback (common test)
     check_slate_bandit_feedback(bandit_feedback=bandit_feedback)
     # check pscore marginal
@@ -292,10 +290,6 @@ def test_synthetic_slate_obtain_batch_bandit_feedback_using_linear_behavior_poli
         _ = dataset.obtain_batch_bandit_feedback(n_rounds=-1)
     with pytest.raises(ValueError):
         _ = dataset.obtain_batch_bandit_feedback(n_rounds="a")
-    with pytest.raises(ValueError):
-        _ = dataset.obtain_batch_bandit_feedback(
-            n_rounds=n_rounds, return_exact_uniform_pscore_item_position=True
-        )
 
     # obtain feedback
     bandit_feedback = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)

--- a/tests/dataset/test_synthetic_slate_functions.py
+++ b/tests/dataset/test_synthetic_slate_functions.py
@@ -315,7 +315,7 @@ invalid_input_of_action_interaction_reward_function = [
         3,
         1,
         ValueError,
-        "the shape of action effect matrix must be",
+        "the shape of action_interaction_weight_matrix must be",
     ),
 ]
 

--- a/tests/dataset/test_synthetic_slate_functions.py
+++ b/tests/dataset/test_synthetic_slate_functions.py
@@ -92,7 +92,7 @@ def test_linear_behavior_policy_logit_using_valid_input(
     assert logit_value.shape == (context.shape[0], action_context.shape[0])
 
 
-# context, action_context, action, base_reward_function, action_interaction_matrix, reward_type, random_state, err, description
+# context, action_context, action, base_reward_function, action_interaction_weight_matrix, reward_type, random_state, err, description
 invalid_input_of_action_interaction_exponential_reward_function = [
     (
         np.array([5, 2]),
@@ -153,7 +153,7 @@ invalid_input_of_action_interaction_exponential_reward_function = [
 
 
 @pytest.mark.parametrize(
-    "context, action_context, action, base_reward_function, action_interaction_matrix, reward_type, random_state, err, description",
+    "context, action_context, action, base_reward_function, action_interaction_weight_matrix, reward_type, random_state, err, description",
     invalid_input_of_action_interaction_exponential_reward_function,
 )
 def test_action_interaction_exponential_reward_function_using_invalid_input(
@@ -161,7 +161,7 @@ def test_action_interaction_exponential_reward_function_using_invalid_input(
     action_context,
     action,
     base_reward_function,
-    action_interaction_matrix,
+    action_interaction_weight_matrix,
     reward_type,
     random_state,
     err,
@@ -172,14 +172,14 @@ def test_action_interaction_exponential_reward_function_using_invalid_input(
             context=context,
             action_context=action_context,
             action=action,
-            action_interaction_matrix=action_interaction_matrix,
+            action_interaction_weight_matrix=action_interaction_weight_matrix,
             base_reward_function=base_reward_function,
             reward_type=reward_type,
             random_state=random_state,
         )
 
 
-# context, action_context, action, base_reward_function, action_interaction_matrix, reward_type, random_state, description
+# context, action_context, action, base_reward_function, action_interaction_weight_matrix, reward_type, random_state, description
 valid_input_of_action_interaction_exponential_reward_function = [
     (
         np.ones([5, 2]),
@@ -205,7 +205,7 @@ valid_input_of_action_interaction_exponential_reward_function = [
 
 
 @pytest.mark.parametrize(
-    "context, action_context, action, base_reward_function, action_interaction_matrix, reward_type, random_state, description",
+    "context, action_context, action, base_reward_function, action_interaction_weight_matrix, reward_type, random_state, description",
     valid_input_of_action_interaction_exponential_reward_function,
 )
 def test_action_interaction_exponential_reward_function_using_valid_input(
@@ -213,7 +213,7 @@ def test_action_interaction_exponential_reward_function_using_valid_input(
     action_context,
     action,
     base_reward_function,
-    action_interaction_matrix,
+    action_interaction_weight_matrix,
     reward_type,
     random_state,
     description,
@@ -222,14 +222,14 @@ def test_action_interaction_exponential_reward_function_using_valid_input(
         context=context,
         action_context=action_context,
         action=action,
-        action_interaction_matrix=action_interaction_matrix,
+        action_interaction_weight_matrix=action_interaction_weight_matrix,
         base_reward_function=base_reward_function,
         reward_type=reward_type,
         random_state=random_state,
     )
     assert expected_reward_factual.shape == (
         context.shape[0],
-        action_interaction_matrix.shape[0],
+        action_interaction_weight_matrix.shape[0],
     )
     if reward_type == "binary":
         assert np.all(0 <= expected_reward_factual) and np.all(
@@ -237,7 +237,7 @@ def test_action_interaction_exponential_reward_function_using_valid_input(
         )
 
 
-# context, action_context, action, base_reward_function, action_interaction_matrix, reward_type, is_cascade, len_list, random_state, err, description
+# context, action_context, action, base_reward_function, action_interaction_weight_matrix, reward_type, is_cascade, len_list, random_state, err, description
 invalid_input_of_action_interaction_reward_function = [
     (
         np.array([5, 2]),
@@ -321,7 +321,7 @@ invalid_input_of_action_interaction_reward_function = [
 
 
 @pytest.mark.parametrize(
-    "context, action_context, action, base_reward_function, action_interaction_matrix, reward_type, is_cascade, len_list, random_state, err, description",
+    "context, action_context, action, base_reward_function, action_interaction_weight_matrix, reward_type, is_cascade, len_list, random_state, err, description",
     invalid_input_of_action_interaction_reward_function,
 )
 def test_action_interaction_reward_function_using_invalid_input(
@@ -329,7 +329,7 @@ def test_action_interaction_reward_function_using_invalid_input(
     action_context,
     action,
     base_reward_function,
-    action_interaction_matrix,
+    action_interaction_weight_matrix,
     reward_type,
     is_cascade,
     len_list,
@@ -342,7 +342,7 @@ def test_action_interaction_reward_function_using_invalid_input(
             context=context,
             action_context=action_context,
             action=action,
-            action_interaction_matrix=action_interaction_matrix,
+            action_interaction_weight_matrix=action_interaction_weight_matrix,
             base_reward_function=base_reward_function,
             reward_type=reward_type,
             random_state=random_state,
@@ -351,7 +351,7 @@ def test_action_interaction_reward_function_using_invalid_input(
         )
 
 
-# context, action_context, action, base_reward_function, action_interaction_matrix, reward_type, is_cascade, len_list, random_state, err, description
+# context, action_context, action, base_reward_function, action_interaction_weight_matrix, reward_type, is_cascade, len_list, random_state, err, description
 valid_input_of_action_interaction_reward_function = [
     (
         np.ones([5, 2]),
@@ -405,7 +405,7 @@ valid_input_of_action_interaction_reward_function = [
 
 
 @pytest.mark.parametrize(
-    "context, action_context, action, base_reward_function, action_interaction_matrix, reward_type, is_cascade, len_list, random_state, description",
+    "context, action_context, action, base_reward_function, action_interaction_weight_matrix, reward_type, is_cascade, len_list, random_state, description",
     valid_input_of_action_interaction_reward_function,
 )
 def test_action_interaction_reward_function_using_valid_input(
@@ -413,7 +413,7 @@ def test_action_interaction_reward_function_using_valid_input(
     action_context,
     action,
     base_reward_function,
-    action_interaction_matrix,
+    action_interaction_weight_matrix,
     reward_type,
     is_cascade,
     len_list,
@@ -424,7 +424,7 @@ def test_action_interaction_reward_function_using_valid_input(
         context=context,
         action_context=action_context,
         action=action,
-        action_interaction_matrix=action_interaction_matrix,
+        action_interaction_weight_matrix=action_interaction_weight_matrix,
         base_reward_function=base_reward_function,
         reward_type=reward_type,
         random_state=random_state,


### PR DESCRIPTION
## important
1. It may be better to check the calculation of `pscore_item_position_i_l`:
 ```Python
# from
if sampled_action_index not in action_list:
# to
if sampled_action != action_list[position_]:
```
as pscore is calculated as :math: `\\pi_k(a_k \\mid x) = \\sum_{a} \\pi(a \\mid x) \\mathbbm{1}{a(k)=a_k}`.
https://github.com/aiueola/zr-obp/blob/57cae57736f00a8f4887c4d3ac41a6544b880b34/obp/dataset/synthetic_slate.py#L376

2. Also, I revised `pscore_item_position_i_l` when using uniform random policy (`self.behavior_policy_function is None`):
```Python
# from
pscore_item_position_i_l = self.len_list / self.n_unique_action
#to
pscore_item_position_i_l = 1 / self.n_unique_action
```
https://github.com/aiueola/zr-obp/blob/57cae57736f00a8f4887c4d3ac41a6544b880b34/obp/dataset/synthetic_slate.py#L368

## refactor
1. Removed `return_exact_uniform_pscore_item_position` parameter from `obtain_batch_bandit_feedback()` and `sample_action_and_obtain_pscore()`. 
```
# from
if return_exact_uniform_pscore_item_position: 
# to
if self.behavior_policy_function is None:  # uniform random
```
It might be more intuitive that we use ground-truth pscore (not approximated one) as default for uniform random policy.
https://github.com/aiueola/zr-obp/blob/57cae57736f00a8f4887c4d3ac41a6544b880b34/obp/dataset/synthetic_slate.py#L447

2. Renamed from `self.behavior_policy` to `self.uniform_behavior_policy` as it always indicates uniform behavior policy.
```Python
# from
self.behavior_policy = np.ones(self.n_unique_action) / self.n_unique_action
# to
self.uniform_behavior_policy = np.ones(self.n_unique_action) / self.n_unique_action
```
https://github.com/aiueola/zr-obp/blob/57cae57736f00a8f4887c4d3ac41a6544b880b34/obp/dataset/synthetic_slate.py#L245

3. Renamed from `action_interaction_matrix` to `action_interaction_weight_matrix`.

https://github.com/aiueola/zr-obp/blob/35f893fd660f627b0bb470d24eaf970aeb541109/obp/dataset/synthetic_slate.py#L49

## tests
Fix `pscore_item_position` target of uniform random policy:
```Python
# from 
pscore_item_position = len_list / n_unique_action
#to
pscore_item_position = 1 / n_unique_action
```
https://github.com/aiueola/zr-obp/blob/d46cd4c9a626020a14c73014a21b8749b9dd88ad/tests/dataset/test_synthetic_slate.py#L229

## others
Minor fix on typos and docstrings.