### PR TITLE
bug fix: batch processing `n_rounds` in SyntheticSlateBanditDataset

### DIFF
--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -871,8 +871,9 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         else:
             n_batch = (
                 n_rounds * n_enumerated_slate_actions * self.len_list - 1
-            ) // 10 ** 8 + 1
-            batch_size = ((n_rounds - 1) // n_batch) + 1
+            ) // 10 ** 7 + 1
+            batch_size = (n_rounds - 1) // n_batch + 1
+            n_batch = (n_rounds - 1) // batch_size + 1
 
             policy_value = 0.0
             for batch_idx in tqdm(


### PR DESCRIPTION
## bug fix
- ZeroDevisionError raises when there is empty batch. (i.e., `n_rounds=0`)
> n_enumerated_slate_actions = len(action) // n_rounds

- added following line to tackle the issue.
> n_batch = (n_rounds - 1) // batch_size + 1

https://github.com/aiueola/zr-obp/blob/9463fb95680021319f757f3b2652d2efa05e345b/obp/dataset/synthetic_slate.py#L876