### PR TITLE
new feature: obtain_pscore_given_evaluation_policy_logit in SyntheticSlateBanditDataset

### DIFF
--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -378,15 +378,15 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                 "the shape of action and evaluation_policy_logit_ must be (n_rounds * len_list, ) and (n_rounds, n_unique_action, respectively"
             )
         n_rounds = action.reshape((-1, self.len_list)).shape[0]
-        pscore_cascade = np.zeros_like(action)
-        pscore = np.zeros_like(action)
+        pscore_cascade = np.zeros(n_rounds * self.len_list)
+        pscore = np.zeros(n_rounds * self.len_list)
         if return_pscore_item_position:
-            pscore_item_position = np.zeros_like(action)
+            pscore_item_position = np.zeros(n_rounds * self.len_list)
         else:
             pscore_item_position = None
         for i in tqdm(
             np.arange(n_rounds),
-            desc="[obtain_pscore_by_evaluation_policy]",
+            desc="[obtain_pscore_given_evaluation_policy_logit]",
             total=n_rounds,
         ):
             unique_action_set = np.arange(self.n_unique_action)
@@ -782,7 +782,11 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         n_rounds = len(evaluation_policy_logit)
         policy_value = 0
 
-        for i in range(n_rounds):
+        for i in tqdm(
+            np.arange(n_rounds),
+            desc="[calc_ground_truth_policy_value]",
+            total=n_rounds,
+        ):
             # calculate pscore for each combinatorial set of items (i.e., slate actions)
             pscores = []
             for action_list in enumerated_slate_actions:

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -83,7 +83,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         For example, when eta=0.5, the position-dependent attractiveness parameter at position `k` is :math:`\\alpha (k) = (1/k)^{0.5}`.
         When eta is very large, the click model induced by eta is close to the original cascade model.
 
-    base_reward_function: Callable[[np.ndarray, np.ndarray], np.ndarray]], default=None
+    base_reward_function: Callable[[np.ndarray, np.ndarray], np.ndarray], default=None
         Function generating expected reward for each given action-context pair,
         i.e., :math:`\\mu: \\mathcal{X} \\times \\mathcal{A} \\rightarrow \\mathbb{R}`.
         If None is set, context **independent** expected reward for each action will be

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -354,7 +354,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         action: array-like, (n_rounds * len_list, )
             Action chosen by behavior policy.
 
-        evaluation_policy_logit_: array-like, (n_rounds, n_unique_action, )
+        evaluation_policy_logit_: array-like, (n_rounds, n_unique_action)
             Evaluation policy logit values by given context (:math:`x`), i.e., :math:`\\f: \\mathcal{X} \\rightarrow \\mathbb{R}^{\\mathcal{A}}`.
 
         return_pscore_item_position: bool, default=True

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -362,6 +362,21 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
             When n_actions and len_list are large, giving True to this parameter may lead to a large computational time.
 
         """
+        if not isinstance(action, np.ndarray) or action.ndim != 1:
+            raise ValueError("action must be 1-dimensional np.ndarray")
+        if (
+            not isinstance(evaluation_policy_logit_, np.ndarray)
+            or evaluation_policy_logit_.ndim != 2
+        ):
+            raise ValueError("evaluation_policy_logit_ must be 2-dimensional array")
+        if (
+            action.reshape((-1, self.len_list)).shape[0]
+            != len(evaluation_policy_logit_)
+            or evaluation_policy_logit_.shape[1] != self.n_unique_action
+        ):
+            raise ValueError(
+                "the shape of action and evaluation_policy_logit_ must be (n_rounds * len_list, ) and (n_rounds, n_unique_action, respectively"
+            )
         n_rounds = action.reshape((-1, self.len_list)).shape[0]
         pscore_cascade = np.zeros_like(action)
         pscore = np.zeros_like(action)

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -347,6 +347,21 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         evaluation_policy_logit_: np.ndarray,
         return_pscore_item_position: bool = True,
     ):
+        """Calculate the propensity score given evaluation policy logit.
+
+        Parameters
+        ------------
+        action: array-like, (n_rounds * len_list, )
+            Action chosen by behavior policy.
+
+        evaluation_policy_logit_: array-like, (n_rounds, n_unique_action, )
+            Evaluation policy logit values by given context (:math:`x`), i.e., :math:`\\f: \\mathcal{X} \\rightarrow \\mathbb{R}^{\\mathcal{A}}`.
+
+        return_pscore_item_position: bool, default=True
+            A boolean parameter whether `pscore_item_position` is returned or not.
+            When n_actions and len_list are large, giving True to this parameter may lead to a large computational time.
+
+        """
         n_rounds = action.reshape((-1, self.len_list)).shape[0]
         pscore_cascade = np.zeros_like(action)
         pscore = np.zeros_like(action)

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -363,19 +363,18 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
 
         """
         if not isinstance(action, np.ndarray) or action.ndim != 1:
