### PR TITLE
Bug fix: update params of epsilon greedy policy

### DIFF
--- a/obp/policy/contextfree.py
+++ b/obp/policy/contextfree.py
@@ -89,8 +89,7 @@ class EpsilonGreedy(BaseContextFreePolicy):
         """
         self.n_trial += 1
         self.action_counts_temp[action] += 1
-        n, old_reward = self.action_counts_temp[action], self.reward_counts_temp[action]
-        self.reward_counts_temp[action] = (old_reward * (n - 1) / n) + (reward / n)
+        self.reward_counts_temp[action] += reward
         if self.n_trial % self.batch_size == 0:
             self.action_counts = np.copy(self.action_counts_temp)
             self.reward_counts = np.copy(self.reward_counts_temp)

--- a/tests/policy/test_contextfree.py
+++ b/tests/policy/test_contextfree.py
@@ -86,9 +86,7 @@ def test_egreedy_update_params():
     reward = 1.0
     policy.update_params(action, reward)
     assert np.array_equal(policy.action_counts, np.array([5, 3]))
-    # in epsilon greedy, reward_counts is defined as the mean of observed rewards for each action
-    next_reward = (2.0 * (5 - 1) / 5) + (reward / 5)
-    assert np.allclose(policy.reward_counts, np.array([next_reward, 0.0]))
+    assert np.allclose(policy.reward_counts, np.array([2.0 + reward, 0.0]))
 
 
 def test_random_compute_batch_action_dist():


### PR DESCRIPTION
`reward_counts` of epsilon greedy policy should not be the mean, but the count.

If `reward_counts` is the mean, `predicted_rewards` defined in `select_action` is not the `reward_counts / action_counts (=expected reward)`, but the `reward_counts / action_counts^2`.


I also fixed a testing script of the epsilon greedy policy.