### PR TITLE
Feature: Implementing Continuous OPE Estimators

### DIFF
--- a/obp/ope/__init__.py
+++ b/obp/ope/__init__.py
@@ -10,6 +10,7 @@ from obp.ope.estimators import DoublyRobustWithShrinkage
 from obp.ope.estimators_slate import SlateStandardIPS
 from obp.ope.estimators_slate import SlateIndependentIPS
 from obp.ope.estimators_slate import SlateRewardInteractionIPS
+from obp.ope.estimators_continuous import BaseContinuousOffPolicyEstimator
 from obp.ope.estimators_continuous import KernelizedInverseProbabilityWeighting
 from obp.ope.estimators_continuous import (
     KernelizedSelfNormalizedInverseProbabilityWeighting,
@@ -41,6 +42,7 @@ __all__ = [
     "SlateStandardIPS",
     "SlateIndependentIPS",
     "SlateRewardInteractionIPS",
+    "BaseContinuousOffPolicyEstimator",
     "KernelizedInverseProbabilityWeighting",
     "KernelizedSelfNormalizedInverseProbabilityWeighting",
     "KernelizedDoublyRobust",

--- a/obp/ope/__init__.py
+++ b/obp/ope/__init__.py
@@ -10,8 +10,18 @@ from obp.ope.estimators import DoublyRobustWithShrinkage
 from obp.ope.estimators_slate import SlateStandardIPS
 from obp.ope.estimators_slate import SlateIndependentIPS
 from obp.ope.estimators_slate import SlateRewardInteractionIPS
+from obp.ope.estimators_continuous import KernelizedInverseProbabilityWeighting
+from obp.ope.estimators_continuous import (
+    KernelizedSelfNormalizedInverseProbabilityWeighting,
+)
+from obp.ope.estimators_continuous import triangular_kernel
+from obp.ope.estimators_continuous import gaussian_kernel
+from obp.ope.estimators_continuous import epanechnikov_kernel
+from obp.ope.estimators_continuous import cosine_kernel
+from obp.ope.estimators_continuous import KernelizedDoublyRobust
 from obp.ope.meta import OffPolicyEvaluation
 from obp.ope.meta_slate import SlateOffPolicyEvaluation
+from obp.ope.meta_continuous import ContinuousOffPolicyEvaluation
 from obp.ope.regression_model import RegressionModel
 
 __all__ = [
@@ -26,10 +36,18 @@ __all__ = [
     "DoublyRobustWithShrinkage",
     "OffPolicyEvaluation",
     "SlateOffPolicyEvaluation",
+    "ContinuousOffPolicyEvaluation",
     "RegressionModel",
     "SlateStandardIPS",
     "SlateIndependentIPS",
     "SlateRewardInteractionIPS",
+    "KernelizedInverseProbabilityWeighting",
+    "KernelizedSelfNormalizedInverseProbabilityWeighting",
+    "KernelizedDoublyRobust",
+    "triangular_kernel",
+    "gaussian_kernel",
+    "epanechnikov_kernel",
+    "cosine_kernel",
 ]
 
 __all_estimators__ = [

--- a/obp/ope/estimators_continuous.py
+++ b/obp/ope/estimators_continuous.py
@@ -4,7 +4,7 @@
 """Off-Policy Estimators for Continuous Actions."""
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 
 import numpy as np
 from sklearn.utils import check_scalar
@@ -48,7 +48,7 @@ kernel_functions = dict(
 
 
 @dataclass
-class BaseOffPolicyEstimatorForContinuousAction(metaclass=ABCMeta):
+class BaseContinuousOffPolicyEstimator(metaclass=ABCMeta):
     """Base class for OPE estimators for continuous actions."""
 
     @abstractmethod
@@ -68,7 +68,7 @@ class BaseOffPolicyEstimatorForContinuousAction(metaclass=ABCMeta):
 
 
 @dataclass
-class KernelizedInverseProbabilityWeighting(BaseOffPolicyEstimatorForContinuousAction):
+class KernelizedInverseProbabilityWeighting(BaseContinuousOffPolicyEstimator):
     """Kernelized Inverse Probability Weighting.
 
     Note
@@ -380,7 +380,7 @@ class KernelizedSelfNormalizedInverseProbabilityWeighting(
 
 
 @dataclass
-class KernelizedDoublyRobust(BaseOffPolicyEstimatorForContinuousAction):
+class KernelizedDoublyRobust(BaseContinuousOffPolicyEstimator):
     """Kernelized Doubly Robust Estimator.
 
     Note

--- a/obp/ope/estimators_continuous.py
+++ b/obp/ope/estimators_continuous.py
@@ -14,8 +14,9 @@ from ..utils import (
     check_continuous_ope_inputs,
 )
 
-# kernel functions
-# reference: https://en.wikipedia.org/wiki/Kernel_(statistics)
+# kernel functions, reference: https://en.wikipedia.org/wiki/Kernel_(statistics)
+
+
 def triangular_kernel(u: np.ndarray) -> np.ndarray:
     """Calculate triangular kernel function."""
     clipped_u = np.clip(u, -1.0, 1.0)

--- a/obp/ope/estimators_continuous.py
+++ b/obp/ope/estimators_continuous.py
@@ -1,0 +1,619 @@
+# Copyright (c) Yuta Saito, Yusuke Narita, and ZOZO Technologies, Inc. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+"""Off-Policy Estimators for Continuous Actions."""
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+import numpy as np
+from sklearn.utils import check_scalar
+
+from ..utils import (
+    estimate_confidence_interval_by_bootstrap,
+    check_continuous_ope_inputs,
+)
+
+# kernel functions
+# reference: https://en.wikipedia.org/wiki/Kernel_(statistics)
+def triangular_kernel(u: np.ndarray) -> np.ndarray:
+    """Calculate triangular kernel function."""
+    clipped_u = np.clip(u, -1.0, 1.0)
+    return 1 - np.abs(clipped_u)
+
+
+def gaussian_kernel(u: np.ndarray) -> np.ndarray:
+    """Calculate gaussian kernel function."""
+    return np.exp(-(u ** 2) / 2) / np.sqrt(2 * np.pi)
+
+
+def epanechnikov_kernel(u: np.ndarray) -> np.ndarray:
+    """Calculate epanechnikov kernel function."""
+    clipped_u = np.clip(u, -1.0, 1.0)
+    return 0.75 * (1 - clipped_u ** 2)
+
+
+def cosine_kernel(u: np.ndarray) -> np.ndarray:
+    """Calculate cosine kernel function."""
+    clipped_u = np.clip(u, -1.0, 1.0)
+    return (np.pi / 4) * np.cos(clipped_u * np.pi / 2)
+
+
+kernel_functions = dict(
+    gaussian=gaussian_kernel,
+    epanechnikov=epanechnikov_kernel,
+    triangular=triangular_kernel,
+    cosine=cosine_kernel,
+)
+
+
+@dataclass
+class BaseOffPolicyEstimatorForContinuousAction(metaclass=ABCMeta):
+    """Base class for OPE estimators for continuous actions."""
+
+    @abstractmethod
+    def _estimate_round_rewards(self) -> np.ndarray:
+        """Estimate rewards for each round."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def estimate_policy_value(self) -> float:
+        """Estimate policy value of an evaluation policy."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def estimate_interval(self) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure."""
+        raise NotImplementedError
+
+
+@dataclass
+class KernelizedInverseProbabilityWeighting(BaseOffPolicyEstimatorForContinuousAction):
+    """Kernelized Inverse Probability Weighting.
+
+    Note
+    -------
+    Kernelized Inverse Probability Weighting (KernelizedIPW)
+    estimates the policy value of a given (deterministic) evaluation policy :math:`\\pi_e` by
+
+    .. math::
+
+        \\hat{V}_{\\mathrm{Kernel-IPW}} (\\pi_e; \\mathcal{D})
+        := \\mathbb{E}_{\\mathcal{D}} \\left[ \\frac{1}{h} K \\left( \\frac{\pi_e(x_t) - a_t}{h} \\right) \\frac{r_t}{q_t} \\right],
+
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by a behavior policy.
+    Note that each action :math:`a_t` in the logged bandit data is a continuous variable.
+    :math:`q_t` is a generalized propensity score that is defined as the conditional probability density of the behavior policy.
+    :math:`K(\cdot)` is a kernel function such as the gaussian kernel, and :math:`h` is a bandwidth hyperparameter.
+    :math:`\\pi_e (x)` is a deterministic evaluation policy that maps :math:`x` to a continuous action value.
+    :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
+
+    Parameters
+    ------------
+
+    kernel: str
+        Choice of kernel function.
+        Must be one of "gaussian", "epanechnikov", "triangular", or "cosine".
+
+    bandwidth: float
+        A bandwidth hyperparameter.
+        A larger value increases bias instead of reducing variance.
+        A smaller value increases variance instead of reducing bias.
+
+    estimator_name: str, default='kernelized_ipw'.
+        Name of off-policy estimator.
+
+    References
+    ------------
+    Nathan Kallus and Angela Zhou.
+    "Policy Evaluation and Optimization with Continuous Treatments", 2018.
+
+    """
+
+    kernel: str
+    bandwidth: float
+    estimator_name: str = "kernelized_ipw"
+
+    def __post_init__(self) -> None:
+        if self.kernel not in ["gaussian", "epanechnikov", "triangular", "cosine"]:
+            raise ValueError(
+                f"kernel must be one of 'gaussian', 'epanechnikov', 'triangular', and 'cosine' but {self.kernel} is given"
+            )
+        check_scalar(
+            self.bandwidth, name="bandwidth", target_type=(int, float), min_val=0
+        )
+
+    def _estimate_round_rewards(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        """Estimate rewards for each round.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action_by_behavior_policy: array-like, shape (n_rounds,)
+            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Probability densities of the continuous action values sampled by a behavior policy
+            (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+
+        Returns
+        ----------
+        estimated_rewards: array-like, shape (n_rounds,)
+            Rewards estimated by KernelizedIPW for each round.
+
+        """
+        kernel_func = kernel_functions[self.kernel]
+        u = action_by_evaluation_policy - action_by_behavior_policy
+        u /= self.bandwidth
+        estimated_rewards = kernel_func(u) * reward / pscore
+        estimated_rewards /= self.bandwidth
+        return estimated_rewards
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        """Estimate policy value of an evaluation policy.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action_by_behavior_policy: array-like, shape (n_rounds,)
+            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Probability densities of the continuous action values sampled by a behavior policy
+            (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+
+        Returns
+        ----------
+        V_hat: float
+            Estimated policy value (performance) of a given evaluation policy.
+
+        """
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action_by_behavior_policy, np.ndarray):
+            raise ValueError("action_by_behavior_policy must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_continuous_ope_inputs(
+            reward=reward,
+            action_by_behavior_policy=action_by_behavior_policy,
+            pscore=pscore,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+        )
+
+        return self._estimate_round_rewards(
+            reward=reward,
+            action_by_behavior_policy=action_by_behavior_policy,
+            pscore=pscore,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+        ).mean()
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action_by_behavior_policy: array-like, shape (n_rounds,)
+            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Probability densities of the continuous action values sampled by a behavior policy
+            (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+
+        alpha: float, default=0.05
+            Significant level of confidence intervals.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action_by_behavior_policy, np.ndarray):
+            raise ValueError("action_by_behavior_policy must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_continuous_ope_inputs(
+            reward=reward,
+            action_by_behavior_policy=action_by_behavior_policy,
+            pscore=pscore,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+        )
+
+        estimated_round_rewards = self._estimate_round_rewards(
+            reward=reward,
+            action_by_behavior_policy=action_by_behavior_policy,
+            pscore=pscore,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+        )
+
+        return estimate_confidence_interval_by_bootstrap(
+            samples=estimated_round_rewards,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@dataclass
+class KernelizedSelfNormalizedInverseProbabilityWeighting(
+    KernelizedInverseProbabilityWeighting
+):
+    """Kernelized Self-Normalized Inverse Probability Weighting.
+
+    Note
+    -------
+    Kernelized Self-Normalized Inverse Probability Weighting (KernelizedSNIPW)
+    estimates the policy value of a given (deterministic) evaluation policy :math:`\\pi_e` by
+
+    .. math::
+
+        \\hat{V}_{\\mathrm{Kernel-SNIPW}} (\\pi_e; \\mathcal{D})
+        := \\frac{\\mathbb{E}_{\\mathcal{D}} \\left[ K \\left( \\frac{\pi_e(x_t) - a_t}{h} \\right) \\frac{r_t}{q_t} \\right]}{\\mathbb{E}_{\\mathcal{D}} \\left[ K \\left( \\frac{\pi_e(x_t) - a_t}{h} \\right) \\frac{r_t}{q_t}},
+
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by a behavior policy.
+    Note that each action :math:`a_t` in the logged bandit data is a continuous variable.
+    :math:`q_t` is a generalized propensity score that is defined as the conditional probability density of the behavior policy.
+    :math:`K(\cdot)` is a kernel function such as the gaussian kernel, and :math:`h` is a bandwidth hyperparameter.
+    :math:`\\pi_e (x)` is a deterministic evaluation policy that maps :math:`x` to a continuous action value.
+    :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
+
+    Parameters
+    ------------
+    kernel: str
+        Choice of kernel function.
+        Must be one of "gaussian", "epanechnikov", and "triangular".
+
+     bandwidth: float
+        A bandwidth hyperparameter.
+        A larger value increases bias instead of reducing variance.
+        A smaller value increases variance instead of reducing bias.
+
+    estimator_name: str, default='kernelized_snipw'.
+        Name of off-policy estimator.
+
+    References
+    ------------
+    Nathan Kallus and Angela Zhou.
+    "Policy Evaluation and Optimization with Continuous Treatments", 2018.
+
+    """
+
+    kernel: str
+    bandwidth: float
+    estimator_name: str = "kernelized_snipw"
+
+    def _estimate_round_rewards(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        """Estimate rewards for each round.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action_by_behavior_policy: array-like, shape (n_rounds,)
+            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Probability densities of the continuous action values sampled by a behavior policy
+            (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+
+        Returns
+        ----------
+        estimated_rewards: array-like, shape (n_rounds,)
+            Rewards estimated by KernelizedSNIPW for each round.
+
+        """
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action_by_behavior_policy, np.ndarray):
+            raise ValueError("action_by_behavior_policy must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        kernel_func = kernel_functions[self.kernel]
+        u = action_by_evaluation_policy - action_by_behavior_policy
+        u /= self.bandwidth
+        estimated_rewards = kernel_func(u) * reward / pscore
+        estimated_rewards /= (kernel_func(u) / pscore).sum() / reward.shape[0]
+        return estimated_rewards
+
+
+@dataclass
+class KernelizedDoublyRobust(BaseOffPolicyEstimatorForContinuousAction):
+    """Kernelized Doubly Robust Estimator.
+
+    Note
+    -------
+    Kernelized Doubly Robust (KernelizedDR) estimates the policy value of a given (deterministic) evaluation policy :math:`\\pi_e` by
+
+    .. math::
+
+        \\hat{V}_{\\mathrm{Kernel-DR}} (\\pi_e; \\mathcal{D})
+        := \\mathbb{E}_{\\mathcal{D}} \\left[ \\frac{1}{h} K \\left( \\frac{\pi_e(x_t) - a_t}{h} \\right) \\frac{(r_t - \\hat{q}(x_t, \\pi_e(x_t)))}{q_t} + \\hat{q}(x_t, \\pi_e(x_t)) \\right],
+
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by a behavior policy.
+    Note that each action :math:`a_t` in the logged bandit data is a continuous variable.
+    :math:`q_t` is a generalized propensity score that is defined as the conditional probability density of the behavior policy.
+    :math:`K(\cdot)` is a kernel function such as the gaussian kernel, and :math:`h` is a bandwidth hyperparameter.
+    :math:`\\pi_e (x)` is a deterministic evaluation policy that maps :math:`x` to a continuous action value.
+    :math:`\\hat{q} (x,a)` is an estimated expected reward given :math:`x` and :math:`a`.
+    :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
+
+    Parameters
+    ------------
+    kernel: str
+        Choice of kernel function.
+        Must be one of "gaussian", "epanechnikov", and "triangular".
+
+     bandwidth: float
+        A bandwidth hyperparameter.
+        A larger value increases bias instead of reducing variance.
+        A smaller value increases variance instead of reducing bias.
+
+    estimator_name: str, default='kernelized_dr'.
+        Name of off-policy estimator.
+
+    References
+    ------------
+    Nathan Kallus and Angela Zhou.
+    "Policy Evaluation and Optimization with Continuous Treatments", 2018.
+
+    """
+
+    kernel: str
+    bandwidth: float
+    estimator_name: str = "kernelized_dr"
+
+    def __post_init__(self) -> None:
+        if self.kernel not in ["gaussian", "epanechnikov", "triangular", "cosine"]:
+            raise ValueError(
+                f"kernel must be one of 'gaussian', 'epanechnikov', 'triangular', and 'cosine' but {self.kernel} is given"
+            )
+        check_scalar(
+            self.bandwidth, name="bandwidth", target_type=(int, float), min_val=0
+        )
+
+    def _estimate_round_rewards(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        """Estimate rewards for each round.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action_by_behavior_policy: array-like, shape (n_rounds,)
+            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Probability densities of the continuous action values sampled by a behavior policy
+            (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds,)
+            Expected rewards given context and action estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        Returns
+        ----------
+        estimated_rewards: array-like, shape (n_rounds,)
+            Rewards estimated by KernelizedDR for each round.
+
+        """
+        kernel_func = kernel_functions[self.kernel]
+        u = action_by_evaluation_policy - action_by_behavior_policy
+        u /= self.bandwidth
+        estimated_rewards = (
+            kernel_func(u) * (reward - estimated_rewards_by_reg_model) / pscore
+        )
+        estimated_rewards /= self.bandwidth
+        estimated_rewards += estimated_rewards_by_reg_model
+        return estimated_rewards
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        """Estimate policy value of an evaluation policy.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action_by_behavior_policy: array-like, shape (n_rounds,)
+            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Probability densities of the continuous action values sampled by a behavior policy
+            (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds,)
+            Expected rewards given context and action estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        Returns
+        ----------
+        V_hat: float
+            Estimated policy value (performance) of a given evaluation policy.
+
+        """
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action_by_behavior_policy, np.ndarray):
+            raise ValueError("action_by_behavior_policy must be ndarray")
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_continuous_ope_inputs(
+            reward=reward,
+            action_by_behavior_policy=action_by_behavior_policy,
+            pscore=pscore,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+
+        return self._estimate_round_rewards(
+            reward=reward,
+            action_by_behavior_policy=action_by_behavior_policy,
+            pscore=pscore,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        ).mean()
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action_by_behavior_policy: array-like, shape (n_rounds,)
+            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Probability densities of the continuous action values sampled by a behavior policy
+            (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds,)
+            Expected rewards given context and action estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        alpha: float, default=0.05
+            Significant level of confidence intervals.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action_by_behavior_policy, np.ndarray):
+            raise ValueError("action_by_behavior_policy must be ndarray")
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_continuous_ope_inputs(
+            reward=reward,
+            action_by_behavior_policy=action_by_behavior_policy,
+            pscore=pscore,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+
+        estimated_round_rewards = self._estimate_round_rewards(
+            reward=reward,
+            action_by_behavior_policy=action_by_behavior_policy,
+            pscore=pscore,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+
+        return estimate_confidence_interval_by_bootstrap(
+            samples=estimated_round_rewards,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )

--- a/obp/ope/estimators_continuous.py
+++ b/obp/ope/estimators_continuous.py
@@ -54,12 +54,12 @@ class BaseContinuousOffPolicyEstimator(metaclass=ABCMeta):
 
     @abstractmethod
     def _estimate_round_rewards(self) -> np.ndarray:
-        """Estimate rewards for each round."""
+        """Estimate round-wise (or sample-wise) rewards."""
         raise NotImplementedError
 
     @abstractmethod
     def estimate_policy_value(self) -> float:
-        """Estimate policy value of an evaluation policy."""
+        """Estimate policy value of evaluation policy."""
         raise NotImplementedError
 
     @abstractmethod
@@ -82,7 +82,7 @@ class KernelizedInverseProbabilityWeighting(BaseContinuousOffPolicyEstimator):
         \\hat{V}_{\\mathrm{Kernel-IPW}} (\\pi_e; \\mathcal{D})
         := \\mathbb{E}_{\\mathcal{D}} \\left[ \\frac{1}{h} K \\left( \\frac{\pi_e(x_t) - a_t}{h} \\right) \\frac{r_t}{q_t} \\right],
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by a behavior policy.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by behavior policy.
     Note that each action :math:`a_t` in the logged bandit data is a continuous variable.
     :math:`q_t` is a generalized propensity score that is defined as the conditional probability density of the behavior policy.
     :math:`K(\cdot)` is a kernel function such as the gaussian kernel, and :math:`h` is a bandwidth hyperparameter.
@@ -101,7 +101,7 @@ class KernelizedInverseProbabilityWeighting(BaseContinuousOffPolicyEstimator):
         A smaller value increases variance instead of reducing bias.
 
     estimator_name: str, default='kernelized_ipw'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ------------
@@ -131,7 +131,7 @@ class KernelizedInverseProbabilityWeighting(BaseContinuousOffPolicyEstimator):
         action_by_evaluation_policy: np.ndarray,
         **kwargs,
     ) -> np.ndarray:
-        """Estimate rewards for each round.
+        """Estimate round-wise (or sample-wise) rewards.
 
         Parameters
         ----------
@@ -139,19 +139,19 @@ class KernelizedInverseProbabilityWeighting(BaseContinuousOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action_by_behavior_policy: array-like, shape (n_rounds,)
-            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Continuous action values sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Probability densities of the continuous action values sampled by a behavior policy
+            Probability densities of the continuous action values sampled by behavior policy
             (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_by_evaluation_policy: array-like, shape (n_rounds,)
-            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+            Continuous action values given by evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
 
         Returns
         ----------
         estimated_rewards: array-like, shape (n_rounds,)
-            Rewards estimated by KernelizedIPW for each round.
+            Rewards of each round estimated by KernelizedIPW.
 
         """
         kernel_func = kernel_functions[self.kernel]
@@ -169,7 +169,7 @@ class KernelizedInverseProbabilityWeighting(BaseContinuousOffPolicyEstimator):
         action_by_evaluation_policy: np.ndarray,
         **kwargs,
     ) -> np.ndarray:
-        """Estimate policy value of an evaluation policy.
+        """Estimate policy value of evaluation policy.
 
         Parameters
         ----------
@@ -177,14 +177,14 @@ class KernelizedInverseProbabilityWeighting(BaseContinuousOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action_by_behavior_policy: array-like, shape (n_rounds,)
-            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Continuous action values sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Probability densities of the continuous action values sampled by a behavior policy
+            Probability densities of the continuous action values sampled by behavior policy
             (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_by_evaluation_policy: array-like, shape (n_rounds,)
-            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+            Continuous action values given by evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
 
         Returns
         ----------
@@ -232,17 +232,17 @@ class KernelizedInverseProbabilityWeighting(BaseContinuousOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action_by_behavior_policy: array-like, shape (n_rounds,)
-            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Continuous action values sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Probability densities of the continuous action values sampled by a behavior policy
+            Probability densities of the continuous action values sampled by behavior policy
             (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_by_evaluation_policy: array-like, shape (n_rounds,)
-            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+            Continuous action values given by evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -301,7 +301,7 @@ class KernelizedSelfNormalizedInverseProbabilityWeighting(
         \\hat{V}_{\\mathrm{Kernel-SNIPW}} (\\pi_e; \\mathcal{D})
         := \\frac{\\mathbb{E}_{\\mathcal{D}} \\left[ K \\left( \\frac{\pi_e(x_t) - a_t}{h} \\right) \\frac{r_t}{q_t} \\right]}{\\mathbb{E}_{\\mathcal{D}} \\left[ K \\left( \\frac{\pi_e(x_t) - a_t}{h} \\right) \\frac{r_t}{q_t}},
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by a behavior policy.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by behavior policy.
     Note that each action :math:`a_t` in the logged bandit data is a continuous variable.
     :math:`q_t` is a generalized propensity score that is defined as the conditional probability density of the behavior policy.
     :math:`K(\cdot)` is a kernel function such as the gaussian kernel, and :math:`h` is a bandwidth hyperparameter.
@@ -320,7 +320,7 @@ class KernelizedSelfNormalizedInverseProbabilityWeighting(
         A smaller value increases variance instead of reducing bias.
 
     estimator_name: str, default='kernelized_snipw'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ------------
@@ -341,7 +341,7 @@ class KernelizedSelfNormalizedInverseProbabilityWeighting(
         action_by_evaluation_policy: np.ndarray,
         **kwargs,
     ) -> np.ndarray:
-        """Estimate rewards for each round.
+        """Estimate round-wise (or sample-wise) rewards.
 
         Parameters
         ----------
@@ -349,19 +349,19 @@ class KernelizedSelfNormalizedInverseProbabilityWeighting(
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action_by_behavior_policy: array-like, shape (n_rounds,)
-            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Continuous action values sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Probability densities of the continuous action values sampled by a behavior policy
+            Probability densities of the continuous action values sampled by behavior policy
             (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_by_evaluation_policy: array-like, shape (n_rounds,)
-            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+            Continuous action values given by evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
 
         Returns
         ----------
         estimated_rewards: array-like, shape (n_rounds,)
-            Rewards estimated by KernelizedSNIPW for each round.
+            Rewards of each round estimated by KernelizedSNIPW.
 
         """
         if not isinstance(reward, np.ndarray):
@@ -392,7 +392,7 @@ class KernelizedDoublyRobust(BaseContinuousOffPolicyEstimator):
         \\hat{V}_{\\mathrm{Kernel-DR}} (\\pi_e; \\mathcal{D})
         := \\mathbb{E}_{\\mathcal{D}} \\left[ \\frac{1}{h} K \\left( \\frac{\pi_e(x_t) - a_t}{h} \\right) \\frac{(r_t - \\hat{q}(x_t, \\pi_e(x_t)))}{q_t} + \\hat{q}(x_t, \\pi_e(x_t)) \\right],
 
-    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by a behavior policy.
+    where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by behavior policy.
     Note that each action :math:`a_t` in the logged bandit data is a continuous variable.
     :math:`q_t` is a generalized propensity score that is defined as the conditional probability density of the behavior policy.
     :math:`K(\cdot)` is a kernel function such as the gaussian kernel, and :math:`h` is a bandwidth hyperparameter.
@@ -412,7 +412,7 @@ class KernelizedDoublyRobust(BaseContinuousOffPolicyEstimator):
         A smaller value increases variance instead of reducing bias.
 
     estimator_name: str, default='kernelized_dr'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ------------
@@ -443,7 +443,7 @@ class KernelizedDoublyRobust(BaseContinuousOffPolicyEstimator):
         estimated_rewards_by_reg_model: np.ndarray,
         **kwargs,
     ) -> np.ndarray:
-        """Estimate rewards for each round.
+        """Estimate round-wise (or sample-wise) rewards.
 
         Parameters
         ----------
@@ -451,22 +451,22 @@ class KernelizedDoublyRobust(BaseContinuousOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action_by_behavior_policy: array-like, shape (n_rounds,)
-            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Continuous action values sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Probability densities of the continuous action values sampled by a behavior policy
+            Probability densities of the continuous action values sampled by behavior policy
             (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_by_evaluation_policy: array-like, shape (n_rounds,)
-            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+            Continuous action values given by evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds,)
-            Expected rewards given context and action estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context and action estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
         estimated_rewards: array-like, shape (n_rounds,)
-            Rewards estimated by KernelizedDR for each round.
+            Rewards of each round estimated by KernelizedDR.
 
         """
         kernel_func = kernel_functions[self.kernel]
@@ -488,7 +488,7 @@ class KernelizedDoublyRobust(BaseContinuousOffPolicyEstimator):
         estimated_rewards_by_reg_model: np.ndarray,
         **kwargs,
     ) -> np.ndarray:
-        """Estimate policy value of an evaluation policy.
+        """Estimate policy value of evaluation policy.
 
         Parameters
         ----------
@@ -496,17 +496,17 @@ class KernelizedDoublyRobust(BaseContinuousOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action_by_behavior_policy: array-like, shape (n_rounds,)
-            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Continuous action values sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Probability densities of the continuous action values sampled by a behavior policy
+            Probability densities of the continuous action values sampled by behavior policy
             (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_by_evaluation_policy: array-like, shape (n_rounds,)
-            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+            Continuous action values given by evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds,)
-            Expected rewards given context and action estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context and action estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -559,20 +559,20 @@ class KernelizedDoublyRobust(BaseContinuousOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action_by_behavior_policy: array-like, shape (n_rounds,)
-            Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Continuous action values sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Probability densities of the continuous action values sampled by a behavior policy
+            Probability densities of the continuous action values sampled by behavior policy
             (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_by_evaluation_policy: array-like, shape (n_rounds,)
-            Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+            Continuous action values given by evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds,)
-            Expected rewards given context and action estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context and action estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.

--- a/obp/ope/estimators_continuous.py
+++ b/obp/ope/estimators_continuous.py
@@ -91,7 +91,6 @@ class KernelizedInverseProbabilityWeighting(BaseContinuousOffPolicyEstimator):
 
     Parameters
     ------------
-
     kernel: str
         Choice of kernel function.
         Must be one of "gaussian", "epanechnikov", "triangular", or "cosine".
@@ -118,7 +117,7 @@ class KernelizedInverseProbabilityWeighting(BaseContinuousOffPolicyEstimator):
     def __post_init__(self) -> None:
         if self.kernel not in ["gaussian", "epanechnikov", "triangular", "cosine"]:
             raise ValueError(
-                f"kernel must be one of 'gaussian', 'epanechnikov', 'triangular', and 'cosine' but {self.kernel} is given"
+                f"kernel must be one of 'gaussian', 'epanechnikov', 'triangular', or 'cosine' but {self.kernel} is given"
             )
         check_scalar(
             self.bandwidth, name="bandwidth", target_type=(int, float), min_val=0
@@ -313,7 +312,7 @@ class KernelizedSelfNormalizedInverseProbabilityWeighting(
     ------------
     kernel: str
         Choice of kernel function.
-        Must be one of "gaussian", "epanechnikov", and "triangular".
+        Must be one of "gaussian", "epanechnikov", "triangular", or "cosine".
 
      bandwidth: float
         A bandwidth hyperparameter.
@@ -376,7 +375,7 @@ class KernelizedSelfNormalizedInverseProbabilityWeighting(
         u = action_by_evaluation_policy - action_by_behavior_policy
         u /= self.bandwidth
         estimated_rewards = kernel_func(u) * reward / pscore
-        estimated_rewards /= (kernel_func(u) / pscore).sum() / reward.shape[0]
+        estimated_rewards /= (kernel_func(u) / pscore).mean()
         return estimated_rewards
 
 
@@ -405,7 +404,7 @@ class KernelizedDoublyRobust(BaseContinuousOffPolicyEstimator):
     ------------
     kernel: str
         Choice of kernel function.
-        Must be one of "gaussian", "epanechnikov", and "triangular".
+        Must be one of "gaussian", "epanechnikov", "triangular", or "cosine".
 
      bandwidth: float
         A bandwidth hyperparameter.
@@ -429,7 +428,7 @@ class KernelizedDoublyRobust(BaseContinuousOffPolicyEstimator):
     def __post_init__(self) -> None:
         if self.kernel not in ["gaussian", "epanechnikov", "triangular", "cosine"]:
             raise ValueError(
-                f"kernel must be one of 'gaussian', 'epanechnikov', 'triangular', and 'cosine' but {self.kernel} is given"
+                f"kernel must be one of 'gaussian', 'epanechnikov', 'triangular', or 'cosine' but {self.kernel} is given"
             )
         check_scalar(
             self.bandwidth, name="bandwidth", target_type=(int, float), min_val=0

--- a/obp/ope/meta.py
+++ b/obp/ope/meta.py
@@ -193,7 +193,7 @@ class OffPolicyEvaluation:
         n_bootstrap_samples: int = 100,
         random_state: Optional[int] = None,
     ) -> Dict[str, Dict[str, float]]:
-        """Estimate confidence intervals of estimated policy values using a nonparametric bootstrap procedure.
+        """Estimate confidence intervals of policy values using nonparametric bootstrap procedure.
 
         Parameters
         ------------
@@ -219,7 +219,7 @@ class OffPolicyEvaluation:
         ----------
         policy_value_interval_dict: Dict[str, Dict[str, float]]
             Dictionary containing confidence intervals of estimated policy value estimated
-            using a nonparametric bootstrap procedure.
+            using nonparametric bootstrap procedure.
 
         """
         check_confidence_interval_arguments(
@@ -511,7 +511,7 @@ class OffPolicyEvaluation:
         Returns
         ----------
         eval_metric_ope_df: DataFrame
-            Evaluation metric for evaluating the estimation performance of OPE estimators.
+            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
 
         """
         eval_metric_ope_df = DataFrame(
@@ -544,7 +544,7 @@ class OffPolicyEvaluation:
         Parameters
         ----------
         policy_name_list: List[str]
-            List of the names of policies.
+            List of the names of evaluation policies.
 
         action_dist_list: List[array-like, shape (n_rounds, n_actions, len_list)]
             List of action choice probabilities by the evaluation policies (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.

--- a/obp/ope/meta_continuous.py
+++ b/obp/ope/meta_continuous.py
@@ -21,12 +21,12 @@ logger = getLogger(__name__)
 
 @dataclass
 class ContinuousOffPolicyEvaluation:
-    """Class to conduct off-policy evaluation for continuous actions with multiple off-policy estimators simultaneously.
+    """Class to conduct OPE using multiple estimators simultaneously.
 
     Parameters
     -----------
     bandit_feedback: BanditFeedback
-        Logged bandit feedback data with continuous actions used for off-policy evaluation.
+        Logged bandit feedback data with continuous actions used to conduct OPE.
 
     ope_estimators: List[BaseOffPolicyEstimator]
         List of OPE estimators used to evaluate the policy value of evaluation policy.
@@ -167,15 +167,15 @@ class ContinuousOffPolicyEvaluation:
             Union[np.ndarray, Dict[str, np.ndarray]]
         ] = None,
     ) -> Dict[str, float]:
-        """Estimate policy value of an evaluation policy.
+        """Estimate policy value of evaluation policy.
 
         Parameters
         ------------
         action_by_evaluation_policy: array-like, shape (n_rounds,)
-            Continuous action values given by the evaluation policy, i.e., :math:`\\pi_e(x_t)`.
+            Continuous action values given by evaluation policy, i.e., :math:`\\pi_e(x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds,) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
@@ -208,7 +208,7 @@ class ContinuousOffPolicyEvaluation:
         n_bootstrap_samples: int = 100,
         random_state: Optional[int] = None,
     ) -> Dict[str, Dict[str, float]]:
-        """Estimate confidence intervals of estimated policy values using a nonparametric bootstrap procedure.
+        """Estimate confidence intervals of policy values by nonparametric bootstrap procedure.
 
         Parameters
         ------------
@@ -216,13 +216,13 @@ class ContinuousOffPolicyEvaluation:
             Continuous action values given by the (deterministic) evaluation policy, i.e., :math:`\\pi_e(x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -234,7 +234,7 @@ class ContinuousOffPolicyEvaluation:
         ----------
         policy_value_interval_dict: Dict[str, Dict[str, float]]
             Dictionary containing confidence intervals of estimated policy value estimated
-            using a nonparametric bootstrap procedure.
+            using nonparametric bootstrap procedure.
 
         """
         check_confidence_interval_arguments(
@@ -267,7 +267,7 @@ class ContinuousOffPolicyEvaluation:
         n_bootstrap_samples: int = 100,
         random_state: Optional[int] = None,
     ) -> Tuple[DataFrame, DataFrame]:
-        """Summarize policy values estimated by OPE estimators and their confidence intervals estimated by a nonparametric bootstrap procedure.
+        """Summarize policy values and their confidence intervals estimated by OPE estimators.
 
         Parameters
         ------------
@@ -275,13 +275,13 @@ class ContinuousOffPolicyEvaluation:
             Continuous action values given by the (deterministic) evaluation policy, i.e., :math:`\\pi_e(x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -292,7 +292,7 @@ class ContinuousOffPolicyEvaluation:
         Returns
         ----------
         (policy_value_df, policy_value_interval_df): Tuple[DataFrame, DataFrame]
-            Estimated policy values and their confidence intervals by OPE estimators.
+            Policy values and their confidence intervals estimated by OPE estimators.
 
         """
         policy_value_df = DataFrame(
@@ -345,13 +345,13 @@ class ContinuousOffPolicyEvaluation:
             Continuous action values given by the (deterministic) evaluation policy, i.e., :math:`\\pi_e(x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -421,11 +421,11 @@ class ContinuousOffPolicyEvaluation:
         ] = None,
         metric: str = "relative-ee",
     ) -> Dict[str, float]:
-        """Evaluate estimation performances of OPE estimators.
+        """Evaluate estimation performance of OPE estimators.
 
         Note
         ------
-        Evaluate the estimation performances of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
+        Evaluate the estimation performance of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
 
         .. math ::
             \\text{Relative-EE} (\\hat{V}; \\mathcal{D}) = \\left|  \\frac{\\hat{V}(\\pi; \\mathcal{D}) - V(\\pi)}{V(\\pi)} \\right|,
@@ -439,14 +439,14 @@ class ContinuousOffPolicyEvaluation:
         Parameters
         ----------
         ground_truth policy value: float
-            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
-            With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as its ground-truth.
+            Ground_truth policy value of evaluation policy, i.e., :math:`V(\\pi)`.
+            With Open Bandit Dataset, we use an on-policy estimate of the policy value as its ground-truth.
 
         action_by_evaluation_policy: array-like, shape (n_rounds,)
             Continuous action values given by the (deterministic) evaluation policy, i.e., :math:`\\pi_e(x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
@@ -502,19 +502,19 @@ class ContinuousOffPolicyEvaluation:
         ] = None,
         metric: str = "relative-ee",
     ) -> DataFrame:
-        """Summarize performance comparisons of OPE estimators.
+        """Summarize performance comparison of OPE estimators.
 
         Parameters
         ----------
         ground_truth policy value: float
-            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
-            With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as ground-truth.
+            Ground_truth policy value of evaluation policy, i.e., :math:`V(\\pi)`.
+            With Open Bandit Dataset, we use an on-policy estimate of the policy value as ground-truth.
 
         action_by_evaluation_policy: array-like, shape (n_rounds,)
             Continuous action values given by the (deterministic) evaluation policy, i.e., :math:`\\pi_e(x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         metric: str, default="relative-ee"
@@ -524,7 +524,7 @@ class ContinuousOffPolicyEvaluation:
         Returns
         ----------
         eval_metric_ope_df: DataFrame
-            Evaluation metric for evaluating the estimation performance of OPE estimators.
+            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
 
         """
         eval_metric_ope_df = DataFrame(
@@ -557,19 +557,19 @@ class ContinuousOffPolicyEvaluation:
         Parameters
         ----------
         policy_name_list: List[str]
-            List of the names of policies.
+            List of the names of evaluation policies.
 
         action_by_evaluation_policy_list: List[array-like, shape (n_rounds, n_actions, len_list)]
             List of action values given by the (deterministic) evaluation policies, i.e., :math:`\\pi_e(x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of an estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.

--- a/obp/ope/meta_continuous.py
+++ b/obp/ope/meta_continuous.py
@@ -1,0 +1,601 @@
+# Copyright (c) Yuta Saito, Yusuke Narita, and ZOZO Technologies, Inc. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+"""Off-Policy Evaluation Class to Streamline OPE."""
+from dataclasses import dataclass
+from logging import getLogger
+from typing import Dict, List, Optional, Tuple, Union
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from pandas import DataFrame
+import seaborn as sns
+
+from .estimators_continuous import BaseContinuousOffPolicyEstimator
+from ..types import BanditFeedback
+from ..utils import check_confidence_interval_arguments
+
+logger = getLogger(__name__)
+
+
+@dataclass
+class ContinuousOffPolicyEvaluation:
+    """Class to conduct off-policy evaluation for continuous actions with multiple off-policy estimators simultaneously.
+
+    Parameters
+    -----------
+    bandit_feedback: BanditFeedback
+        Logged bandit feedback data with continuous actions used for off-policy evaluation.
+
+    ope_estimators: List[BaseOffPolicyEstimator]
+        List of OPE estimators used to evaluate the policy value of evaluation policy.
+        Estimators must follow the interface of `obp.ope.BaseContinuousOffPolicyEstimator`.
+
+    Examples
+    ----------
+
+    .. code-block:: python
+
+
+    """
+
+    bandit_feedback: BanditFeedback
+    ope_estimators: List[BaseContinuousOffPolicyEstimator]
+
+    def __post_init__(self) -> None:
+        """Initialize class."""
+        for key_ in ["action", "reward", "pscore"]:
+            if key_ not in self.bandit_feedback:
+                raise RuntimeError(f"Missing key of {key_} in 'bandit_feedback'.")
+        self.bandit_feedback["action_by_behavior_policy"] = self.bandit_feedback[
+            "action"
+        ]
+        self.ope_estimators_ = dict()
+        for estimator in self.ope_estimators:
+            self.ope_estimators_[estimator.estimator_name] = estimator
+
+    def _create_estimator_inputs(
+        self,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[
+            Union[np.ndarray, Dict[str, np.ndarray]]
+        ] = None,
+    ) -> Dict[str, Dict[str, np.ndarray]]:
+        """Create input dictionary to estimate policy value by subclasses of `BaseOffPolicyEstimator`"""
+        if (
+            not isinstance(action_by_evaluation_policy, np.ndarray)
+            or action_by_evaluation_policy.ndim != 1
+        ):
+            raise ValueError(
+                "action_by_evaluation_policy must be 1-dimensional ndarray"
+            )
+        if estimated_rewards_by_reg_model is None:
+            logger.warning(
+                "`estimated_rewards_by_reg_model` is not given; model dependent estimators such as DM or DR cannot be used."
+            )
+        elif isinstance(estimated_rewards_by_reg_model, dict):
+            for estimator_name, value in estimated_rewards_by_reg_model.items():
+                if not isinstance(value, np.ndarray):
+                    raise ValueError(
+                        f"estimated_rewards_by_reg_model[{estimator_name}] must be ndarray"
+                    )
+                elif value.shape != action_by_evaluation_policy.shape:
+                    raise ValueError(
+                        f"estimated_rewards_by_reg_model[{estimator_name}].shape and action_by_evaluation_policy.shape must be the same"
+                    )
+        elif estimated_rewards_by_reg_model.shape != action_by_evaluation_policy.shape:
+            raise ValueError(
+                "estimated_rewards_by_reg_model.shape and action_by_evaluation_policy.shape must be the same"
+            )
+        estimator_inputs = {
+            estimator_name: {
+                input_: self.bandit_feedback[input_]
+                for input_ in ["reward", "action_by_behavior_policy", "pscore"]
+            }
+            for estimator_name in self.ope_estimators_
+        }
+
+        for estimator_name in self.ope_estimators_:
+            estimator_inputs[estimator_name][
+                "action_by_evaluation_policy"
+            ] = action_by_evaluation_policy
+            if isinstance(estimated_rewards_by_reg_model, dict):
+                if estimator_name in estimated_rewards_by_reg_model:
+                    estimator_inputs[estimator_name][
+                        "estimated_rewards_by_reg_model"
+                    ] = estimated_rewards_by_reg_model[estimator_name]
+                else:
+                    estimator_inputs[estimator_name][
+                        "estimated_rewards_by_reg_model"
+                    ] = None
+            else:
+                estimator_inputs[estimator_name][
+                    "estimated_rewards_by_reg_model"
+                ] = estimated_rewards_by_reg_model
+
+        return estimator_inputs
+
+    def estimate_policy_values(
+        self,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[
+            Union[np.ndarray, Dict[str, np.ndarray]]
+        ] = None,
+    ) -> Dict[str, float]:
+        """Estimate policy value of an evaluation policy.
+
+        Parameters
+        ------------
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the evaluation policy, i.e., :math:`\\pi_e(x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds,) or Dict[str, array-like], default=None
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            When an array-like is given, all OPE estimators use it.
+            When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
+            When it is not given, model-dependent estimators such as DM and DR cannot be used.
+
+        Returns
+        ----------
+        policy_value_dict: Dict[str, float]
+            Dictionary containing estimated policy values by OPE estimators.
+
+        """
+        policy_value_dict = dict()
+        estimator_inputs = self._create_estimator_inputs(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        for estimator_name, estimator in self.ope_estimators_.items():
+            policy_value_dict[estimator_name] = estimator.estimate_policy_value(
+                **estimator_inputs[estimator_name]
+            )
+
+        return policy_value_dict
+
+    def estimate_intervals(
+        self,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[
+            Union[np.ndarray, Dict[str, np.ndarray]]
+        ] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 100,
+        random_state: Optional[int] = None,
+    ) -> Dict[str, Dict[str, float]]:
+        """Estimate confidence intervals of estimated policy values using a nonparametric bootstrap procedure.
+
+        Parameters
+        ------------
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the (deterministic) evaluation policy, i.e., :math:`\\pi_e(x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            When an array-like is given, all OPE estimators use it.
+            When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
+            When it is not given, model-dependent estimators such as DM and DR cannot be used.
+
+        alpha: float, default=0.05
+            Significant level of confidence intervals.
+
+        n_bootstrap_samples: int, default=100
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        policy_value_interval_dict: Dict[str, Dict[str, float]]
+            Dictionary containing confidence intervals of estimated policy value estimated
+            using a nonparametric bootstrap procedure.
+
+        """
+        check_confidence_interval_arguments(
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+        policy_value_interval_dict = dict()
+        estimator_inputs = self._create_estimator_inputs(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        for estimator_name, estimator in self.ope_estimators_.items():
+            policy_value_interval_dict[estimator_name] = estimator.estimate_interval(
+                **estimator_inputs[estimator_name],
+                alpha=alpha,
+                n_bootstrap_samples=n_bootstrap_samples,
+                random_state=random_state,
+            )
+
+        return policy_value_interval_dict
+
+    def summarize_off_policy_estimates(
+        self,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[
+            Union[np.ndarray, Dict[str, np.ndarray]]
+        ] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 100,
+        random_state: Optional[int] = None,
+    ) -> Tuple[DataFrame, DataFrame]:
+        """Summarize policy values estimated by OPE estimators and their confidence intervals estimated by a nonparametric bootstrap procedure.
+
+        Parameters
+        ------------
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the (deterministic) evaluation policy, i.e., :math:`\\pi_e(x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            When an array-like is given, all OPE estimators use it.
+            When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
+            When it is not given, model-dependent estimators such as DM and DR cannot be used.
+
+        alpha: float, default=0.05
+            Significant level of confidence intervals.
+
+        n_bootstrap_samples: int, default=100
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        (policy_value_df, policy_value_interval_df): Tuple[DataFrame, DataFrame]
+            Estimated policy values and their confidence intervals by OPE estimators.
+
+        """
+        policy_value_df = DataFrame(
+            self.estimate_policy_values(
+                action_by_evaluation_policy=action_by_evaluation_policy,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            ),
+            index=["estimated_policy_value"],
+        )
+        policy_value_interval_df = DataFrame(
+            self.estimate_intervals(
+                action_by_evaluation_policy=action_by_evaluation_policy,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                alpha=alpha,
+                n_bootstrap_samples=n_bootstrap_samples,
+                random_state=random_state,
+            )
+        )
+        policy_value_of_behavior_policy = self.bandit_feedback["reward"].mean()
+        policy_value_df = policy_value_df.T
+        if policy_value_of_behavior_policy <= 0:
+            logger.warning(
+                f"Policy value of the behavior policy is {policy_value_of_behavior_policy} (<=0); relative estimated policy value is set to np.nan"
+            )
+            policy_value_df["relative_estimated_policy_value"] = np.nan
+        else:
+            policy_value_df["relative_estimated_policy_value"] = (
+                policy_value_df.estimated_policy_value / policy_value_of_behavior_policy
+            )
+        return policy_value_df, policy_value_interval_df.T
+
+    def visualize_off_policy_estimates(
+        self,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[
+            Union[np.ndarray, Dict[str, np.ndarray]]
+        ] = None,
+        alpha: float = 0.05,
+        is_relative: bool = False,
+        n_bootstrap_samples: int = 100,
+        random_state: Optional[int] = None,
+        fig_dir: Optional[Path] = None,
+        fig_name: str = "estimated_policy_value.png",
+    ) -> None:
+        """Visualize policy values estimated by OPE estimators.
+
+        Parameters
+        ----------
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the (deterministic) evaluation policy, i.e., :math:`\\pi_e(x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            When an array-like is given, all OPE estimators use it.
+            When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
+            When it is not given, model-dependent estimators such as DM and DR cannot be used.
+
+        alpha: float, default=0.05
+            Significant level of confidence intervals.
+
+        n_bootstrap_samples: int, default=100
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        is_relative: bool, default=False,
+            If True, the method visualizes the estimated policy values of evaluation policy
+            relative to the ground-truth policy value of behavior policy.
+
+        fig_dir: Path, default=None
+            Path to store the bar figure.
+            If 'None' is given, the figure will not be saved.
+
+        fig_name: str, default="estimated_policy_value.png"
+            Name of the bar figure.
+
+        """
+        if fig_dir is not None:
+            assert isinstance(fig_dir, Path), "fig_dir must be a Path"
+        if fig_name is not None:
+            assert isinstance(fig_name, str), "fig_dir must be a string"
+
+        estimated_round_rewards_dict = dict()
+        estimator_inputs = self._create_estimator_inputs(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        for estimator_name, estimator in self.ope_estimators_.items():
+            estimated_round_rewards_dict[
+                estimator_name
+            ] = estimator._estimate_round_rewards(**estimator_inputs[estimator_name])
+        estimated_round_rewards_df = DataFrame(estimated_round_rewards_dict)
+        estimated_round_rewards_df.rename(
+            columns={key: key.upper() for key in estimated_round_rewards_dict.keys()},
+            inplace=True,
+        )
+        if is_relative:
+            estimated_round_rewards_df /= self.bandit_feedback["reward"].mean()
+
+        plt.style.use("ggplot")
+        fig, ax = plt.subplots(figsize=(8, 6))
+        sns.barplot(
+            data=estimated_round_rewards_df,
+            ax=ax,
+            ci=100 * (1 - alpha),
+            n_boot=n_bootstrap_samples,
+            seed=random_state,
+        )
+        plt.xlabel("OPE Estimators", fontsize=25)
+        plt.ylabel(
+            f"Estimated Policy Value (± {np.int(100*(1 - alpha))}% CI)", fontsize=20
+        )
+        plt.yticks(fontsize=15)
+        plt.xticks(fontsize=25 - 2 * len(self.ope_estimators))
+
+        if fig_dir:
+            fig.savefig(str(fig_dir / fig_name))
+
+    def evaluate_performance_of_estimators(
+        self,
+        ground_truth_policy_value: float,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[
+            Union[np.ndarray, Dict[str, np.ndarray]]
+        ] = None,
+        metric: str = "relative-ee",
+    ) -> Dict[str, float]:
+        """Evaluate estimation performances of OPE estimators.
+
+        Note
+        ------
+        Evaluate the estimation performances of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
+
+        .. math ::
+            \\text{Relative-EE} (\\hat{V}; \\mathcal{D}) = \\left|  \\frac{\\hat{V}(\\pi; \\mathcal{D}) - V(\\pi)}{V(\\pi)} \\right|,
+
+        .. math ::
+            \\text{SE} (\\hat{V}; \\mathcal{D}) = \\left(\\hat{V}(\\pi; \\mathcal{D}) - V(\\pi) \\right)^2,
+
+        where :math:`V({\\pi})` is the ground-truth policy value of the evalation policy :math:`\\pi_e` (often estimated using on-policy estimation).
+        :math:`\\hat{V}(\\pi; \\mathcal{D})` is an estimated policy value by an OPE estimator :math:`\\hat{V}` and logged bandit feedback :math:`\\mathcal{D}`.
+
+        Parameters
+        ----------
+        ground_truth policy value: float
+            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
+            With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as its ground-truth.
+
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the (deterministic) evaluation policy, i.e., :math:`\\pi_e(x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            When an array-like is given, all OPE estimators use it.
+            When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
+            When it is not given, model-dependent estimators such as DM and DR cannot be used.
+
+        metric: str, default="relative-ee"
+            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
+            Must be "relative-ee" or "se".
+
+        Returns
+        ----------
+        eval_metric_ope_dict: Dict[str, float]
+            Dictionary containing evaluation metric for evaluating the estimation performance of OPE estimators.
+
+        """
+
+        if not isinstance(ground_truth_policy_value, float):
+            raise ValueError(
+                f"ground_truth_policy_value must be a float, but {ground_truth_policy_value} is given"
+            )
+        if metric not in ["relative-ee", "se"]:
+            raise ValueError(
+                f"metric must be either 'relative-ee' or 'se', but {metric} is given"
+            )
+        if metric == "relative-ee" and ground_truth_policy_value == 0.0:
+            raise ValueError(
+                "ground_truth_policy_value must be non-zero when metric is relative-ee"
+            )
+
+        eval_metric_ope_dict = dict()
+        estimator_inputs = self._create_estimator_inputs(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        for estimator_name, estimator in self.ope_estimators_.items():
+            estimated_policy_value = estimator.estimate_policy_value(
+                **estimator_inputs[estimator_name]
+            )
+            if metric == "relative-ee":
+                relative_ee_ = estimated_policy_value - ground_truth_policy_value
+                relative_ee_ /= ground_truth_policy_value
+                eval_metric_ope_dict[estimator_name] = np.abs(relative_ee_)
+            elif metric == "se":
+                se_ = (estimated_policy_value - ground_truth_policy_value) ** 2
+                eval_metric_ope_dict[estimator_name] = se_
+        return eval_metric_ope_dict
+
+    def summarize_estimators_comparison(
+        self,
+        ground_truth_policy_value: float,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[
+            Union[np.ndarray, Dict[str, np.ndarray]]
+        ] = None,
+        metric: str = "relative-ee",
+    ) -> DataFrame:
+        """Summarize performance comparisons of OPE estimators.
+
+        Parameters
+        ----------
+        ground_truth policy value: float
+            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
+            With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as ground-truth.
+
+        action_by_evaluation_policy: array-like, shape (n_rounds,)
+            Continuous action values given by the (deterministic) evaluation policy, i.e., :math:`\\pi_e(x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            When it is not given, model-dependent estimators such as DM and DR cannot be used.
+
+        metric: str, default="relative-ee"
+            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
+            Must be either "relative-ee" or "se".
+
+        Returns
+        ----------
+        eval_metric_ope_df: DataFrame
+            Evaluation metric for evaluating the estimation performance of OPE estimators.
+
+        """
+        eval_metric_ope_df = DataFrame(
+            self.evaluate_performance_of_estimators(
+                ground_truth_policy_value=ground_truth_policy_value,
+                action_by_evaluation_policy=action_by_evaluation_policy,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                metric=metric,
+            ),
+            index=[metric],
+        )
+        return eval_metric_ope_df.T
+
+    def visualize_off_policy_estimates_of_multiple_policies(
+        self,
+        policy_name_list: List[str],
+        action_by_evaluation_policy_list: List[np.ndarray],
+        estimated_rewards_by_reg_model: Optional[
+            Union[np.ndarray, Dict[str, np.ndarray]]
+        ] = None,
+        alpha: float = 0.05,
+        is_relative: bool = False,
+        n_bootstrap_samples: int = 100,
+        random_state: Optional[int] = None,
+        fig_dir: Optional[Path] = None,
+        fig_name: str = "estimated_policy_value.png",
+    ) -> None:
+        """Visualize policy values estimated by OPE estimators.
+
+        Parameters
+        ----------
+        policy_name_list: List[str]
+            List of the names of policies.
+
+        action_by_evaluation_policy_list: List[array-like, shape (n_rounds, n_actions, len_list)]
+            List of action values given by the (deterministic) evaluation policies, i.e., :math:`\\pi_e(x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            When an array-like is given, all OPE estimators use it.
+            When a dict is given, if the dict has the name of an estimator as a key, the corresponding value is used.
+            When it is not given, model-dependent estimators such as DM and DR cannot be used.
+
+        alpha: float, default=0.05
+            Significant level of confidence intervals.
+
+        n_bootstrap_samples: int, default=100
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        is_relative: bool, default=False,
+            If True, the method visualizes the estimated policy values of evaluation policy
+            relative to the ground-truth policy value of behavior policy.
+
+        fig_dir: Path, default=None
+            Path to store the bar figure.
+            If 'None' is given, the figure will not be saved.
+
+        fig_name: str, default="estimated_policy_value.png"
+            Name of the bar figure.
+
+        """
+        if len(policy_name_list) != len(action_by_evaluation_policy_list):
+            raise ValueError(
+                "the length of policy_name_list must be the same as action_by_evaluation_policy_list"
+            )
+        if fig_dir is not None:
+            assert isinstance(fig_dir, Path), "fig_dir must be a Path"
+        if fig_name is not None:
+            assert isinstance(fig_name, str), "fig_dir must be a string"
+
+        estimated_round_rewards_dict = {
+            estimator_name: {} for estimator_name in self.ope_estimators_
+        }
+
+        for policy_name, action_by_evaluation_policy in zip(
+            policy_name_list, action_by_evaluation_policy_list
+        ):
+            estimator_inputs = self._create_estimator_inputs(
+                action_by_evaluation_policy=action_by_evaluation_policy,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            )
+            for estimator_name, estimator in self.ope_estimators_.items():
+                estimated_round_rewards_dict[estimator_name][
+                    policy_name
+                ] = estimator._estimate_round_rewards(
+                    **estimator_inputs[estimator_name]
+                )
+
+        plt.style.use("ggplot")
+        fig = plt.figure(figsize=(8, 6.2 * len(self.ope_estimators_)))
+
+        for i, estimator_name in enumerate(self.ope_estimators_):
+            estimated_round_rewards_df = DataFrame(
+                estimated_round_rewards_dict[estimator_name]
+            )
+            if is_relative:
+                estimated_round_rewards_df /= self.bandit_feedback["reward"].mean()
+
+            ax = fig.add_subplot(len(action_by_evaluation_policy_list), 1, i + 1)
+            sns.barplot(
+                data=estimated_round_rewards_df,
+                ax=ax,
+                ci=100 * (1 - alpha),
+                n_boot=n_bootstrap_samples,
+                seed=random_state,
+            )
+            ax.set_title(estimator_name.upper(), fontsize=20)
+            ax.set_ylabel(
+                f"Estimated Policy Value (± {np.int(100*(1 - alpha))}% CI)", fontsize=20
+            )
+            plt.yticks(fontsize=15)
+            plt.xticks(fontsize=25 - 2 * len(policy_name_list))
+
+        if fig_dir:
+            fig.savefig(str(fig_dir / fig_name))

--- a/obp/ope/meta_continuous.py
+++ b/obp/ope/meta_continuous.py
@@ -37,6 +37,50 @@ class ContinuousOffPolicyEvaluation:
 
     .. code-block:: python
 
+        # a case of implementing OPE (with continuous actions) of an synthetic evaluation policy
+        >>> from obp.dataset import (
+                SyntheticContinuousBanditDataset,
+                linear_reward_funcion_continuous,
+                linear_behavior_policy_continuous,
+                linear_synthetic_policy_continuous
+            )
+        >>> from obp.ope import (
+                ContinuousOffPolicyEvaluation,
+                KernelizedInverseProbabilityWeighting as KernelizedIPW
+            )
+
+        # (1) Synthetic Data Generation
+        >>> dataset = SyntheticContinuousBanditDataset(
+                dim_context=5,
+                reward_function=linear_reward_funcion_continuous,
+                behavior_policy_function=linear_behavior_policy_continuous,
+                random_state=12345,
+            )
+        >>> bandit_feedback = dataset.obtain_batch_bandit_feedback(
+                n_rounds=10000, min_action_value=-10, max_action_value=10,
+            )
+
+        # (2) Synthetic Evaluation Policy
+        >>> action_by_evaluation_policy = linear_synthetic_policy_continuous(
+                context=bandit_feedback["context"]
+            )
+
+        # (3) Off-Policy Evaluation
+        >>> ope = ContinuousOffPolicyEvaluation(
+                bandit_feedback=bandit_feedback,
+                ope_estimators=[KernelizedIPW(kernel="epanechnikov", bandwidth=0.02)]
+            )
+        >>> estimated_policy_value = ope.estimate_policy_values(
+                action_by_evaluation_policy=action_by_evaluation_policy,
+            )
+        >>> estimated_policy_value
+        {'kernelized_ipw': 2.2858905015106723}
+
+        # (4) Ground-truth Policy Value of the Synthetic Evaluation Policy
+        >>> dataset.calc_ground_truth_policy_value(
+                context=bandit_feedback["context"], action=action_by_evaluation_policy
+            )
+        2.2893029243895215
 
     """
 

--- a/obp/ope/meta_slate.py
+++ b/obp/ope/meta_slate.py
@@ -202,7 +202,7 @@ class SlateOffPolicyEvaluation:
         n_bootstrap_samples: int = 100,
         random_state: Optional[int] = None,
     ) -> Dict[str, Dict[str, float]]:
-        """Estimate confidence intervals of estimated policy values using a nonparametric bootstrap procedure.
+        """Estimate confidence intervals of policy values using nonparametric bootstrap procedure.
 
         Parameters
         ------------
@@ -228,7 +228,7 @@ class SlateOffPolicyEvaluation:
         ----------
         policy_value_interval_dict: Dict[str, Dict[str, float]]
             Dictionary containing confidence intervals of estimated policy value estimated
-            using a nonparametric bootstrap procedure.
+            using nonparametric bootstrap procedure.
 
         """
         check_confidence_interval_arguments(
@@ -530,7 +530,7 @@ class SlateOffPolicyEvaluation:
         Returns
         ----------
         eval_metric_ope_df: DataFrame
-            Evaluation metric for evaluating the estimation performance of OPE estimators.
+            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
 
         """
         eval_metric_ope_df = DataFrame(

--- a/obp/ope/regression_model.py
+++ b/obp/ope/regression_model.py
@@ -33,8 +33,8 @@ class RegressionModel(BaseEstimator):
         When Open Bandit Dataset is used, 3 should be set.
 
     action_context: array-like, shape (n_actions, dim_action_context), default=None
-        Context vector characterizing each action, vector representation of each action.
-        If not given, then one-hot encoding of the action variable is automatically used.
+        Context vector characterizing action (i.e., vector representation of each action).
+        If not given, one-hot encoding of the action variable is used as default.
 
     fitting_method: str, default='normal'
         Method to fit the regression model.
@@ -102,18 +102,17 @@ class RegressionModel(BaseEstimator):
         Parameters
         ----------
         context: array-like, shape (n_rounds, dim_context)
-            Context vectors in each round, i.e., :math:`x_t`.
+            Context vectors observed in each round of the logged bandit feedback, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
             Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
-            Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
-        pscore: array-like, shape (n_rounds,), default=None
-            Action choice probabilities (propensity score) of a behavior policy
-            in the training logged bandit feedback.
-            When None is given, the behavior policy is assumed to be a uniform one.
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            When None is given, behavior policy is assumed to be uniform.
 
         position: array-like, shape (n_rounds,), default=None
             Positions of each round in the given logged bandit feedback.
@@ -193,12 +192,12 @@ class RegressionModel(BaseEstimator):
         Parameters
         -----------
         context: array-like, shape (n_rounds_of_new_data, dim_context)
-            Context vectors for new data.
+            Context vectors of new data.
 
         Returns
         -----------
         estimated_rewards_by_reg_model: array-like, shape (n_rounds_of_new_data, n_actions, len_list)
-            Estimated expected rewards for new data by the regression model.
+            Expected rewards of new data estimated by the regression model.
 
         """
         n_rounds_of_new_data = context.shape[0]
@@ -246,7 +245,7 @@ class RegressionModel(BaseEstimator):
         Parameters
         ----------
         context: array-like, shape (n_rounds, dim_context)
-            Context vectors in each round, i.e., :math:`x_t`.
+            Context vectors observed in each round of the logged bandit feedback, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
             Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
@@ -280,7 +279,7 @@ class RegressionModel(BaseEstimator):
         Returns
         -----------
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Estimated expected rewards for new data by the regression model.
+            Expected rewards of new data estimated by the regression model.
 
         """
         check_bandit_feedback_inputs(
@@ -361,7 +360,7 @@ class RegressionModel(BaseEstimator):
         action: np.ndarray,
         action_context: np.ndarray,
     ) -> np.ndarray:
-        """Preprocess feature vectors to train a give regression model.
+        """Preprocess feature vectors to train a regression model.
 
         Note
         -----
@@ -371,13 +370,13 @@ class RegressionModel(BaseEstimator):
         Parameters
         -----------
         context: array-like, shape (n_rounds,)
-            Context vectors in the training logged bandit feedback.
+            Context vectors observed in each round of the logged bandit feedback, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
             Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         action_context: array-like, shape shape (n_actions, dim_action_context)
-            Context vector characterizing each action, vector representation of each action.
+            Context vector characterizing action (i.e., vector representation of each action).
 
         """
         return np.c_[context, action_context[action]]

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -331,6 +331,150 @@ def check_ope_inputs(
             raise ValueError("pscore must be positive")
 
 
+def check_continuous_bandit_feedback_inputs(
+    context: np.ndarray,
+    action_by_behavior_policy: np.ndarray,
+    reward: np.ndarray,
+    expected_reward: Optional[np.ndarray] = None,
+    pscore: Optional[np.ndarray] = None,
+) -> Optional[ValueError]:
+    """Check inputs for bandit learning or simulation with continuous actions.
+
+    Parameters
+    -----------
+    context: array-like, shape (n_rounds, dim_context)
+        Context vectors in each round, i.e., :math:`x_t`.
+
+    action_by_behavior_policy: array-like, shape (n_rounds,)
+        Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+    reward: array-like, shape (n_rounds,)
+        Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
+
+    expected_reward: array-like, shape (n_rounds, n_actions), default=None
+        Expected rewards (or outcome) in each round, i.e., :math:`\\mathbb{E}[r_t]`.
+
+    pscore: array-like, shape (n_rounds,), default=None
+        Probability densities of the continuous action values sampled by a behavior policy
+        (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+    """
+    if not isinstance(context, np.ndarray) or context.ndim != 2:
+        raise ValueError("context must be 2-dimensional ndarray")
+    if (
+        not isinstance(action_by_behavior_policy, np.ndarray)
+        or action_by_behavior_policy.ndim != 1
+    ):
+        raise ValueError("action_by_behavior_policy must be 1-dimensional ndarray")
+    if not isinstance(reward, np.ndarray) or reward.ndim != 1:
+        raise ValueError("reward must be 1-dimensional ndarray")
+
+    if expected_reward is not None:
+        if not isinstance(expected_reward, np.ndarray) or expected_reward.ndim != 1:
+            raise ValueError("expected_reward must be 1-dimensional ndarray")
+        if not (
+            context.shape[0]
+            == action_by_behavior_policy.shape[0]
+            == reward.shape[0]
+            == expected_reward.shape[0]
+        ):
+            raise ValueError(
+                "context, action, reward, and expected_reward must be the same size."
+            )
+    if pscore is not None:
+        if not isinstance(pscore, np.ndarray) or pscore.ndim != 1:
+            raise ValueError("pscore must be 1-dimensional ndarray")
+        if not (
+            context.shape[0]
+            == action_by_behavior_policy.shape[0]
+            == reward.shape[0]
+            == pscore.shape[0]
+        ):
+            raise ValueError(
+                "context, action, reward, and pscore must be the same size."
+            )
+        if np.any(pscore <= 0):
+            raise ValueError("pscore must be positive")
+
+
+def check_continuous_ope_inputs(
+    action_by_evaluation_policy: np.ndarray,
+    action_by_behavior_policy: Optional[np.ndarray] = None,
+    reward: Optional[np.ndarray] = None,
+    pscore: Optional[np.ndarray] = None,
+    estimated_rewards_by_reg_model: Optional[np.ndarray] = None,
+) -> Optional[ValueError]:
+    """Check inputs for OPE with continuous actions.
+
+    Parameters
+    -----------
+    action_by_behavior_policy: array-like, shape (n_rounds,)
+        Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+    action_by_evaluation_policy: array-like, shape (n_rounds,), default=None
+        Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+
+    reward: array-like, shape (n_rounds,), default=None
+        Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
+
+    pscore: array-like, shape (n_rounds,), default=None
+        Probability densities of the continuous action values sampled by a behavior policy
+        (generalized propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+    estimated_rewards_by_reg_model: array-like, shape (n_rounds,), default=None
+            Expected rewards given context and action estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+    """
+    # action_by_evaluation_policy
+    if (
+        not isinstance(action_by_evaluation_policy, np.ndarray)
+        or action_by_evaluation_policy.ndim != 1
+    ):
+        raise ValueError("action_by_evaluation_policy must be 1-dimensional ndarray")
+
+    # estimated_rewards_by_reg_model
+    if estimated_rewards_by_reg_model is not None:
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray) or estimated_rewards_by_reg_model.ndim != 1:
+            raise ValueError("estimated_rewards_by_reg_model must be 1-dimensional ndarray")
+        if estimated_rewards_by_reg_model.shape[0] != action_by_evaluation_policy.shape[0]:
+            raise ValueError(
+                "estimated_rewards_by_reg_model and action_by_evaluation_policy must be the same size"
+            )
+
+    # action, reward
+    if action_by_behavior_policy is not None or reward is not None:
+        if (
+            not isinstance(action_by_behavior_policy, np.ndarray)
+            or action_by_behavior_policy.ndim != 1
+        ):
+            raise ValueError("action_by_behavior_policy must be 1-dimensional ndarray")
+        if not isinstance(reward, np.ndarray) or reward.ndim != 1:
+            raise ValueError("reward must be 1-dimensional ndarray")
+        if not (action_by_behavior_policy.shape[0] == reward.shape[0]):
+            raise ValueError(
+                "action_by_behavior_policy and reward must be the same size"
+            )
+        if not (
+            action_by_behavior_policy.shape[0] == action_by_evaluation_policy.shape[0]
+        ):
+            raise ValueError(
+                "action_by_behavior_policy and action_by_evaluation_policy must be the same size"
+            )
+
+    # pscore
+    if pscore is not None:
+        if not isinstance(pscore, np.ndarray) or pscore.ndim != 1:
+            raise ValueError("pscore must be 1-dimensional ndarray")
+        if not (
+            action_by_behavior_policy.shape[0] == reward.shape[0] == pscore.shape[0]
+        ):
+            raise ValueError(
+                "action_by_behavior_policy, reward, and pscore must be the same size"
+            )
+        if np.any(pscore <= 0):
+            raise ValueError("pscore must be positive")
+
+
 def _check_slate_ope_inputs(
     slate_id: np.ndarray,
     reward: np.ndarray,
@@ -342,6 +486,7 @@ def _check_slate_ope_inputs(
     """Check inputs of Slate OPE estimators.
 
     Parameters
+    -----------
     slate_id: array-like, shape (<= n_rounds * len_list,)
         Slate id observed in each round of the logged bandit feedback.
 

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -408,11 +408,11 @@ def check_continuous_ope_inputs(
 
     Parameters
     -----------
-    action_by_behavior_policy: array-like, shape (n_rounds,)
-        Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
-
-    action_by_evaluation_policy: array-like, shape (n_rounds,), default=None
+    action_by_evaluation_policy: array-like, shape (n_rounds,)
         Continuous action values given by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(x_t)`.
+
+    action_by_behavior_policy: array-like, shape (n_rounds,), default=None
+        Continuous action values sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
     reward: array-like, shape (n_rounds,), default=None
         Observed rewards (or outcome) in each round, i.e., :math:`r_t`.

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -434,9 +434,17 @@ def check_continuous_ope_inputs(
 
     # estimated_rewards_by_reg_model
     if estimated_rewards_by_reg_model is not None:
-        if not isinstance(estimated_rewards_by_reg_model, np.ndarray) or estimated_rewards_by_reg_model.ndim != 1:
-            raise ValueError("estimated_rewards_by_reg_model must be 1-dimensional ndarray")
-        if estimated_rewards_by_reg_model.shape[0] != action_by_evaluation_policy.shape[0]:
+        if (
+            not isinstance(estimated_rewards_by_reg_model, np.ndarray)
+            or estimated_rewards_by_reg_model.ndim != 1
+        ):
+            raise ValueError(
+                "estimated_rewards_by_reg_model must be 1-dimensional ndarray"
+            )
+        if (
+            estimated_rewards_by_reg_model.shape[0]
+            != action_by_evaluation_policy.shape[0]
+        ):
             raise ValueError(
                 "estimated_rewards_by_reg_model and action_by_evaluation_policy must be the same size"
             )

--- a/tests/ope/conftest.py
+++ b/tests/ope/conftest.py
@@ -13,6 +13,7 @@ from obp.dataset import (
     logistic_reward_function,
     linear_behavior_policy,
     SyntheticSlateBanditDataset,
+    SyntheticContinuousBanditDataset,
 )
 from obp.utils import sigmoid
 
@@ -20,7 +21,7 @@ from obp.utils import sigmoid
 os.environ["PY_IGNORE_IMPORTMISMATCH"] = "1"
 
 
-# generate synthetic dataset using SyntheticBanditDataset
+# generate synthetic bandit dataset using SyntheticBanditDataset
 @pytest.fixture(scope="session")
 def synthetic_bandit_feedback() -> BanditFeedback:
     n_actions = 10
@@ -38,7 +39,7 @@ def synthetic_bandit_feedback() -> BanditFeedback:
     return bandit_feedback
 
 
-# generate synthetic slate dataset using SyntheticBanditDataset
+# generate synthetic slate bandit dataset using SyntheticSlateBanditDataset
 @pytest.fixture(scope="session")
 def synthetic_slate_bandit_feedback() -> BanditFeedback:
     # set parameters
@@ -57,6 +58,28 @@ def synthetic_slate_bandit_feedback() -> BanditFeedback:
     )
     # obtain feedback
     bandit_feedback = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
+    return bandit_feedback
+
+
+# generate synthetic continuous bandit dataset using SyntheticContinuousBanditDataset
+@pytest.fixture(scope="session")
+def synthetic_continuous_bandit_feedback() -> BanditFeedback:
+    # set parameters
+    dim_context = 2
+    random_state = 12345
+    n_rounds = 100
+    min_action_value = -10
+    max_action_value = 10
+    dataset = SyntheticContinuousBanditDataset(
+        dim_context=dim_context,
+        random_state=random_state,
+    )
+    # obtain feedback
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(
+        n_rounds=n_rounds,
+        min_action_value=min_action_value,
+        max_action_value=max_action_value,
+    )
     return bandit_feedback
 
 

--- a/tests/ope/conftest.py
+++ b/tests/ope/conftest.py
@@ -72,14 +72,12 @@ def synthetic_continuous_bandit_feedback() -> BanditFeedback:
     max_action_value = 10
     dataset = SyntheticContinuousBanditDataset(
         dim_context=dim_context,
+        min_action_value=min_action_value,
+        max_action_value=max_action_value,
         random_state=random_state,
     )
     # obtain feedback
-    bandit_feedback = dataset.obtain_batch_bandit_feedback(
-        n_rounds=n_rounds,
-        min_action_value=min_action_value,
-        max_action_value=max_action_value,
-    )
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
     return bandit_feedback
 
 

--- a/tests/ope/test_dr_estimators_continuous.py
+++ b/tests/ope/test_dr_estimators_continuous.py
@@ -1,0 +1,369 @@
+import pytest
+import numpy as np
+
+from obp.ope import KernelizedDoublyRobust
+from obp.dataset import (
+    SyntheticContinuousBanditDataset,
+    linear_reward_funcion_continuous,
+    linear_behavior_policy_continuous,
+    linear_synthetic_policy_continuous,
+)
+
+
+def test_synthetic_init():
+    # kernel
+    with pytest.raises(ValueError):
+        KernelizedDoublyRobust(kernel="a", bandwidth=0.1)
+
+    with pytest.raises(ValueError):
+        KernelizedDoublyRobust(kernel=None, bandwidth=0.1)
+
+    # bandwidth
+    with pytest.raises(TypeError):
+        KernelizedDoublyRobust(kernel="gaussian", bandwidth="a")
+
+    with pytest.raises(TypeError):
+        KernelizedDoublyRobust(kernel="gaussian", bandwidth=None)
+
+    with pytest.raises(ValueError):
+        KernelizedDoublyRobust(kernel="gaussian", bandwidth=-1.0)
+
+
+# prepare dr instances
+dr = KernelizedDoublyRobust(kernel="cosine", bandwidth=0.1)
+
+# --- invalid inputs (all kernelized estimators) ---
+
+# action_by_evaluation_policy, estimated_rewards_by_reg_model, action_by_behavior_policy, reward, pscore, description
+invalid_input_of_dr = [
+    (
+        None,  #
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=5),
+        "action_by_evaluation_policy must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones((5, 1)),  #
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=5),
+        "action_by_evaluation_policy must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones(5),
+        None,  #
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=5),
+        "estimated_rewards_by_reg_model must be ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones((5, 1)),  #
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=5),
+        "estimated_rewards_by_reg_model must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones(5),  #
+        np.ones(4),  #
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=5),
+        "estimated_rewards_by_reg_model and action_by_evaluation_policy must be the same size",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        None,  #
+        np.ones(5),
+        np.random.uniform(size=5),
+        "action_by_behavior_policy must be ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones((5, 1)),  #
+        np.ones(5),
+        np.random.uniform(size=5),
+        "action_by_behavior_policy must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        None,  #
+        np.random.uniform(size=5),
+        "reward must be ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.ones((5, 1)),  #
+        np.random.uniform(size=5),
+        "reward must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(4),  #
+        np.ones(3),  #
+        np.random.uniform(size=5),
+        "action_by_behavior_policy and reward must be the same size",
+    ),
+    (
+        np.ones(5),  #
+        np.ones(5),
+        np.ones(4),  #
+        np.ones(4),
+        np.random.uniform(size=5),
+        "action_by_behavior_policy and action_by_evaluation_policy must be the same size",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        None,  #
+        "pscore must be ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=(5, 1)),  #
+        "pscore must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=4),  #
+        "action_by_behavior_policy, reward, and pscore must be the same size",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.arange(5),  #
+        "pscore must be positive",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, action_by_behavior_policy, reward, pscore, description",
+    invalid_input_of_dr,
+)
+def test_dr_continuous_using_invalid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    action_by_behavior_policy,
+    reward,
+    pscore,
+    description: str,
+) -> None:
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = dr.estimate_policy_value(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            action_by_behavior_policy=action_by_behavior_policy,
+            reward=reward,
+            pscore=pscore,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = dr.estimate_interval(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            action_by_behavior_policy=action_by_behavior_policy,
+            reward=reward,
+            pscore=pscore,
+        )
+
+
+# --- valid inputs (all kernelized estimators) ---
+
+# action_by_evaluation_policy, estimated_rewards_by_reg_model, action_by_behavior_policy, reward, pscore
+valid_input_of_dr = [
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=5),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, action_by_behavior_policy, reward, pscore",
+    valid_input_of_dr,
+)
+def test_dr_continuous_using_valid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    action_by_behavior_policy,
+    reward,
+    pscore,
+) -> None:
+    _ = dr.estimate_policy_value(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+    )
+
+
+# --- confidence intervals ---
+# alpha, n_bootstrap_samples, random_state, description
+invalid_input_of_estimate_intervals = [
+    (0.05, 100, "s", "random_state must be an integer"),
+    (0.05, -1, 1, "n_bootstrap_samples must be a positive integer"),
+    (0.05, "s", 1, "n_bootstrap_samples must be a positive integer"),
+    (0.0, 1, 1, "alpha must be a positive float (< 1)"),
+    (1.0, 1, 1, "alpha must be a positive float (< 1)"),
+    ("0", 1, 1, "alpha must be a positive float (< 1)"),
+]
+
+valid_input_of_estimate_intervals = [
+    (0.05, 100, 1, "random_state is 1"),
+    (0.05, 1, 1, "n_bootstrap_samples is 1"),
+]
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, action_by_behavior_policy, reward, pscore",
+    valid_input_of_dr,
+)
+@pytest.mark.parametrize(
+    "alpha, n_bootstrap_samples, random_state, description",
+    invalid_input_of_estimate_intervals,
+)
+def test_estimate_intervals_of_all_estimators_using_invalid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    action_by_behavior_policy,
+    reward,
+    pscore,
+    alpha,
+    n_bootstrap_samples,
+    random_state,
+    description,
+) -> None:
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = dr.estimate_interval(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            action_by_behavior_policy=action_by_behavior_policy,
+            reward=reward,
+            pscore=pscore,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, action_by_behavior_policy, reward, pscore",
+    valid_input_of_dr,
+)
+@pytest.mark.parametrize(
+    "alpha, n_bootstrap_samples, random_state, description",
+    valid_input_of_estimate_intervals,
+)
+def test_estimate_intervals_of_all_estimators_using_valid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    action_by_behavior_policy,
+    reward,
+    pscore,
+    alpha,
+    n_bootstrap_samples,
+    random_state,
+    description,
+) -> None:
+    _ = dr.estimate_interval(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+        alpha=alpha,
+        n_bootstrap_samples=n_bootstrap_samples,
+        random_state=random_state,
+    )
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    ["triangular", "gaussian", "epanechnikov", "cosine"],
+)
+def test_continuous_ope_performance(kernel):
+    # define dr instances
+    dr = KernelizedDoublyRobust(kernel=kernel, bandwidth=0.1)
+    # set parameters
+    dim_context = 2
+    reward_noise = 0.1
+    random_state = 12345
+    n_rounds = 10000
+    min_action_value = -10
+    max_action_value = 10
+    behavior_policy_function = linear_behavior_policy_continuous
+    reward_function = linear_reward_funcion_continuous
+    dataset = SyntheticContinuousBanditDataset(
+        dim_context=dim_context,
+        reward_function=reward_function,
+        behavior_policy_function=behavior_policy_function,
+        random_state=random_state,
+    )
+    # obtain feedback
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(
+        n_rounds=n_rounds,
+        reward_noise=reward_noise,
+        min_action_value=min_action_value,
+        max_action_value=max_action_value,
+    )
+    context = bandit_feedback["context"]
+    action_by_evaluation_policy = linear_synthetic_policy_continuous(context)
+    action_by_behavior_policy = bandit_feedback["action"]
+    reward = bandit_feedback["reward"]
+    pscore = bandit_feedback["pscore"]
+
+    # compute statistics of ground truth policy value
+    q_pi_e = linear_reward_funcion_continuous(
+        context=context, action=action_by_evaluation_policy, random_state=random_state
+    )
+    true_policy_value = q_pi_e.mean()
+    print(f"true_policy_value: {true_policy_value}")
+
+    # OPE
+    policy_value_estimated_by_dr = dr.estimate_policy_value(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=q_pi_e,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+    )
+
+    # check the performance of OPE
+    estimated_policy_value = {
+        "dr": policy_value_estimated_by_dr,
+    }
+    for key in estimated_policy_value:
+        print(
+            f"estimated_value: {estimated_policy_value[key]} ------ estimator: {key}, "
+        )
+        # test the performance of each estimator
+        assert (
+            np.abs(true_policy_value - estimated_policy_value[key]) / true_policy_value
+            <= 0.1
+        ), f"{key} does not work well (relative estimation error is greater than 10%)"

--- a/tests/ope/test_dr_estimators_continuous.py
+++ b/tests/ope/test_dr_estimators_continuous.py
@@ -321,6 +321,9 @@ def test_continuous_ope_performance(kernel):
     reward_function = linear_reward_funcion_continuous
     dataset = SyntheticContinuousBanditDataset(
         dim_context=dim_context,
+        reward_noise=reward_noise,
+        min_action_value=min_action_value,
+        max_action_value=max_action_value,
         reward_function=reward_function,
         behavior_policy_function=behavior_policy_function,
         random_state=random_state,
@@ -328,9 +331,6 @@ def test_continuous_ope_performance(kernel):
     # obtain feedback
     bandit_feedback = dataset.obtain_batch_bandit_feedback(
         n_rounds=n_rounds,
-        reward_noise=reward_noise,
-        min_action_value=min_action_value,
-        max_action_value=max_action_value,
     )
     context = bandit_feedback["context"]
     action_by_evaluation_policy = linear_synthetic_policy_continuous(context)

--- a/tests/ope/test_ipw_estimators_continuous.py
+++ b/tests/ope/test_ipw_estimators_continuous.py
@@ -355,6 +355,9 @@ def test_continuous_ope_performance(kernel):
     reward_function = linear_reward_funcion_continuous
     dataset = SyntheticContinuousBanditDataset(
         dim_context=dim_context,
+        reward_noise=reward_noise,
+        min_action_value=min_action_value,
+        max_action_value=max_action_value,
         reward_function=reward_function,
         behavior_policy_function=behavior_policy_function,
         random_state=random_state,
@@ -362,9 +365,6 @@ def test_continuous_ope_performance(kernel):
     # obtain feedback
     bandit_feedback = dataset.obtain_batch_bandit_feedback(
         n_rounds=n_rounds,
-        reward_noise=reward_noise,
-        min_action_value=min_action_value,
-        max_action_value=max_action_value,
     )
     context = bandit_feedback["context"]
     action_by_evaluation_policy = linear_synthetic_policy_continuous(context)

--- a/tests/ope/test_ipw_estimators_continuous.py
+++ b/tests/ope/test_ipw_estimators_continuous.py
@@ -1,0 +1,409 @@
+import pytest
+import numpy as np
+
+from obp.ope import (
+    KernelizedInverseProbabilityWeighting,
+    KernelizedSelfNormalizedInverseProbabilityWeighting,
+)
+from obp.dataset import (
+    SyntheticContinuousBanditDataset,
+    linear_reward_funcion_continuous,
+    linear_behavior_policy_continuous,
+    linear_synthetic_policy_continuous,
+)
+
+
+def test_synthetic_init():
+    # kernel
+    with pytest.raises(ValueError):
+        KernelizedInverseProbabilityWeighting(kernel="a", bandwidth=0.1)
+
+    with pytest.raises(ValueError):
+        KernelizedInverseProbabilityWeighting(kernel=None, bandwidth=0.1)
+
+    with pytest.raises(ValueError):
+        KernelizedSelfNormalizedInverseProbabilityWeighting(kernel="a", bandwidth=0.1)
+
+    with pytest.raises(ValueError):
+        KernelizedSelfNormalizedInverseProbabilityWeighting(kernel=None, bandwidth=0.1)
+
+    # bandwidth
+    with pytest.raises(TypeError):
+        KernelizedInverseProbabilityWeighting(kernel="gaussian", bandwidth="a")
+
+    with pytest.raises(TypeError):
+        KernelizedInverseProbabilityWeighting(kernel="gaussian", bandwidth=None)
+
+    with pytest.raises(ValueError):
+        KernelizedInverseProbabilityWeighting(kernel="gaussian", bandwidth=-1.0)
+
+    with pytest.raises(TypeError):
+        KernelizedSelfNormalizedInverseProbabilityWeighting(
+            kernel="gaussian", bandwidth="a"
+        )
+
+    with pytest.raises(TypeError):
+        KernelizedSelfNormalizedInverseProbabilityWeighting(
+            kernel="gaussian", bandwidth=None
+        )
+
+    with pytest.raises(ValueError):
+        KernelizedSelfNormalizedInverseProbabilityWeighting(
+            kernel="gaussian", bandwidth=-1.0
+        )
+
+
+# prepare ipw instances
+ipw = KernelizedInverseProbabilityWeighting(kernel="cosine", bandwidth=0.1)
+snipw = KernelizedSelfNormalizedInverseProbabilityWeighting(
+    kernel="epanechnikov", bandwidth=0.1
+)
+
+# --- invalid inputs (all kernelized estimators) ---
+
+# action_by_evaluation_policy, action_by_behavior_policy, reward, pscore, description
+invalid_input_of_ipw = [
+    (
+        None,  #
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=5),
+        "action_by_evaluation_policy must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones((5, 1)),  #
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=5),
+        "action_by_evaluation_policy must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones(5),
+        None,  #
+        np.ones(5),
+        np.random.uniform(size=5),
+        "action_by_behavior_policy must be ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones((5, 1)),  #
+        np.ones(5),
+        np.random.uniform(size=5),
+        "action_by_behavior_policy must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        None,  #
+        np.random.uniform(size=5),
+        "reward must be ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones((5, 1)),  #
+        np.random.uniform(size=5),
+        "reward must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(4),  #
+        np.ones(3),  #
+        np.random.uniform(size=5),
+        "action_by_behavior_policy and reward must be the same size",
+    ),
+    (
+        np.ones(4),  #
+        np.ones(5),  #
+        np.ones(5),
+        np.random.uniform(size=5),
+        "action_by_behavior_policy and action_by_evaluation_policy must be the same size",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        None,  #
+        "pscore must be ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=(5, 1)),  #
+        "pscore must be 1-dimensional ndarray",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=4),  #
+        "action_by_behavior_policy, reward, and pscore must be the same size",
+    ),
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.arange(5),  #
+        "pscore must be positive",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, action_by_behavior_policy, reward, pscore, description",
+    invalid_input_of_ipw,
+)
+def test_ipw_continuous_using_invalid_input_data(
+    action_by_evaluation_policy,
+    action_by_behavior_policy,
+    reward,
+    pscore,
+    description: str,
+) -> None:
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ipw.estimate_policy_value(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            action_by_behavior_policy=action_by_behavior_policy,
+            reward=reward,
+            pscore=pscore,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ipw.estimate_interval(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            action_by_behavior_policy=action_by_behavior_policy,
+            reward=reward,
+            pscore=pscore,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = snipw.estimate_policy_value(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            action_by_behavior_policy=action_by_behavior_policy,
+            reward=reward,
+            pscore=pscore,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = snipw.estimate_interval(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            action_by_behavior_policy=action_by_behavior_policy,
+            reward=reward,
+            pscore=pscore,
+        )
+
+
+# --- valid inputs (all kernelized estimators) ---
+
+# action_by_evaluation_policy, action_by_behavior_policy, reward, pscore
+valid_input_of_ipw = [
+    (
+        np.ones(5),
+        np.ones(5),
+        np.ones(5),
+        np.random.uniform(size=5),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, action_by_behavior_policy, reward, pscore",
+    valid_input_of_ipw,
+)
+def test_ipw_continuous_using_valid_input_data(
+    action_by_evaluation_policy,
+    action_by_behavior_policy,
+    reward,
+    pscore,
+) -> None:
+    _ = ipw.estimate_policy_value(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+    )
+    _ = ipw.estimate_interval(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+    )
+    _ = snipw.estimate_policy_value(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+    )
+    _ = snipw.estimate_interval(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+    )
+
+
+# --- confidence intervals ---
+# alpha, n_bootstrap_samples, random_state, description
+invalid_input_of_estimate_intervals = [
+    (0.05, 100, "s", "random_state must be an integer"),
+    (0.05, -1, 1, "n_bootstrap_samples must be a positive integer"),
+    (0.05, "s", 1, "n_bootstrap_samples must be a positive integer"),
+    (0.0, 1, 1, "alpha must be a positive float (< 1)"),
+    (1.0, 1, 1, "alpha must be a positive float (< 1)"),
+    ("0", 1, 1, "alpha must be a positive float (< 1)"),
+]
+
+valid_input_of_estimate_intervals = [
+    (0.05, 100, 1, "random_state is 1"),
+    (0.05, 1, 1, "n_bootstrap_samples is 1"),
+]
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, action_by_behavior_policy, reward, pscore",
+    valid_input_of_ipw,
+)
+@pytest.mark.parametrize(
+    "alpha, n_bootstrap_samples, random_state, description",
+    invalid_input_of_estimate_intervals,
+)
+def test_estimate_intervals_of_all_estimators_using_invalid_input_data(
+    action_by_evaluation_policy,
+    action_by_behavior_policy,
+    reward,
+    pscore,
+    alpha,
+    n_bootstrap_samples,
+    random_state,
+    description,
+) -> None:
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ipw.estimate_interval(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            action_by_behavior_policy=action_by_behavior_policy,
+            reward=reward,
+            pscore=pscore,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+        _ = snipw.estimate_interval(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            action_by_behavior_policy=action_by_behavior_policy,
+            reward=reward,
+            pscore=pscore,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, action_by_behavior_policy, reward, pscore",
+    valid_input_of_ipw,
+)
+@pytest.mark.parametrize(
+    "alpha, n_bootstrap_samples, random_state, description",
+    valid_input_of_estimate_intervals,
+)
+def test_estimate_intervals_of_all_estimators_using_valid_input_data(
+    action_by_evaluation_policy,
+    action_by_behavior_policy,
+    reward,
+    pscore,
+    alpha,
+    n_bootstrap_samples,
+    random_state,
+    description,
+) -> None:
+    _ = ipw.estimate_interval(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+        alpha=alpha,
+        n_bootstrap_samples=n_bootstrap_samples,
+        random_state=random_state,
+    )
+    _ = snipw.estimate_interval(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+        alpha=alpha,
+        n_bootstrap_samples=n_bootstrap_samples,
+        random_state=random_state,
+    )
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    ["triangular", "gaussian", "epanechnikov", "cosine"],
+)
+def test_continuous_ope_performance(kernel):
+    # define ipw instances
+    ipw = KernelizedInverseProbabilityWeighting(kernel=kernel, bandwidth=0.1)
+    snipw = KernelizedSelfNormalizedInverseProbabilityWeighting(
+        kernel=kernel, bandwidth=0.1
+    )
+    # set parameters
+    dim_context = 2
+    reward_noise = 0.1
+    random_state = 12345
+    n_rounds = 10000
+    min_action_value = -10
+    max_action_value = 10
+    behavior_policy_function = linear_behavior_policy_continuous
+    reward_function = linear_reward_funcion_continuous
+    dataset = SyntheticContinuousBanditDataset(
+        dim_context=dim_context,
+        reward_function=reward_function,
+        behavior_policy_function=behavior_policy_function,
+        random_state=random_state,
+    )
+    # obtain feedback
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(
+        n_rounds=n_rounds,
+        reward_noise=reward_noise,
+        min_action_value=min_action_value,
+        max_action_value=max_action_value,
+    )
+    context = bandit_feedback["context"]
+    action_by_evaluation_policy = linear_synthetic_policy_continuous(context)
+    action_by_behavior_policy = bandit_feedback["action"]
+    reward = bandit_feedback["reward"]
+    pscore = bandit_feedback["pscore"]
+
+    # compute statistics of ground truth policy value
+    q_pi_e = linear_reward_funcion_continuous(
+        context=context, action=action_by_evaluation_policy, random_state=random_state
+    )
+    true_policy_value = q_pi_e.mean()
+    print(f"true_policy_value: {true_policy_value}")
+
+    # OPE
+    policy_value_estimated_by_ipw = ipw.estimate_policy_value(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+    )
+    policy_value_estimated_by_snipw = snipw.estimate_policy_value(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        action_by_behavior_policy=action_by_behavior_policy,
+        reward=reward,
+        pscore=pscore,
+    )
+
+    # check the performance of OPE
+    estimated_policy_value = {
+        "ipw": policy_value_estimated_by_ipw,
+        "snipw": policy_value_estimated_by_snipw,
+    }
+    for key in estimated_policy_value:
+        print(
+            f"estimated_value: {estimated_policy_value[key]} ------ estimator: {key}, "
+        )
+        # test the performance of each estimator
+        assert (
+            np.abs(true_policy_value - estimated_policy_value[key]) / true_policy_value
+            <= 0.1
+        ), f"{key} does not work well (relative estimation error is greater than 10%)"

--- a/tests/ope/test_kernel_functions.py
+++ b/tests/ope/test_kernel_functions.py
@@ -1,0 +1,45 @@
+import numpy as np
+from scipy import integrate
+
+from obp.ope import (
+    triangular_kernel,
+    epanechnikov_kernel,
+    gaussian_kernel,
+    cosine_kernel,
+)
+
+
+def test_kernel_functions():
+    # triangular
+    assert np.isclose(
+        integrate.quad(lambda x: triangular_kernel(x), -np.inf, np.inf)[0], 1
+    )
+    assert np.isclose(
+        integrate.quad(lambda x: x * triangular_kernel(x), -np.inf, np.inf)[0], 0
+    )
+    assert integrate.quad(lambda x: triangular_kernel(x) ** 2, -np.inf, np.inf)[0] > 0
+
+    # epanechnikov
+    assert np.isclose(
+        integrate.quad(lambda x: epanechnikov_kernel(x), -np.inf, np.inf)[0], 1
+    )
+    assert np.isclose(
+        integrate.quad(lambda x: x * epanechnikov_kernel(x), -np.inf, np.inf)[0], 0
+    )
+    assert integrate.quad(lambda x: epanechnikov_kernel(x) ** 2, -np.inf, np.inf)[0] > 0
+
+    # gaussian
+    assert np.isclose(
+        integrate.quad(lambda x: gaussian_kernel(x), -np.inf, np.inf)[0], 1
+    )
+    assert np.isclose(
+        integrate.quad(lambda x: x * gaussian_kernel(x), -np.inf, np.inf)[0], 0
+    )
+    assert integrate.quad(lambda x: gaussian_kernel(x) ** 2, -np.inf, np.inf)[0] > 0
+
+    # cosine
+    assert np.isclose(integrate.quad(lambda x: cosine_kernel(x), -np.inf, np.inf)[0], 1)
+    assert np.isclose(
+        integrate.quad(lambda x: x * cosine_kernel(x), -np.inf, np.inf)[0], 0
+    )
+    assert integrate.quad(lambda x: cosine_kernel(x) ** 2, -np.inf, np.inf)[0] > 0

--- a/tests/ope/test_meta.py
+++ b/tests/ope/test_meta.py
@@ -140,7 +140,7 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
     """Inverse Probability Weighting (IPW) Mock."""
 
     estimator_name: str = "ipw"
-    eps: int = 0.1
+    eps: float = 0.1
 
     def _estimate_round_rewards(
         self,

--- a/tests/ope/test_meta_continuous.py
+++ b/tests/ope/test_meta_continuous.py
@@ -1,0 +1,674 @@
+from typing import Dict, Optional
+from dataclasses import dataclass
+import itertools
+from copy import deepcopy
+
+import pytest
+import numpy as np
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from obp.types import BanditFeedback
+from obp.ope import (
+    ContinuousOffPolicyEvaluation,
+    BaseContinuousOffPolicyEstimator,
+)
+from obp.utils import check_confidence_interval_arguments
+
+
+mock_policy_value = 0.5
+mock_confidence_interval = {
+    "mean": 0.5,
+    "95.0% CI (lower)": 0.3,
+    "95.0% CI (upper)": 0.7,
+}
+
+
+@dataclass
+class KernelizedInverseProbabilityWeightingMock(BaseContinuousOffPolicyEstimator):
+    """Mock Kernelized Inverse Probability Weighting."""
+
+    eps: float = 0.1
+    estimator_name: str = "ipw"
+
+    def _estimate_round_rewards(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        return np.ones_like(reward)
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        **kwargs,
+    ) -> float:
+        """Estimate policy value of an evaluation policy.
+
+        Returns
+        ----------
+        mock_policy_value: float
+
+        """
+        return mock_policy_value + self.eps
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Returns
+        ----------
+        mock_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        check_confidence_interval_arguments(
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+        return {k: v + self.eps for k, v in mock_confidence_interval.items()}
+
+
+@dataclass
+class KernelizedDoublyRobustMock(BaseContinuousOffPolicyEstimator):
+    """Mock Kernelized Doubly Robust."""
+
+    estimator_name: str = "kernelized_dr"
+
+    def _estimate_round_rewards(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        return np.ones_like(reward)
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        **kwargs,
+    ) -> float:
+        """Estimate policy value of an evaluation policy.
+
+        Returns
+        ----------
+        mock_policy_value: float
+
+        """
+        return mock_policy_value
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action_by_behavior_policy: np.ndarray,
+        pscore: np.ndarray,
+        action_by_evaluation_policy: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Returns
+        ----------
+        mock_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        check_confidence_interval_arguments(
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+        return {k: v for k, v in mock_confidence_interval.items()}
+
+
+# define Mock instances
+ipw = KernelizedInverseProbabilityWeightingMock()
+ipw2 = KernelizedInverseProbabilityWeightingMock(eps=0.02)
+ipw3 = KernelizedInverseProbabilityWeightingMock(estimator_name="ipw3")
+dr = KernelizedDoublyRobustMock(estimator_name="dr")
+
+
+def test_meta_post_init(synthetic_continuous_bandit_feedback: BanditFeedback) -> None:
+    """
+    Test the __post_init__ function
+    """
+    # __post_init__ saves the latter estimator when the same estimator name is used
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[ipw, ipw2]
+    )
+    assert ope_.ope_estimators_ == {"ipw": ipw2}, "__post_init__ returns a wrong value"
+    # __post_init__ can handle the same estimator if the estimator names are different
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[ipw, ipw3]
+    )
+    assert ope_.ope_estimators_ == {
+        "ipw": ipw,
+        "ipw3": ipw3,
+    }, "__post_init__ returns a wrong value"
+    # __post__init__ raises RuntimeError when necessary_keys are not included in the bandit_feedback
+    necessary_keys = ["action_by_behavior_policy", "reward", "pscore"]
+    for i in range(len(necessary_keys)):
+        for deleted_keys in itertools.combinations(necessary_keys, i + 1):
+            invalid_bandit_feedback_dict = {key: "_" for key in necessary_keys}
+            # delete
+            for k in deleted_keys:
+                del invalid_bandit_feedback_dict[k]
+            with pytest.raises(RuntimeError, match=r"Missing key*"):
+                _ = ContinuousOffPolicyEvaluation(
+                    bandit_feedback=invalid_bandit_feedback_dict, ope_estimators=[ipw]
+                )
+
+
+# action_by_evaluation_policy, estimated_rewards_by_reg_model, description
+invalid_input_of_create_estimator_inputs = [
+    (
+        np.zeros(5),  #
+        np.zeros(4),  #
+        "estimated_rewards_by_reg_model.shape and action_by_evaluation_policy.shape must be the same",
+    ),
+    (
+        np.zeros(5),
+        {"dr": np.zeros(4)},
+        r"estimated_rewards_by_reg_model\[dr\].shape and action_by_evaluation_policy.shape must be the same",
+    ),
+    (
+        np.zeros(5),
+        {"dr": None},
+        r"estimated_rewards_by_reg_model\[dr\] must be ndarray",
+    ),
+    (
+        np.zeros((2, 3)),
+        None,
+        "action_by_evaluation_policy must be 1-dimensional ndarray",
+    ),
+    ("3", None, "action_by_evaluation_policy must be 1-dimensional ndarray"),
+    (None, None, "action_by_evaluation_policy must be 1-dimensional ndarray"),
+]
+
+valid_input_of_create_estimator_inputs = [
+    (
+        np.zeros(5),
+        np.zeros(5),
+        "same shape",
+    ),
+    (
+        np.zeros(5),
+        {"dr": np.zeros(5)},
+        "same shape",
+    ),
+    (np.zeros(5), None, "estimated_rewards_by_reg_model is None"),
+]
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, description",
+    invalid_input_of_create_estimator_inputs,
+)
+def test_meta_create_estimator_inputs_using_invalid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    description: str,
+    synthetic_continuous_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the _create_estimator_inputs using valid data
+    """
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[ipw]
+    )
+    # raise ValueError when the shape of two arrays are different
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_._create_estimator_inputs(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+    # _create_estimator_inputs function is called in the following functions
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_.estimate_policy_values(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_.estimate_intervals(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_.summarize_off_policy_estimates(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_.evaluate_performance_of_estimators(
+            ground_truth_policy_value=0.1,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ope_.summarize_estimators_comparison(
+            ground_truth_policy_value=0.1,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, description",
+    valid_input_of_create_estimator_inputs,
+)
+def test_meta_create_estimator_inputs_using_valid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    description: str,
+    synthetic_continuous_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the _create_estimator_inputs using invalid data
+    """
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[ipw]
+    )
+    estimator_inputs = ope_._create_estimator_inputs(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+    assert set(estimator_inputs.keys()) == set(["ipw"])
+    assert set(estimator_inputs["ipw"].keys()) == set(
+        [
+            "reward",
+            "action_by_behavior_policy",
+            "pscore",
+            "action_by_evaluation_policy",
+            "estimated_rewards_by_reg_model",
+        ]
+    ), f"Invalid response of _create_estimator_inputs (test case: {description})"
+    # _create_estimator_inputs function is called in the following functions
+    _ = ope_.estimate_policy_values(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+    _ = ope_.estimate_intervals(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+    _ = ope_.summarize_off_policy_estimates(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+    _ = ope_.evaluate_performance_of_estimators(
+        ground_truth_policy_value=0.1,
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+    _ = ope_.summarize_estimators_comparison(
+        ground_truth_policy_value=0.1,
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    )
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, description",
+    valid_input_of_create_estimator_inputs,
+)
+def test_meta_estimate_policy_values_using_valid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    description: str,
+    synthetic_continuous_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the response of estimate_policy_values using valid data
+    """
+    # single ope estimator
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[dr]
+    )
+    assert ope_.estimate_policy_values(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    ) == {
+        "dr": mock_policy_value
+    }, "OffPolicyEvaluation.estimate_policy_values ([DoublyRobust]) returns a wrong value"
+    # multiple ope estimators
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[dr, ipw]
+    )
+    assert ope_.estimate_policy_values(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+    ) == {
+        "dr": mock_policy_value,
+        "ipw": mock_policy_value + ipw.eps,
+    }, "OffPolicyEvaluation.estimate_policy_values ([DoublyRobust, IPW]) returns a wrong value"
+
+
+# alpha, n_bootstrap_samples, random_state, description
+invalid_input_of_estimate_intervals = [
+    (0.05, 100, "s", "random_state must be an integer"),
+    (0.05, -1, 1, "n_bootstrap_samples must be a positive integer"),
+    (0.05, "s", 1, "n_bootstrap_samples must be a positive integer"),
+    (0.0, 1, 1, "alpha must be a positive float (< 1)"),
+    (1.0, 1, 1, "alpha must be a positive float (< 1)"),
+    ("0", 1, 1, "alpha must be a positive float (< 1)"),
+]
+
+valid_input_of_estimate_intervals = [
+    (0.05, 100, 1, "random_state is 1"),
+    (0.05, 1, 1, "n_bootstrap_samples is 1"),
+]
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, description_1",
+    valid_input_of_create_estimator_inputs,
+)
+@pytest.mark.parametrize(
+    "alpha, n_bootstrap_samples, random_state, description_2",
+    invalid_input_of_estimate_intervals,
+)
+def test_meta_estimate_intervals_using_invalid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    description_1: str,
+    alpha,
+    n_bootstrap_samples,
+    random_state,
+    description_2: str,
+    synthetic_continuous_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the response of estimate_intervals using invalid data
+    """
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[dr]
+    )
+    with pytest.raises(ValueError, match=f"{description_2}*"):
+        _ = ope_.estimate_intervals(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+    # estimate_intervals function is called in summarize_off_policy_estimates
+    with pytest.raises(ValueError, match=f"{description_2}*"):
+        _ = ope_.summarize_off_policy_estimates(
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, description_1",
+    valid_input_of_create_estimator_inputs,
+)
+@pytest.mark.parametrize(
+    "alpha, n_bootstrap_samples, random_state, description_2",
+    valid_input_of_estimate_intervals,
+)
+def test_meta_estimate_intervals_using_valid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    description_1: str,
+    alpha: float,
+    n_bootstrap_samples: int,
+    random_state: int,
+    description_2: str,
+    synthetic_continuous_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the response of estimate_intervals using valid data
+    """
+    # single ope estimator
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[dr]
+    )
+    assert ope_.estimate_intervals(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        alpha=alpha,
+        n_bootstrap_samples=n_bootstrap_samples,
+        random_state=random_state,
+    ) == {
+        "dr": mock_confidence_interval
+    }, "OffPolicyEvaluation.estimate_intervals ([DoublyRobust]) returns a wrong value"
+    # multiple ope estimators
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[dr, ipw]
+    )
+    assert ope_.estimate_intervals(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        alpha=alpha,
+        n_bootstrap_samples=n_bootstrap_samples,
+        random_state=random_state,
+    ) == {
+        "dr": mock_confidence_interval,
+        "ipw": {k: v + ipw.eps for k, v in mock_confidence_interval.items()},
+    }, "OffPolicyEvaluation.estimate_intervals ([DoublyRobust, IPW]) returns a wrong value"
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, description_1",
+    valid_input_of_create_estimator_inputs,
+)
+@pytest.mark.parametrize(
+    "alpha, n_bootstrap_samples, random_state, description_2",
+    valid_input_of_estimate_intervals,
+)
+def test_meta_summarize_off_policy_estimates(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    description_1: str,
+    alpha: float,
+    n_bootstrap_samples: int,
+    random_state: int,
+    description_2: str,
+    synthetic_continuous_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the response of summarize_off_policy_estimates using valid data
+    """
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[ipw, ipw3]
+    )
+    value, interval = ope_.summarize_off_policy_estimates(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        alpha=alpha,
+        n_bootstrap_samples=n_bootstrap_samples,
+        random_state=random_state,
+    )
+    expected_value = pd.DataFrame(
+        {
+            "ipw": mock_policy_value + ipw.eps,
+            "ipw3": mock_policy_value + ipw3.eps,
+        },
+        index=["estimated_policy_value"],
+    ).T
+    expected_value["relative_estimated_policy_value"] = (
+        expected_value["estimated_policy_value"]
+        / synthetic_continuous_bandit_feedback["reward"].mean()
+    )
+    expected_interval = pd.DataFrame(
+        {
+            "ipw": {k: v + ipw.eps for k, v in mock_confidence_interval.items()},
+            "ipw3": {k: v + ipw3.eps for k, v in mock_confidence_interval.items()},
+        }
+    ).T
+    assert_frame_equal(value, expected_value), "Invalid summarization (policy value)"
+    assert_frame_equal(interval, expected_interval), "Invalid summarization (interval)"
+    # check relative estimated policy value when the average of bandit_feedback["reward"] is zero
+    zero_reward_bandit_feedback = deepcopy(synthetic_continuous_bandit_feedback)
+    zero_reward_bandit_feedback["reward"] = np.zeros(
+        zero_reward_bandit_feedback["reward"].shape[0]
+    )
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=zero_reward_bandit_feedback, ope_estimators=[ipw, ipw3]
+    )
+    value, _ = ope_.summarize_off_policy_estimates(
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        alpha=alpha,
+        n_bootstrap_samples=n_bootstrap_samples,
+        random_state=random_state,
+    )
+    expected_value = pd.DataFrame(
+        {
+            "ipw": mock_policy_value + ipw.eps,
+            "ipw3": mock_policy_value + ipw3.eps,
+        },
+        index=["estimated_policy_value"],
+    ).T
+    expected_value["relative_estimated_policy_value"] = np.nan
+    assert_frame_equal(value, expected_value), "Invalid summarization (policy value)"
+
+
+invalid_input_of_evaluation_performance_of_estimators = [
+    ("foo", 0.3, "metric must be either 'relative-ee' or 'se'"),
+    ("se", 1, "ground_truth_policy_value must be a float"),
+    ("se", "a", "ground_truth_policy_value must be a float"),
+    (
+        "relative-ee",
+        0.0,
+        "ground_truth_policy_value must be non-zero when metric is relative-ee",
+    ),
+]
+
+valid_input_of_evaluation_performance_of_estimators = [
+    ("se", 0.0, "metric is se and ground_truth_policy_value is 0.0"),
+    ("relative-ee", 1.0, "metric is relative-ee and ground_truth_policy_value is 1.0"),
+]
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, description_1",
+    valid_input_of_create_estimator_inputs,
+)
+@pytest.mark.parametrize(
+    "metric, ground_truth_policy_value, description_2",
+    invalid_input_of_evaluation_performance_of_estimators,
+)
+def test_meta_evaluate_performance_of_estimators_using_invalid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    description_1: str,
+    metric,
+    ground_truth_policy_value,
+    description_2: str,
+    synthetic_continuous_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the response of evaluate_performance_of_estimators using invalid data
+    """
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[dr]
+    )
+    with pytest.raises(ValueError, match=f"{description_2}*"):
+        _ = ope_.evaluate_performance_of_estimators(
+            ground_truth_policy_value=ground_truth_policy_value,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            metric=metric,
+        )
+    # estimate_intervals function is called in summarize_off_policy_estimates
+    with pytest.raises(ValueError, match=f"{description_2}*"):
+        _ = ope_.summarize_estimators_comparison(
+            ground_truth_policy_value=ground_truth_policy_value,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            action_by_evaluation_policy=action_by_evaluation_policy,
+            metric=metric,
+        )
+
+
+@pytest.mark.parametrize(
+    "action_by_evaluation_policy, estimated_rewards_by_reg_model, description_1",
+    valid_input_of_create_estimator_inputs,
+)
+@pytest.mark.parametrize(
+    "metric, ground_truth_policy_value, description_2",
+    valid_input_of_evaluation_performance_of_estimators,
+)
+def test_meta_evaluate_performance_of_estimators_using_valid_input_data(
+    action_by_evaluation_policy,
+    estimated_rewards_by_reg_model,
+    description_1: str,
+    metric,
+    ground_truth_policy_value,
+    description_2: str,
+    synthetic_continuous_bandit_feedback: BanditFeedback,
+) -> None:
+    """
+    Test the response of evaluate_performance_of_estimators using valid data
+    """
+    if metric == "relative-ee":
+        # calculate relative-ee
+        eval_metric_ope_dict = {
+            "ipw": np.abs(
+                (mock_policy_value + ipw.eps - ground_truth_policy_value)
+                / ground_truth_policy_value
+            ),
+            "ipw3": np.abs(
+                (mock_policy_value + ipw3.eps - ground_truth_policy_value)
+                / ground_truth_policy_value
+            ),
+        }
+    else:
+        # calculate se
+        eval_metric_ope_dict = {
+            "ipw": (mock_policy_value + ipw.eps - ground_truth_policy_value) ** 2,
+            "ipw3": (mock_policy_value + ipw3.eps - ground_truth_policy_value) ** 2,
+        }
+    # check performance estimators
+    ope_ = ContinuousOffPolicyEvaluation(
+        bandit_feedback=synthetic_continuous_bandit_feedback, ope_estimators=[ipw, ipw3]
+    )
+    performance = ope_.evaluate_performance_of_estimators(
+        ground_truth_policy_value=ground_truth_policy_value,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        metric=metric,
+    )
+    for k, v in performance.items():
+        assert k in eval_metric_ope_dict, "Invalid key of performance response"
+        assert v == eval_metric_ope_dict[k], "Invalid value of performance response"
+    performance_df = ope_.summarize_estimators_comparison(
+        ground_truth_policy_value=ground_truth_policy_value,
+        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        action_by_evaluation_policy=action_by_evaluation_policy,
+        metric=metric,
+    )
+    assert_frame_equal(
+        performance_df, pd.DataFrame(eval_metric_ope_dict, index=[metric]).T
+    ), "Invalid summarization (performance)"

--- a/tests/ope/test_meta_slate.py
+++ b/tests/ope/test_meta_slate.py
@@ -32,7 +32,7 @@ class SlateStandardIPSMock(SlateStandardIPS):
     """Slate Standard Inverse Propensity Scoring (SIPS) Mock."""
 
     estimator_name: str = "sips"
-    eps: int = 0.1
+    eps: float = 0.1
 
     def estimate_policy_value(
         self,


### PR DESCRIPTION
## new feature

#### [estimators_continuous.py](https://github.com/st-tech/zr-obp/blob/continuous-estimators/obp/ope/estimators_continuous.py)
- implement the following Continuous OPE estimators
   - [KernelizedInverseProbabilityWeighting](https://github.com/st-tech/zr-obp/blob/efab71d3a7253eaed0ebd45e84b030d064ef2bc0/obp/ope/estimators_continuous.py#L72)
   - [KernelizedSelfNormalizedInverseProbabilityWeighting](https://github.com/st-tech/zr-obp/blob/efab71d3a7253eaed0ebd45e84b030d064ef2bc0/obp/ope/estimators_continuous.py#L290)
   - [KernelizedDoublyRobust](https://github.com/st-tech/zr-obp/blob/efab71d3a7253eaed0ebd45e84b030d064ef2bc0/obp/ope/estimators_continuous.py#L384)
- implement [some kernel functions](https://github.com/st-tech/zr-obp/blob/efab71d3a7253eaed0ebd45e84b030d064ef2bc0/obp/ope/estimators_continuous.py#L17)
    - triangular_kernel
    - gaussian_kernel
    - epanechnikov_kernel
    - cosine_kernel

**reference**
Nathan Kallus and Angela Zhou.
"Policy Evaluation and Optimization with Continuous Treatments", AISTATS, 2018.

#### [meta_continuous.py](https://github.com/st-tech/zr-obp/blob/continuous-estimators/obp/ope/meta_continuous.py)

- implement `ContinuousOffPolicyEvaluation` that streamlines OPE with continuous actions. This works as follows.

```python
# (1) Synthetic Data Generation
dataset = SyntheticContinuousBanditDataset(dim_context=5)
bandit_feedback = dataset.obtain_batch_bandit_feedback(
    n_rounds=10000, min_action_value=-10, max_action_value=10,
)

# (2) Off-Policy Evaluation
ope = ContinuousOffPolicyEvaluation(
    bandit_feedback=bandit_feedback,
    ope_estimators=[KernelizedIPW(kernel="epanechnikov", bandwidth=0.02)]
)
estimated_policy_value = ope.estimate_policy_values(
     action_by_evaluation_policy=action_by_evaluation_policy,
)
```

## tests

- add the following tests wrt the new features
    1. [test_ipw_estimators_continuous.py](https://github.com/st-tech/zr-obp/blob/continuous-estimators/tests/ope/test_ipw_estimators_continuous.py)
    2. [test_dr_estimators_continuous.py](https://github.com/st-tech/zr-obp/blob/continuous-estimators/tests/ope/test_dr_estimators_continuous.py)
    3. [test_meta_continuous.py](https://github.com/st-tech/zr-obp/blob/continuous-estimators/tests/ope/test_meta_continuous.py)
    4. [test_kernel_functions.py](https://github.com/st-tech/zr-obp/blob/continuous-estimators/tests/ope/test_kernel_functions.py)
  
1 and 2 include some performance tests of the continuous OPE estimators using synthetic data as well as input checks. 
4 checks whether the kernel functions satisfy the conditions described on page 9 of the following lecture slides: http://ibis.t.u-tokyo.ac.jp/suzuki/lecture/2015/dataanalysis/L9.pdf

- fix descriptions (mostly English expressions) of docstrings