### PR TITLE
bug fix: action_interaction_reward_function in SyntheticSlateBanditDataset

### DIFF
--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -713,7 +713,6 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                 len_list=self.len_list,
                 random_state=self.random_state,
             )
-        expected_reward_factual = np.clip(expected_reward_factual, 0, None)
         # check the shape of expected_reward_factual
         if not (
             isinstance(expected_reward_factual, np.ndarray)
@@ -900,10 +899,6 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                     is_enumerated=True,
                     random_state=self.random_state,
                 )
-
-                expected_slate_rewards_ = np.clip(
-                    expected_slate_rewards_, 0, None
-                )  # (n_slate_actions, self.len_list)
 
                 # click models based on expected reward
                 expected_slate_rewards_ *= self.exam_weight
@@ -1311,9 +1306,9 @@ def action_interaction_reward_function(
         if reward_structure == "independent":
             continue
         elif is_additive:
-            for position2_ in np.arange(len_list)[::-1]:
+            for position2_ in np.arange(len_list):
                 if is_cascade:
-                    if position_ >= position2_:
+                    if position_ <= position2_:
                         break
                 elif position_ == position2_:
                     continue
@@ -1321,9 +1316,9 @@ def action_interaction_reward_function(
                     action_2d[:, position_], action_2d[:, position2_]
                 ]
         else:
-            for position2_ in np.arange(len_list)[::-1]:
+            for position2_ in np.arange(len_list):
                 if is_cascade:
-                    if position_ >= position2_:
+                    if position_ <= position2_:
                         break
                 elif position_ == position2_:
                     continue
@@ -1334,8 +1329,12 @@ def action_interaction_reward_function(
                 weight_ = action_interaction_weight_matrix[position_, position2_]
                 tmp_fixed_reward += expected_reward_ * weight_
         expected_reward_factual[:, position_] = tmp_fixed_reward
+
     if reward_type == "binary":
         expected_reward_factual = sigmoid(expected_reward_factual)
+    else:
+        expected_reward_factual = np.clip(expected_reward_factual, 0, None)
+
     assert expected_reward_factual.shape == (
         action_2d.shape[0],
         len_list,


### PR DESCRIPTION
## important
Cascade reward structure implementation is incorrect. It now considers interactions from the **latter** slots, where it should be from the **former** slots.
https://github.com/st-tech/zr-obp/blob/67222b12e8448f137bf93aedfc8b9ea1ecb1faec/obp/dataset/synthetic_slate.py#L1314
```Python
# current
len_list = 5
for position_ in np.arange(len_list):
    for position2_ in np.arange(len_list)[::-1]:
        if position_ >= position2_:
            break
        print(position_, position2_)

>>>
0 4
0 3
0 2
0 1
1 4
1 3
1 2
2 4
2 3
3 4
```
```Python
# should be
for position_ in np.arange(len_list):
    for position2_ in np.arange(len_list)[::-1]:
        if position_ >= position2_:
            break
        print(position_, position2_)

>>>
1 0
2 0
2 1
3 0
3 1
3 2
4 0
4 1
4 2
4 3
```

## refactor
Relocated clipping function of `expected_reward_factual` into `action_interaction_reward_function`.
https://github.com/aiueola/zr-obp/blob/367d9753caf6a11b5ebee284b2b1bc903255a8df/obp/dataset/synthetic_slate.py#L1335