### PR TITLE
Add faster method to calculate pscore item position

### DIFF
--- a/examples/synthetic/obtain_slate_bandit_feedback.py
+++ b/examples/synthetic/obtain_slate_bandit_feedback.py
@@ -1,0 +1,55 @@
+import argparse
+
+from obp.dataset import (
+    logistic_reward_function,
+    linear_behavior_policy_logit,
+    SyntheticSlateBanditDataset,
+)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="run slate dataset.")
+    parser.add_argument(
+        "--n_unique_action", type=int, default=10, help="number of unique actions."
+    )
+    parser.add_argument(
+        "--len_list", type=int, default=3, help="number of item positions."
+    )
+    parser.add_argument("--n_rounds", type=int, default=100, help="number of slates.")
+    parser.add_argument(
+        "--clip_logit_value",
+        type=float,
+        default=None,
+        help="a float parameter to clip logit value.",
+    )
+    parser.add_argument(
+        "--is_factorizable",
+        type=bool,
+        default=False,
+        help="a boolean parameter whether to use factorizable evaluation policy.",
+    )
+    parser.add_argument(
+        "--return_pscore_item_position",
+        type=bool,
+        default=True,
+        help="a boolean parameter whether `pscore_item_position` is returned or not",
+    )
+    parser.add_argument("--random_state", type=int, default=12345)
+    args = parser.parse_args()
+    dataset = SyntheticSlateBanditDataset(
+        n_unique_action=args.n_unique_action,
+        dim_context=5,
+        len_list=args.len_list,
+        base_reward_function=logistic_reward_function,
+        behavior_policy_function=linear_behavior_policy_logit,
+        reward_type="binary",
+        reward_structure="cascade_additive",
+        click_model="cascade",
+        random_state=12345,
+        is_factorizable=args.is_factorizable,
+    )
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(
+        n_rounds=args.n_rounds,
+        return_pscore_item_position=args.return_pscore_item_position,
+        clip_logit_value=args.clip_logit_value,
+    )

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -11,7 +11,6 @@ from scipy.stats import truncnorm
 from scipy.special import perm
 from sklearn.utils import check_random_state, check_scalar
 from tqdm import tqdm
-from profilehooks import profile
 
 from .base import BaseBanditDataset
 from ..types import BanditFeedback
@@ -519,8 +518,6 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
 
         return pscore, pscore_item_position, pscore_cascade
 
