### PR TITLE
Add a method to visualize the policy values of multiple policies

### DIFF
--- a/obp/ope/meta.py
+++ b/obp/ope/meta.py
@@ -608,10 +608,6 @@ class OffPolicyEvaluation:
             estimated_round_rewards_df = DataFrame(
                 estimated_round_rewards_dict[estimator_name]
             )
-            estimated_round_rewards_df.rename(
-                columns={key: key.upper() for key in policy_name_list},
-                inplace=True,
-            )
             if is_relative:
                 estimated_round_rewards_df /= self.bandit_feedback["reward"].mean()
 

--- a/obp/ope/meta.py
+++ b/obp/ope/meta.py
@@ -623,7 +623,7 @@ class OffPolicyEvaluation:
                 n_boot=n_bootstrap_samples,
                 seed=random_state,
             )
-            ax.set_title(estimator_name)
+            ax.set_title(estimator_name.upper(), fontsize=20)
             ax.set_ylabel(
                 f"Estimated Policy Value (± {np.int(100*(1 - alpha))}% CI)", fontsize=20
             )


### PR DESCRIPTION
I implement a method to visualize the policy values of multiple policies.

When you do the following in `examples/quickstart/synthetic.ipynb`,

```python3
ope.visualize_off_policy_estimates_of_multiple_policies(
    policy_name_list=["IPW LR", "IPW RF", "Random"],
    action_dist_list=[action_dist_ipw_lr, action_dist_ipw_rf, action_dist_random],
    estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
    n_bootstrap_samples=100, # number of resampling performed in the bootstrap procedure
    random_state=12345,
)
```

![multiple-policy-values](https://user-images.githubusercontent.com/10551744/120101861-393b5b80-c183-11eb-8c81-fbf2d4f99196.png)