-            raise ValueError("action must be 1-dimensional np.ndarray")
+            raise ValueError("action must be 1-dimensional ndarray")
         if (
             not isinstance(evaluation_policy_logit_, np.ndarray)
             or evaluation_policy_logit_.ndim != 2
         ):
-            raise ValueError("evaluation_policy_logit_ must be 2-dimensional array")
+            raise ValueError("evaluation_policy_logit_ must be 2-dimensional ndarray")
         if (
-            action.reshape((-1, self.len_list)).shape[0]
-            != len(evaluation_policy_logit_)
+            len(action) / self.len_list != len(evaluation_policy_logit_)
             or evaluation_policy_logit_.shape[1] != self.n_unique_action
         ):
             raise ValueError(
-                "the shape of action and evaluation_policy_logit_ must be (n_rounds * len_list, ) and (n_rounds, n_unique_action, respectively"
+                "the shape of action and evaluation_policy_logit_ must be (n_rounds * len_list, ) and (n_rounds, n_unique_action) respectively"
             )
         n_rounds = action.reshape((-1, self.len_list)).shape[0]
         pscore_cascade = np.zeros(n_rounds * self.len_list)

--- a/obp/ope/meta_slate.py
+++ b/obp/ope/meta_slate.py
@@ -47,7 +47,7 @@ class SlateOffPolicyEvaluation:
             )
 
         # (1) Synthetic Data Generation