-    # TODO: `@profile` will be removed before merging.
-    @profile
     def sample_action_and_obtain_pscore(
         self,
         behavior_policy_logit_: np.ndarray,

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -359,8 +359,8 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
 
         return pscores
 
-    def _calc_pscore_given_policy_value(
-        self, all_slate_actions: np.ndarray, policy_value_i_: np.ndarray
+    def _calc_pscore_given_policy_softmax(
+        self, all_slate_actions: np.ndarray, policy_softmax_i_: np.ndarray
     ) -> np.ndarray:
         """Calculate the propensity score of each of the possible slate actions given policy_logit.
 
@@ -369,7 +369,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         all_slate_actions: array-like, (n_action, len_list)
             All possible slate actions.
 
-        policy_value_i_: array-like, (n_unique_action, )
+        policy_softmax_i_: array-like, (n_unique_action, )
             Policy values given context (:math:`x`), i.e., :math:`\\f: \\mathcal{X} \\rightarrow \\mathbb{R}^{\\mathcal{A}}`.
 
         Returns
@@ -385,7 +385,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
             action_index = np.where(
                 unique_action_set_2d == all_slate_actions[:, position_][:, np.newaxis]
             )[1]
-            score_ = policy_value_i_[unique_action_set_2d]
+            score_ = policy_softmax_i_[unique_action_set_2d]
             pscores *= np.divide(score_, score_.sum(axis=1, keepdims=True))[
                 np.arange(n_actions), action_index
             ]
@@ -463,7 +463,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                 target_type=(float),
                 max_val=700.0,
             )
-            evaluation_policy_value_ = np.exp(
+            evaluation_policy_softmax_ = np.exp(
                 np.minimum(evaluation_policy_logit_, clip_logit_value)
             )
         for i in tqdm(
@@ -496,9 +496,9 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                         pscore_item_position_i_l = score_[action_index_]
                     else:
                         if isinstance(clip_logit_value, float):
-                            pscores = self._calc_pscore_given_policy_value(
+                            pscores = self._calc_pscore_given_policy_softmax(
                                 all_slate_actions=enumerated_slate_actions,
-                                policy_value_i_=evaluation_policy_value_[i],
+                                policy_softmax_i_=evaluation_policy_softmax_[i],
                             )
                         else:
                             pscores = self._calc_pscore_given_policy_logit(
@@ -586,7 +586,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                 target_type=(float),
                 max_val=700.0,
             )
-            behavior_policy_value_ = np.exp(
+            behavior_policy_softmax_ = np.exp(
                 np.minimum(behavior_policy_logit_, clip_logit_value)
             )
         for i in tqdm(
@@ -626,9 +626,9 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                         pscore_item_position_i_l = pscore_i
                     else:
                         if isinstance(clip_logit_value, float):
-                            pscores = self._calc_pscore_given_policy_value(
+                            pscores = self._calc_pscore_given_policy_softmax(
                                 all_slate_actions=enumerated_slate_actions,
-                                policy_value_i_=behavior_policy_value_[i],
+                                policy_softmax_i_=behavior_policy_softmax_[i],
                             )
                         else:
                             pscores = self._calc_pscore_given_policy_logit(
@@ -731,7 +731,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
             A boolean parameter whether `pscore_item_position` is returned or not.
             When `n_unique_action` and `len_list` are large, this parameter should be set to False because of the computational time.
 
-        clip_softmax_value: Optional[float], default=None
+        clip_logit_value: Optional[float], default=None
             A float parameter to clip logit value.
             When None is given, we calculate softmax values without clipping to obtain `pscore_item_position`.
             When a float value is given, we clip logit values to calculate softmax values to obtain `pscore_item_position`.

--- a/tests/dataset/test_synthetic_slate.py
+++ b/tests/dataset/test_synthetic_slate.py
@@ -2157,7 +2157,7 @@ def test_calc_pscore_given_policy_logit_using_valid_input_data(
         all_slate_actions, policy_logit_i_
     )
     assert np.allclose(true_pscores, pscores)
-    pscores = dataset._calc_pscore_given_policy_value(
+    pscores = dataset._calc_pscore_given_policy_softmax(
         all_slate_actions, np.exp(policy_logit_i_)
     )
     assert np.allclose(true_pscores, pscores)

--- a/tests/dataset/test_synthetic_slate.py
+++ b/tests/dataset/test_synthetic_slate.py
@@ -2157,6 +2157,10 @@ def test_calc_pscore_given_policy_logit_using_valid_input_data(
         all_slate_actions, policy_logit_i_
     )
     assert np.allclose(true_pscores, pscores)
+    pscores = dataset._calc_pscore_given_policy_value(
+        all_slate_actions, np.exp(policy_logit_i_)
+    )
+    assert np.allclose(true_pscores, pscores)
 
 
 # n_unique_action, len_list, evaluation_policy_logit_, action, true_pscores, true_pscores_cascade, true_pscores_item_position,description
@@ -2276,6 +2280,22 @@ def test_obtain_pscore_given_evaluation_policy_logit_using_mock_input_data(
         evaluation_policy_pscore_cascade,
     ) = dataset.obtain_pscore_given_evaluation_policy_logit(
         action, evaluation_policy_logit_, return_pscore_item_position=True
+    )
+    assert np.allclose(true_pscores, evaluation_policy_pscore)
+    assert np.allclose(true_pscores_cascade, evaluation_policy_pscore_cascade)
+    assert np.allclose(
+        true_pscores_item_position, evaluation_policy_pscore_item_position
+    )
+
+    (
+        evaluation_policy_pscore,
+        evaluation_policy_pscore_item_position,
+        evaluation_policy_pscore_cascade,
+    ) = dataset.obtain_pscore_given_evaluation_policy_logit(
+        action,
+        evaluation_policy_logit_,
+        return_pscore_item_position=True,
+        clip_logit_value=100.0,
     )
     assert np.allclose(true_pscores, evaluation_policy_pscore)
     assert np.allclose(true_pscores_cascade, evaluation_policy_pscore_cascade)


### PR DESCRIPTION
# Overview

- Added `_calc_pscore_given_policy_value` to compute `pscore_item_position` faster.
  - We need to clip `policy_logit_` before computing softmax values.

- Added `@profile` to measure the computation time of `sample_action_and_obtain_pscore`.
  - We need to remove `@profile` before merging the code.

- Verified the correctness of the method by adding several testing codes.

# Details

It is well known that calculating `pscore_item_position` suffers from the heavy computation time. The bottleneck is in the method to calculate softmax values:

```
% python examples/synthetic/obtain_slate_bandit_feedback.py --len_list 6 --n_rounds 100 
[sample_action_and_obtain_pscore]: 100%|██████████████████████████████████████████████████████████████████| 100/100 [01:09<00:00,  1.43it/s]
  zr-obp/obp/utils.py:698: RuntimeWarning: overflow encountered in exp
  return 1.0 / (1.0 + np.exp(-x))

*** PROFILER RESULTS ***
sample_action_and_obtain_pscore (zr-obp/obp/dataset/synthetic_slate.py:499)
function called 1 times

         222616 function calls (222601 primitive calls) in 69.954 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 308 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.159    0.159   69.954   69.954 synthetic_slate.py:499(sample_action_and_obtain_pscore)
      500   14.476    0.029   69.516    0.139 synthetic_slate.py:324(_calc_pscore_given_policy_logit)
     3600   18.060    0.005   44.090    0.012 utils.py:701(softmax)
    16600    9.400    0.001   35.793    0.002 {built-in method numpy.core._multiarray_umath.implement_array_function}
     7200    0.031    0.000   25.974    0.004 fromnumeric.py:70(_wrapreduction)
     7700   25.941    0.003   25.941    0.003 {method 'reduce' of 'numpy.ufunc' objects}
     3600    0.008    0.000   21.081    0.006 <__array_function__ internals>:2(amax)
     3600    0.010    0.000   21.066    0.006 fromnumeric.py:2589(amax)
     3600    0.007    0.000    8.801    0.002 <__array_function__ internals>:2(where)
     3600    0.009    0.000    4.950    0.001 <__array_function__ internals>:2(sum)
     3600    0.012    0.000    4.934    0.001 fromnumeric.py:2105(sum)
     2500    0.932    0.000    0.932    0.000 {method 'astype' of 'numpy.ndarray' objects}
     3000    0.008    0.000    0.626    0.000 numeric.py:144(ones)
     3000    0.008    0.000    0.605    0.000 <__array_function__ internals>:2(copyto)
      500    0.000    0.000    0.374    0.001 <__array_function__ internals>:2(tile)
      500    0.004    0.000    0.373    0.001 shape_base.py:1171(tile)
      500    0.366    0.001    0.366    0.001 {method 'repeat' of 'numpy.ndarray' objects}
     6702    0.227    0.000    0.227    0.000 {built-in method numpy.arange}
     2701    0.126    0.000    0.126    0.000 {built-in method numpy.array}
      600    0.036    0.000    0.061    0.000 {method 'choice' of 'numpy.random.mtrand.RandomState' objects}
      101    0.001    0.000    0.027    0.000 std.py:1136(__iter__)
      101    0.000    0.000    0.026    0.000 std.py:1360(refresh)
      102    0.000    0.000    0.024    0.000 std.py:1491(display)
      102    0.001    0.000    0.017    0.000 std.py:1126(__repr__)
        1    0.017    0.017    0.017    0.017 synthetic_slate.py:552(<listcomp>)
      102    0.003    0.000    0.015    0.000 std.py:343(format_meter)
     3600    0.013    0.000    0.013    0.000 {built-in method numpy.empty}
      306    0.000    0.000    0.012    0.000 utils.py:325(disp_len)
      600    0.001    0.000    0.011    0.000 <__array_function__ internals>:2(unique)
      306    0.000    0.000    0.011    0.000 utils.py:320(_text_width)
      306    0.002    0.000    0.011    0.000 {built-in method builtins.sum}
      500    0.001    0.000    0.011    0.000 {method 'sum' of 'numpy.ndarray' objects}
        1    0.000    0.000    0.010    0.010 std.py:557(__new__)
      600    0.001    0.000    0.010    0.000 arraysetops.py:149(unique)
      500    0.000    0.000    0.009    0.000 _methods.py:45(_sum)
     3500    0.009    0.000    0.009    0.000 {method 'reshape' of 'numpy.ndarray' objects}
        1    0.000    0.000    0.009    0.009 std.py:654(get_lock)
        1    0.000    0.000    0.009    0.009 std.py:92(__init__)
        1    0.000    0.000    0.009    0.009 std.py:118(create_mp_lock)
        1    0.000    0.000    0.009    0.009 context.py:70(RLock)
```

I implemented faster method to calculate `pscore_item_position` by [simplifying](https://github.com/st-tech/zr-obp/pull/110/files#diff-08712719ea691a3e30112fb3d8225724748582036a735c3d419a01e8dbea64adR390-R392) softmax calculation (**more than twice as fast**).
I added an argument, `clip_logit_value`, to prevent `overflow encountered in exp` (**this clipping may not be appropriate if logit values are too large**).


```
% python examples/synthetic/obtain_slate_bandit_feedback.py --len_list 6 --n_rounds 100 --clip_logit_value 100.0
[sample_action_and_obtain_pscore]: 100%|██████████████████████████████████████████████████████████████████| 100/100 [00:34<00:00,  2.88it/s]
zr-obp/obp/utils.py:698: RuntimeWarning: overflow encountered in exp
  return 1.0 / (1.0 + np.exp(-x))

*** PROFILER RESULTS ***
sample_action_and_obtain_pscore (zr-obp/obp/dataset/synthetic_slate.py:499)
function called 1 times

         177625 function calls (177610 primitive calls) in 34.884 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 309 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.162    0.162   34.884   34.884 synthetic_slate.py:499(sample_action_and_obtain_pscore)
      500   17.638    0.035   34.440    0.069 synthetic_slate.py:363(_calc_pscore_given_policy_value)
    10600   10.114    0.001   10.518    0.001 {built-in method numpy.core._multiarray_umath.implement_array_function}
     3600    0.008    0.000    9.526    0.003 <__array_function__ internals>:2(where)
     3500    0.012    0.000    5.103    0.001 {method 'sum' of 'numpy.ndarray' objects}
     4700    5.091    0.001    5.091    0.001 {method 'reduce' of 'numpy.ufunc' objects}
     3500    0.004    0.000    5.091    0.001 _methods.py:45(_sum)
     2500    0.947    0.000    0.947    0.000 {method 'astype' of 'numpy.ndarray' objects}
     3000    0.009    0.000    0.626    0.000 numeric.py:144(ones)
     3000    0.008    0.000    0.604    0.000 <__array_function__ internals>:2(copyto)
      500    0.000    0.000    0.376    0.001 <__array_function__ internals>:2(tile)
      500    0.005    0.000    0.375    0.001 shape_base.py:1171(tile)
      500    0.368    0.001    0.368    0.001 {method 'repeat' of 'numpy.ndarray' objects}
     6702    0.229    0.000    0.229    0.000 {built-in method numpy.arange}
     2701    0.127    0.000    0.127    0.000 {built-in method numpy.array}
      600    0.037    0.000    0.063    0.000 {method 'choice' of 'numpy.random.mtrand.RandomState' objects}
      101    0.001    0.000    0.027    0.000 std.py:1136(__iter__)
      101    0.000    0.000    0.026    0.000 std.py:1360(refresh)
      102    0.000    0.000    0.024    0.000 std.py:1491(display)
      102    0.001    0.000    0.017    0.000 std.py:1126(__repr__)
      600    0.006    0.000    0.017    0.000 utils.py:701(softmax)
        1    0.016    0.016    0.016    0.016 synthetic_slate.py:552(<listcomp>)
      102    0.003    0.000    0.015    0.000 std.py:343(format_meter)
     3600    0.013    0.000    0.013    0.000 {built-in method numpy.empty}
      306    0.000    0.000    0.012    0.000 utils.py:325(disp_len)
      600    0.001    0.000    0.012    0.000 <__array_function__ internals>:2(unique)
      306    0.000    0.000    0.011    0.000 utils.py:320(_text_width)
      306    0.002    0.000    0.011    0.000 {built-in method builtins.sum}
        1    0.000    0.000    0.010    0.010 std.py:557(__new__)
      600    0.001    0.000    0.010    0.000 arraysetops.py:149(unique)
     3500    0.009    0.000    0.009    0.000 {method 'reshape' of 'numpy.ndarray' objects}
        1    0.000    0.000    0.009    0.009 std.py:654(get_lock)
        1    0.000    0.000    0.009    0.009 std.py:92(__init__)
        1    0.000    0.000    0.009    0.009 std.py:118(create_mp_lock)
    36296    0.006    0.000    0.008    0.000 utils.py:321(<genexpr>)
        1    0.000    0.000    0.008    0.008 context.py:70(RLock)
        1    0.000    0.000    0.008    0.008 synchronize.py:186(__init__)
        1    0.000    0.000    0.008    0.008 synchronize.py:50(__init__)
      600    0.006    0.000    0.008    0.000 arraysetops.py:309(_unique1d)
     1200    0.002    0.000    0.007    0.000 fromnumeric.py:70(_wrapreduction)
```


pytest works well after removing `@profile`:

```
% pytest tests/dataset/test_synthetic_slate.py   
====================================================================== test session starts =======================================================================
platform darwin -- Python 3.9.1, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /zr-obp
collected 108 items                                                                                                                                              

tests/dataset/test_synthetic_slate.py ............................................................................................................         [100%]

======================================================================== warnings summary ========================================================================
tests/dataset/test_synthetic_slate.py: 12 warnings
   zr-obp/obp/utils.py:698: RuntimeWarning: overflow encountered in exp
    return 1.0 / (1.0 + np.exp(-x))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================================================== 108 passed, 12 warnings in 23.16s ================================================================
```