-        >>> dataset = dataset = SyntheticSlateBanditDataset(
+        >>> dataset = SyntheticSlateBanditDataset(
                 n_unique_action=10,
                 len_list=3,
                 dim_context=2,
@@ -444,7 +444,7 @@ class SlateOffPolicyEvaluation:
 
         Parameters
         ----------
-        ground_truth policy value: float
+        ground_truth_policy_value: float
             Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
             With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as its ground-truth.
 
@@ -510,7 +510,7 @@ class SlateOffPolicyEvaluation:
 
         Parameters
         ----------
-        ground_truth policy value: float
+        ground_truth_policy_value: float
             Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
             With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as ground-truth.
 

--- a/tests/dataset/test_synthetic_slate.py
+++ b/tests/dataset/test_synthetic_slate.py
@@ -13,7 +13,7 @@ from obp.dataset import (
 
 from obp.types import BanditFeedback
 
-# n_unique_action, len_list, dim_context, reward_type, reward_structure, click_model, eta, random_state, err, description
+# n_unique_action, len_list, dim_context, reward_type, reward_structure, decay_function, click_model, eta, random_state, err, description
 invalid_input_of_init = [
     (
         "4",
@@ -21,6 +21,7 @@ invalid_input_of_init = [
         2,
         "binary",
         "independent",
+        "exponential",
         "pbm",
         1.0,
         1,
@@ -33,6 +34,7 @@ invalid_input_of_init = [
         2,
         "binary",
         "independent",
+        "exponential",
         "pbm",
         1.0,
         1,
@@ -45,6 +47,7 @@ invalid_input_of_init = [
         2,
         "binary",
         "independent",
+        "exponential",
         "pbm",
         1.0,
         1,
@@ -57,6 +60,7 @@ invalid_input_of_init = [
         2,
         "binary",
         "independent",
+        "exponential",
         "pbm",
         1.0,
         1,
@@ -69,6 +73,7 @@ invalid_input_of_init = [
         2,
         "binary",
         "independent",
+        "exponential",
         "pbm",
         1.0,
         1,
@@ -81,6 +86,7 @@ invalid_input_of_init = [
         0,
         "binary",
         "independent",
+        "exponential",
         "pbm",
         1.0,
         1,
@@ -93,6 +99,7 @@ invalid_input_of_init = [
         "2",
         "binary",
         "independent",
+        "exponential",
         "pbm",
         1.0,
         1,
@@ -105,6 +112,7 @@ invalid_input_of_init = [
         2,
         "aaa",
         "independent",
+        "exponential",
         "pbm",
         1.0,
         1,
@@ -117,6 +125,7 @@ invalid_input_of_init = [
         2,
         "binary",
         "aaa",
+        "exponential",
         "pbm",
         1.0,
         1,
@@ -130,6 +139,20 @@ invalid_input_of_init = [
         "binary",
         "independent",
         "aaa",
+        "pbm",
+        1.0,
+        1,
+        ValueError,
+        "decay_function must be either",
+    ),
+    (
+        5,
+        3,
+        2,
+        "binary",
+        "independent",
+        "exponential",
+        "aaa",
         1.0,
         1,
         ValueError,
@@ -141,6 +164,7 @@ invalid_input_of_init = [
         2,
         "binary",
         "independent",
+        "exponential",
         "pbm",
         "aaa",
         1,
@@ -153,6 +177,7 @@ invalid_input_of_init = [
         2,
         "binary",
         "independent",
+        "exponential",
         "pbm",
         -1.0,
         1,
@@ -165,6 +190,7 @@ invalid_input_of_init = [
         2,
         "binary",
         "independent",
+        "exponential",
         "pbm",
         1.0,
         "x",
@@ -177,6 +203,7 @@ invalid_input_of_init = [
         2,
         "binary",
         "independent",
+        "exponential",
         "pbm",
         1.0,
         None,
@@ -187,7 +214,7 @@ invalid_input_of_init = [
 
 
 @pytest.mark.parametrize(
-    "n_unique_action, len_list, dim_context, reward_type, reward_structure, click_model, eta, random_state, err, description",
+    "n_unique_action, len_list, dim_context, reward_type, reward_structure, decay_function, click_model, eta, random_state, err, description",
     invalid_input_of_init,
 )
 def test_synthetic_slate_init_using_invalid_inputs(
@@ -196,6 +223,7 @@ def test_synthetic_slate_init_using_invalid_inputs(
     dim_context,
     reward_type,
     reward_structure,
+    decay_function,
     click_model,
     eta,
     random_state,
@@ -209,6 +237,7 @@ def test_synthetic_slate_init_using_invalid_inputs(
             dim_context=dim_context,
             reward_type=reward_type,
             reward_structure=reward_structure,
+            decay_function=decay_function,
             click_model=click_model,
             eta=eta,
             random_state=random_state,
@@ -455,7 +484,7 @@ def test_synthetic_slate_obtain_batch_bandit_feedback_using_linear_behavior_poli
         assert set(np.unique(bandit_feedback["reward"])) == set([0, 1])
 
 
-# n_unique_action, len_list, dim_context, reward_type, random_state, n_rounds, reward_structure, click_model, eta, behavior_policy_function, reward_function, return_pscore_item_position, description
+# n_unique_action, len_list, dim_context, reward_type, decay_function, random_state, n_rounds, reward_structure, click_model, eta, behavior_policy_function, reward_function, return_pscore_item_position, description
 valid_input_of_obtain_batch_bandit_feedback = [
     (
         10,
@@ -465,6 +494,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "standard_additive",
+        "exponential",
         None,
         1.0,
         linear_behavior_policy_logit,
@@ -480,6 +510,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "independent",
+        "exponential",
         None,
         1.0,
         linear_behavior_policy_logit,
@@ -495,6 +526,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "cascade_additive",
+        "exponential",
         None,
         1.0,
         linear_behavior_policy_logit,
@@ -510,6 +542,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "standard_additive",
+        "exponential",
         None,
         1.0,
         linear_behavior_policy_logit,
@@ -525,6 +558,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "independent",
+        "exponential",
         None,
         1.0,
         linear_behavior_policy_logit,
@@ -540,6 +574,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "cascade_additive",
+        "exponential",
         None,
         1.0,
         linear_behavior_policy_logit,
@@ -555,6 +590,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "cascade_additive",
+        "exponential",
         None,
         0.0,
         None,
@@ -570,6 +606,23 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "cascade_decay",
+        "exponential",
+        None,
+        0.0,
+        linear_behavior_policy_logit,
+        logistic_reward_function,
+        False,
+        "cascade_decay (binary reward)",
+    ),
+    (
+        10,
+        3,
+        2,
+        "binary",
+        123,
+        1000,
+        "cascade_decay",
+        "inverse",
         None,
         0.0,
         linear_behavior_policy_logit,
@@ -585,6 +638,23 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "cascade_decay",
+        "exponential",
+        None,
+        0.0,
+        linear_behavior_policy_logit,
+        linear_reward_function,
+        False,
+        "cascade_decay (continuous reward)",
+    ),
+    (
+        10,
+        3,
+        2,
+        "continuous",
+        123,
+        1000,
+        "cascade_decay",
+        "inverse",
         None,
         0.0,
         linear_behavior_policy_logit,
@@ -600,6 +670,23 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "standard_decay",
+        "exponential",
+        None,
+        0.0,
+        linear_behavior_policy_logit,
+        logistic_reward_function,
+        False,
+        "standard_decay (binary reward)",
+    ),
+    (
+        10,
+        3,
+        2,
+        "binary",
+        123,
+        1000,
+        "standard_decay",
+        "inverse",
         None,
         0.0,
         linear_behavior_policy_logit,
@@ -615,6 +702,23 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "standard_decay",
+        "exponential",
+        None,
+        0.0,
+        linear_behavior_policy_logit,
+        linear_reward_function,
+        False,
+        "standard_decay (continuous reward)",
+    ),
+    (
+        10,
+        3,
+        2,
+        "continuous",
+        123,
+        1000,
+        "standard_decay",
+        "inverse",
         None,
         0.0,
         linear_behavior_policy_logit,
@@ -630,6 +734,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "cascade_additive",
+        "exponential",
         "cascade",
         0.0,
         linear_behavior_policy_logit,
@@ -645,6 +750,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "cascade_decay",
+        "exponential",
         "cascade",
         0.5,
         linear_behavior_policy_logit,
@@ -660,6 +766,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "standard_additive",
+        "exponential",
         "cascade",
         0.5,
         linear_behavior_policy_logit,
@@ -675,6 +782,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "standard_decay",
+        "exponential",
         "cascade",
         0.5,
         linear_behavior_policy_logit,
@@ -690,6 +798,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "independent",
+        "exponential",
         "cascade",
         0.5,
         linear_behavior_policy_logit,
@@ -705,6 +814,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "cascade_additive",
+        "exponential",
         "pbm",
         0.5,
         linear_behavior_policy_logit,
@@ -720,6 +830,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "cascade_decay",
+        "exponential",
         "pbm",
         0.5,
         linear_behavior_policy_logit,
@@ -735,6 +846,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "standard_additive",
+        "exponential",
         "pbm",
         0.5,
         linear_behavior_policy_logit,
@@ -750,6 +862,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "standard_decay",
+        "exponential",
         "pbm",
         0.5,
         linear_behavior_policy_logit,
@@ -765,6 +878,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
         123,
         1000,
         "independent",
+        "exponential",
         "pbm",
         0.5,
         linear_behavior_policy_logit,
@@ -776,7 +890,7 @@ valid_input_of_obtain_batch_bandit_feedback = [
 
 
 @pytest.mark.parametrize(
-    "n_unique_action, len_list, dim_context, reward_type, random_state, n_rounds, reward_structure, click_model, eta, behavior_policy_function, reward_function, return_pscore_item_position, description",
+    "n_unique_action, len_list, dim_context, reward_type, random_state, n_rounds, reward_structure, decay_function, click_model, eta, behavior_policy_function, reward_function, return_pscore_item_position, description",
     valid_input_of_obtain_batch_bandit_feedback,
 )
 def test_synthetic_slate_using_valid_inputs(
@@ -787,6 +901,7 @@ def test_synthetic_slate_using_valid_inputs(
     random_state,
     n_rounds,
     reward_structure,
+    decay_function,
     click_model,
     eta,
     behavior_policy_function,
@@ -800,6 +915,7 @@ def test_synthetic_slate_using_valid_inputs(
         dim_context=dim_context,
         reward_type=reward_type,
         reward_structure=reward_structure,
+        decay_function=decay_function,
         click_model=click_model,
         eta=eta,
         random_state=random_state,
@@ -835,7 +951,7 @@ def test_synthetic_slate_using_valid_inputs(
 n_rounds = 5
 len_list = 3
 # slate_id, reward, description
-invalid_input_of_calc_true_policy_value = [
+invalid_input_of_calc_on_policy_policy_value = [
     (
         np.repeat(np.arange(n_rounds), len_list),
         "4",  #
@@ -866,7 +982,7 @@ invalid_input_of_calc_true_policy_value = [
 
 @pytest.mark.parametrize(
     "slate_id, reward, description",
-    invalid_input_of_calc_true_policy_value,
+    invalid_input_of_calc_on_policy_policy_value,
 )
 def test_calc_on_policy_policy_value_using_invalid_input_data(
     slate_id, reward, description
@@ -889,7 +1005,7 @@ def test_calc_on_policy_policy_value_using_invalid_input_data(
 
 
 # slate_id, reward, description
-valid_input_of_calc_true_policy_value = [
+valid_input_of_calc_on_policy_policy_value = [
     (
         np.array([1, 1, 2, 2, 3, 4]),
         np.array([0, 1, 1, 0, 0, 0]),
@@ -907,7 +1023,7 @@ valid_input_of_calc_true_policy_value = [
 
 @pytest.mark.parametrize(
     "slate_id, reward, result, description",
-    valid_input_of_calc_true_policy_value,
+    valid_input_of_calc_on_policy_policy_value,
 )
 def test_calc_on_policy_policy_value_using_valid_input_data(
     slate_id, reward, result, description
@@ -1239,6 +1355,92 @@ def test_calc_epsilon_greedy_pscore_using_valid_input_data(
     assert np.allclose(true_pscore_cascade, pscore_cascade)
 
 
+# n_rounds, n_unique_action, len_list, dim_context, reward_type, reward_structure, click_model, evaluation_policy_logit, context, description
+invalid_input_of_calc_ground_truth_policy_value = [
+    (
+        3,
+        3,
+        2,
+        2,
+        "binary",
+        "independent",
+        None,
+        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [1, 2, 3]]),
+        np.ones((3, 2)),
+        None,
+    ),
+    (
+        4,
+        3,
+        2,
+        2,
+        "binary",
+        "independent",
+        None,
+        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [1, 2, 3]]),
+        np.ones((3, 2)),
+        None,
+    ),
+    (
+        3,
+        2,
+        2,
+        2,
+        "binary",
+        "independent",
+        None,
+        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [1, 2, 3]]),
+        np.ones((3, 2)),
+        None,
+    ),
+    (
+        3,
+        3,
+        2,
+        1,
+        "binary",
+        "independent",
+        None,
+        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [1, 2, 3]]),
+        np.ones((3, 2)),
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "n_rounds, n_unique_action, len_list, dim_context, reward_type, reward_structure, click_model, evaluation_policy_logit, context, description",
+    invalid_input_of_calc_ground_truth_policy_value,
+)
+def test_calc_ground_truth_policy_value_using_invalid_input_data(
+    n_rounds,
+    n_unique_action,
+    len_list,
+    dim_context,
+    reward_type,
+    reward_structure,
+    click_model,
+    evaluation_policy_logit,
+    context,
+    description,
+):
+    dataset = SyntheticSlateBanditDataset(
+        n_unique_action=n_unique_action,
+        len_list=len_list,
+        dim_context=dim_context,
+        reward_type=reward_type,
+        reward_structure=reward_structure,
+        click_model=click_model,
+        base_reward_function=logistic_reward_function,
+    )
+    _ = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
+    with pytest.raises(ValueError):
+        dataset.calc_ground_truth_policy_value(
+            evaluation_policy_logit=evaluation_policy_logit,
+            context=context,
+        )
+
+
 # n_rounds, n_unique_action, len_list, dim_context, reward_type, reward_structure, click_model, base_reward_function, evaluation_policy_logit, description
 valid_input_of_calc_ground_truth_policy_value = [
     (
@@ -1530,87 +1732,76 @@ def test_calc_ground_truth_policy_value_value_check_with_eta(click_model):
     assert policy_value_2 < policy_value_1 < policy_value_05
 
 
-# n_rounds, n_unique_action, len_list, dim_context, reward_type, reward_structure, click_model, evaluation_policy_logit, context, description
-invalid_input_of_calc_ground_truth_policy_value = [
-    (
-        3,
-        3,
-        2,
-        2,
-        "binary",
-        "independent",
-        None,
-        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [1, 2, 3]]),
-        np.ones((3, 2)),
-        None,
-    ),
-    (
-        4,
-        3,
-        2,
-        2,
-        "binary",
-        "independent",
-        None,
-        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [1, 2, 3]]),
-        np.ones((3, 2)),
-        None,
-    ),
-    (
-        3,
-        2,
-        2,
-        2,
-        "binary",
-        "independent",
-        None,
-        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [1, 2, 3]]),
-        np.ones((3, 2)),
-        None,
-    ),
-    (
-        3,
-        3,
-        2,
-        1,
-        "binary",
-        "independent",
-        None,
-        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [1, 2, 3]]),
-        np.ones((3, 2)),
-        None,
-    ),
+n_rounds = 10
+n_unique_action = 5
+len_list = 3
+# action, evaluation_policy_logit_
+invalid_input_of_obtain_pscore_given_evaluation_policy_logit = [
+    (np.ones((n_rounds, len_list)), np.ones((n_rounds, n_unique_action))),
+    (np.ones((n_rounds * len_list)), np.ones((n_rounds * n_unique_action))),
+    (np.ones((n_rounds * len_list + 1)), np.ones((n_rounds, n_unique_action))),
+    (np.ones((n_rounds * len_list)), np.ones((n_rounds, n_unique_action + 1))),
+    (np.ones((n_rounds * len_list)), np.ones((n_rounds + 1, n_unique_action))),
 ]
 
 
 @pytest.mark.parametrize(
-    "n_rounds, n_unique_action, len_list, dim_context, reward_type, reward_structure, click_model, evaluation_policy_logit, context, description",
-    invalid_input_of_calc_ground_truth_policy_value,
+    "action, evaluation_policy_logit_",
+    invalid_input_of_obtain_pscore_given_evaluation_policy_logit,
 )
-def test_calc_ground_truth_policy_value_using_invalid_input_data(
-    n_rounds,
-    n_unique_action,
-    len_list,
-    dim_context,
-    reward_type,
-    reward_structure,
-    click_model,
-    evaluation_policy_logit,
-    context,
-    description,
-):
+def test_obtain_pscore_given_evaluation_policy_logit(action, evaluation_policy_logit_):
     dataset = SyntheticSlateBanditDataset(
         n_unique_action=n_unique_action,
         len_list=len_list,
-        dim_context=dim_context,
-        reward_type=reward_type,
-        reward_structure=reward_structure,
-        click_model=click_model,
-        base_reward_function=logistic_reward_function,
     )
-    _ = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
     with pytest.raises(ValueError):
-        dataset.calc_ground_truth_policy_value(
-            evaluation_policy_logit=evaluation_policy_logit,
-            context=context,
+        dataset.obtain_pscore_given_evaluation_policy_logit(
+            action=action,
+            evaluation_policy_logit_=evaluation_policy_logit_,
         )
+
+
+@pytest.mark.parametrize("return_pscore_item_position", [(True), (False)])
+def test_obtain_pscore_given_evaluation_policy_logit_value_check(
+    return_pscore_item_position,
+):
+    dataset = SyntheticSlateBanditDataset(
+        n_unique_action=10,
+        len_list=5,
+        behavior_policy_function=linear_behavior_policy_logit,
+        random_state=12345,
+    )
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(
+        n_rounds=2,
+        return_pscore_item_position=return_pscore_item_position,
+    )
+    behavior_and_evaluation_policy_logit_ = dataset.behavior_policy_function(
+        context=bandit_feedback["context"],
+        action_context=bandit_feedback["action_context"],
+        random_state=dataset.random_state,
+    )
+    (
+        evaluation_policy_pscore,
+        evaluation_policy_pscore_item_position,
+        evaluation_policy_pscore_cascade,
+    ) = dataset.obtain_pscore_given_evaluation_policy_logit(
+        action=bandit_feedback["action"],
+        evaluation_policy_logit_=behavior_and_evaluation_policy_logit_,
+        return_pscore_item_position=return_pscore_item_position,
+    )
+    print(bandit_feedback["pscore"])
+    print(evaluation_policy_pscore)
+
+    assert np.allclose(bandit_feedback["pscore"], evaluation_policy_pscore)
+    assert np.allclose(
+        bandit_feedback["pscore_cascade"], evaluation_policy_pscore_cascade
+    )
+    assert (
+        np.allclose(
+            bandit_feedback["pscore_item_position"],
+            evaluation_policy_pscore_item_position,
+        )
+        if return_pscore_item_position
+        else bandit_feedback["pscore_item_position"]
+        == evaluation_policy_pscore_item_position
+    )


### PR DESCRIPTION
## new feature
- implement a function `obtain_pscore_given_evaluation_policy_logit` to calculate and return `pscore`, `pscore_cascade`, and `pscore_item_position` by evaluation policy, given `evaluation_policy_logit_` and `bandit_feedback["action"]`.
https://github.com/aiueola/zr-obp/blob/22a89152e61526db495e6504577721f19e4ab28a/obp/dataset/synthetic_slate.py#L344

## refactor
- added tdqm in `calc_ground_truth_policy_value`.
https://github.com/aiueola/zr-obp/blob/22a89152e61526db495e6504577721f19e4ab28a/obp/dataset/synthetic_slate.py#L785

## test
- add tests for `obtain_pscore_given_evaluation_policy_logit`.
https://github.com/aiueola/zr-obp/blob/22a89152e61526db495e6504577721f19e4ab28a/tests/dataset/test_synthetic_slate.py#L954
- add tests for `decay_function` option in `__init__`.
https://github.com/aiueola/zr-obp/blob/22a89152e61526db495e6504577721f19e4ab28a/tests/dataset/test_synthetic_slate.py#L16
- refactored name from `calc_true_policy_value` into `calc_on_policy_policy_value`
https://github.com/aiueola/zr-obp/blob/22a89152e61526db495e6504577721f19e4ab28a/tests/dataset/test_synthetic_slate.py#L954

## others
- minor fix on typos and docstrings