### PR TITLE
Feature: Implementing weight clipping

### DIFF
--- a/benchmark/cf_policy_search/run_cf_policy_search.py
+++ b/benchmark/cf_policy_search/run_cf_policy_search.py
@@ -14,7 +14,7 @@ from custom_dataset import OBDWithInteractionFeatures
 from obp.policy import IPWLearner
 from obp.ope import InverseProbabilityWeighting
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 with open("./conf/hyperparams.yaml", "rb") as f:
     hyperparams = yaml.safe_load(f)
 

--- a/examples/multiclass/evaluate_off_policy_estimators.py
+++ b/examples/multiclass/evaluate_off_policy_estimators.py
@@ -24,7 +24,7 @@ from obp.ope import (
 )
 
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 with open("./conf/hyperparams.yaml", "rb") as f:
     hyperparams = yaml.safe_load(f)
 

--- a/examples/obd/evaluate_off_policy_estimators.py
+++ b/examples/obd/evaluate_off_policy_estimators.py
@@ -21,7 +21,7 @@ from obp.ope import (
 
 evaluation_policy_dict = dict(bts=BernoulliTS, random=Random)
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 with open("./conf/hyperparams.yaml", "rb") as f:
     hyperparams = yaml.safe_load(f)
 

--- a/examples/opl/evaluate_off_policy_learners.py
+++ b/examples/opl/evaluate_off_policy_learners.py
@@ -24,7 +24,7 @@ from obp.ope import (
 )
 
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 with open("./conf/hyperparams.yaml", "rb") as f:
     hyperparams = yaml.safe_load(f)
 

--- a/examples/synthetic/evaluate_off_policy_estimators.py
+++ b/examples/synthetic/evaluate_off_policy_estimators.py
@@ -28,7 +28,7 @@ from obp.ope import (
 )
 
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 with open("./conf/hyperparams.yaml", "rb") as f:
     hyperparams = yaml.safe_load(f)
 

--- a/obp/dataset/synthetic.py
+++ b/obp/dataset/synthetic.py
@@ -324,7 +324,7 @@ class SyntheticBanditDataset(BaseBanditDataset):
             This is often the expected_reward of the test set of logged bandit feedback data.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         Returns
         ----------

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -747,7 +747,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         Parameters
         -----------
         reward: array-like, shape (<= n_rounds * len_list,)
-            Reward observed in each round and slot of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
+            Reward observed at each slot in each round of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
 
         slate_id: array-like, shape (<= n_rounds * len_list,)
             Slate ids of the logged bandit feedback.

--- a/obp/ope/__init__.py
+++ b/obp/ope/__init__.py
@@ -7,6 +7,10 @@ from obp.ope.estimators import DoublyRobust
 from obp.ope.estimators import SelfNormalizedDoublyRobust
 from obp.ope.estimators import SwitchDoublyRobust
 from obp.ope.estimators import DoublyRobustWithShrinkage
+from obp.ope.estimators_tuning import InverseProbabilityWeightingTuning
+from obp.ope.estimators_tuning import DoublyRobustTuning
+from obp.ope.estimators_tuning import SwitchDoublyRobustTuning
+from obp.ope.estimators_tuning import DoublyRobustWithShrinkageTuning
 from obp.ope.estimators_slate import SlateStandardIPS
 from obp.ope.estimators_slate import SlateIndependentIPS
 from obp.ope.estimators_slate import SlateRewardInteractionIPS
@@ -24,6 +28,10 @@ __all__ = [
     "SelfNormalizedDoublyRobust",
     "SwitchDoublyRobust",
     "DoublyRobustWithShrinkage",
+    "InverseProbabilityWeightingTuning",
+    "DoublyRobustTuning",
+    "SwitchDoublyRobustTuning",
+    "DoublyRobustWithShrinkageTuning",
     "OffPolicyEvaluation",
     "SlateOffPolicyEvaluation",
     "RegressionModel",
@@ -41,4 +49,12 @@ __all_estimators__ = [
     "DoublyRobustWithShrinkage",
     "SwitchDoublyRobust",
     "SelfNormalizedDoublyRobust",
+]
+
+
+__all_estimators_tuning__ = [
+    "InverseProbabilityWeightingTuning",
+    "DoublyRobustTuning",
+    "SwitchDoublyRobustTuning",
+    "DoublyRobustWithShrinkageTuning",
 ]

--- a/obp/ope/estimators.py
+++ b/obp/ope/estimators.py
@@ -333,7 +333,9 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
         if position is None:
             position = np.zeros(action_dist.shape[0], dtype=int)
         iw = action_dist[np.arange(action.shape[0]), action, position] / pscore
-        iw = np.minimum(iw, self.lambda_)  # weight clipping
+        # weight clipping
+        if isinstance(iw, np.ndarray):
+            iw = np.minimum(iw, self.lambda_)
         return reward * iw
 
     def estimate_policy_value(
@@ -961,7 +963,9 @@ class DoublyRobust(BaseOffPolicyEstimator):
             position = np.zeros(action_dist.shape[0], dtype=int)
         n_rounds = action.shape[0]
         iw = action_dist[np.arange(n_rounds), action, position] / pscore
-        iw = np.minimum(iw, self.lambda_)  # weight clipping
+        # weight clipping
+        if isinstance(iw, np.ndarray):
+            iw = np.minimum(iw, self.lambda_)
         q_hat_at_position = estimated_rewards_by_reg_model[
             np.arange(n_rounds), :, position
         ]
@@ -979,7 +983,7 @@ class DoublyRobust(BaseOffPolicyEstimator):
         elif isinstance(reward, torch.Tensor):
             estimated_rewards = torch.sum(q_hat_at_position * pi_e_at_position, dim=1)
         else:
-            raise ValueError("reward must be nd-array or Tensor")
+            raise ValueError("reward must be ndarray or Tensor")
 
         estimated_rewards += iw * (reward - q_hat_factual)
         return estimated_rewards
@@ -1298,7 +1302,7 @@ class SelfNormalizedDoublyRobust(DoublyRobust):
         elif isinstance(reward, torch.Tensor):
             estimated_rewards = torch.sum(q_hat_at_position * pi_e_at_position, dim=1)
         else:
-            raise ValueError("reward must be nd-array or Tensor")
+            raise ValueError("reward must be ndarray or Tensor")
 
         q_hat_factual = estimated_rewards_by_reg_model[
             np.arange(n_rounds), action, position
@@ -1551,7 +1555,7 @@ class DoublyRobustWithShrinkage(DoublyRobust):
         elif isinstance(reward, torch.Tensor):
             estimated_rewards = torch.sum(q_hat_at_position * pi_e_at_position, dim=1)
         else:
-            raise ValueError("reward must be nd-array or Tensor")
+            raise ValueError("reward must be ndarray or Tensor")
 
         estimated_rewards += shrinkage_weight * (reward - q_hat_factual)
         return estimated_rewards

--- a/obp/ope/estimators.py
+++ b/obp/ope/estimators.py
@@ -258,7 +258,7 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
     where :math:`\\mathcal{D}=\\{(x_t,a_t,r_t)\\}_{t=1}^{T}` is logged bandit feedback data with :math:`T` rounds collected by
     a behavior policy :math:`\\pi_b`. :math:`w(x,a):=\\pi_e (a|x)/\\pi_b (a|x)` is the importance weight given :math:`x` and :math:`a`.
     :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
-    When the weight-clipping is applied, a large importance weight is clipped as :math:`\\hat{w}(x,a) := \\min \\{ \lambda, w(x,a) \\}`
+    When the weight-clipping is applied, a large importance weight is clipped as :math:`\\hat{w}(x,a) := \\min \\{ \\lambda, w(x,a) \\}`
     where :math:`\\lambda (>0)` is a hyperparameter that decides a maximum allowed importance weight.
 
     IPW re-weights the rewards by the ratio of the evaluation policy and behavior policy (importance weight).
@@ -269,7 +269,7 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
     ------------
     lambda_: float, default=np.inf
         A maximum possible value of the importance weight.
-        When a positive finite value is given, then an importance weight larger than `lambda_` will be clipped.
+        When a positive finite value is given, then importance weights larger than `lambda_` will be clipped.
 
     estimator_name: str, default='ipw'.
         Name of off-policy estimator.
@@ -295,6 +295,8 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
             target_type=(int, float),
             min_val=0.0,
         )
+        if self.lambda_ != self.lambda_:
+            raise ValueError("lambda_ must not be nan")
 
     def _estimate_round_rewards(
         self,
@@ -874,7 +876,7 @@ class DoublyRobust(BaseOffPolicyEstimator):
     :math:`\\mathbb{E}_{\\mathcal{D}}[\\cdot]` is the empirical average over :math:`T` observations in :math:`\\mathcal{D}`.
     :math:`\\hat{q} (x,a)` is an estimated expected reward given :math:`x` and :math:`a`.
     :math:`\\hat{q} (x_t,\\pi):= \\mathbb{E}_{a \\sim \\pi(a|x)}[\\hat{q}(x,a)]` is the expectation of the estimated reward function over :math:`\\pi`.
-    When the weight-clipping is applied, a large importance weight is clipped as :math:`\\hat{w}(x,a) := \\min \\{ \lambda, w(x,a) \\}`
+    When the weight-clipping is applied, a large importance weight is clipped as :math:`\\hat{w}(x,a) := \\min \\{ \\lambda, w(x,a) \\}`
     where :math:`\\lambda (>0)` is a hyperparameter that decides a maximum allowed importance weight.
 
     To estimate the mean reward function, please use `obp.ope.regression_model.RegressionModel`,
@@ -890,7 +892,7 @@ class DoublyRobust(BaseOffPolicyEstimator):
     ----------
     lambda_: float, default=np.inf
         A maximum possible value of the importance weight.
-        When a positive finite value is given, then an importance weight larger than `lambda_` will be clipped.
+        When a positive finite value is given, then importance weights larger than `lambda_` will be clipped.
         DoublyRobust with a finite positive `lambda_` corresponds to the Doubly Robust with pessimistic shrinkage stated in Su et al.(2020).
 
     estimator_name: str, default='dr'.
@@ -920,6 +922,8 @@ class DoublyRobust(BaseOffPolicyEstimator):
             target_type=(int, float),
             min_val=0.0,
         )
+        if self.lambda_ != self.lambda_:
+            raise ValueError("lambda_ must not be nan")
 
     def _estimate_round_rewards(
         self,
@@ -1363,6 +1367,8 @@ class SwitchDoublyRobust(DoublyRobust):
             target_type=(int, float),
             min_val=0.0,
         )
+        if self.tau != self.tau:
+            raise ValueError("tau must not be nan")
 
     def _estimate_round_rewards(
         self,
@@ -1496,6 +1502,8 @@ class DoublyRobustWithShrinkage(DoublyRobust):
             target_type=(int, float),
             min_val=0.0,
         )
+        if self.lambda_ != self.lambda_:
+            raise ValueError("lambda_ must not be nan")
 
     def _estimate_round_rewards(
         self,

--- a/obp/ope/estimators.py
+++ b/obp/ope/estimators.py
@@ -10,6 +10,7 @@ import numpy as np
 import torch
 from sklearn.utils import check_scalar
 
+from .helper import estimate_high_probability_upper_bound_bias
 from ..utils import (
     estimate_confidence_interval_by_bootstrap,
     check_ope_inputs,
@@ -23,17 +24,18 @@ class BaseOffPolicyEstimator(metaclass=ABCMeta):
 
     @abstractmethod
     def _estimate_round_rewards(self) -> Union[np.ndarray, torch.Tensor]:
-        """Estimate rewards for each round."""
+        """Estimate round-wise (or sample-wise) rewards."""
         raise NotImplementedError
 
     @abstractmethod
     def estimate_policy_value(self) -> float:
-        """Estimate policy value of an evaluation policy."""
+        """Estimate the policy value of evaluation policy."""
         raise NotImplementedError
 
     @abstractmethod
     def estimate_policy_value_tensor(self) -> torch.Tensor:
-        """Estimate policy value of an evaluation policy and return PyTorch Tensor.
+        """
+        Estimate the policy value of evaluation policy and return PyTorch Tensor.
         This is intended for being used with NNPolicyLearner.
         """
         raise NotImplementedError
@@ -46,11 +48,11 @@ class BaseOffPolicyEstimator(metaclass=ABCMeta):
 
 @dataclass
 class ReplayMethod(BaseOffPolicyEstimator):
-    """Estimate the policy value by Relpay Method (RM).
+    """Relpay Method (RM).
 
     Note
     -------
-    Replay Method (RM) estimates the policy value of a given evaluation policy :math:`\\pi_e` by
+    Replay Method (RM) estimates the policy value of evaluation policy :math:`\\pi_e` by
 
     .. math::
 
@@ -65,7 +67,7 @@ class ReplayMethod(BaseOffPolicyEstimator):
     Parameters
     ----------
     estimator_name: str, default='rm'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ------------
@@ -84,7 +86,7 @@ class ReplayMethod(BaseOffPolicyEstimator):
         position: Optional[np.ndarray] = None,
         **kwargs,
     ) -> np.ndarray:
-        """Estimate rewards for each round.
+        """Estimate round-wise (or sample-wise) rewards.
 
         Parameters
         ------------
@@ -92,18 +94,20 @@ class ReplayMethod(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (must be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (must be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
         estimated_rewards: array-like, shape (n_rounds,)
-            Rewards estimated by the Replay Method for each round.
+            Rewards of each round estimated by the Replay Method.
 
         """
         if position is None:
@@ -124,7 +128,7 @@ class ReplayMethod(BaseOffPolicyEstimator):
         position: Optional[np.ndarray] = None,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ------------
@@ -132,13 +136,15 @@ class ReplayMethod(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (must be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (must be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
@@ -168,7 +174,8 @@ class ReplayMethod(BaseOffPolicyEstimator):
         self,
         **kwargs,
     ) -> torch.Tensor:
-        """Estimate policy value of an evaluation policy and return PyTorch Tensor.
+        """
+        Estimate the policy value of evaluation policy and return PyTorch Tensor.
         This is intended for being used with NNPolicyLearner.
         This is not implemented for RM because it is indifferentiable.
         """
@@ -195,16 +202,18 @@ class ReplayMethod(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (must be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (must be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -245,11 +254,11 @@ class ReplayMethod(BaseOffPolicyEstimator):
 
 @dataclass
 class InverseProbabilityWeighting(BaseOffPolicyEstimator):
-    """Estimate the policy value by Inverse Probability Weighting (IPW).
+    """Inverse Probability Weighting (IPW) Estimator.
 
     Note
     -------
-    Inverse Probability Weighting (IPW) estimates the policy value of a given evaluation policy :math:`\\pi_e` by
+    Inverse Probability Weighting (IPW) estimates the policy value of evaluation policy :math:`\\pi_e` by
 
     .. math::
 
@@ -269,10 +278,10 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
     ------------
     lambda_: float, default=np.inf
         A maximum possible value of the importance weight.
-        When a positive finite value is given, then importance weights larger than `lambda_` will be clipped.
+        When a positive finite value is given, importance weights larger than `lambda_` will be clipped.
 
     estimator_name: str, default='ipw'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ------------
@@ -281,6 +290,9 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
 
     Miroslav Dudík, Dumitru Erhan, John Langford, and Lihong Li.
     "Doubly Robust Policy Evaluation and Optimization.", 2014.
+
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
 
     """
 
@@ -307,7 +319,7 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
         position: Optional[Union[np.ndarray, torch.Tensor]] = None,
         **kwargs,
     ) -> Union[np.ndarray, torch.Tensor]:
-        """Estimate rewards for each round.
+        """Estimate round-wise (or sample-wise) rewards.
 
         Parameters
         ----------
@@ -315,21 +327,23 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like or Tensor, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like or Tensor, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like or Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         position: array-like or Tensor, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
         estimated_rewards: array-like or Tensor, shape (n_rounds,)
-            Rewards estimated by IPW for each round.
+            Rewards of each round estimated by IPW.
 
         """
         if position is None:
@@ -349,7 +363,7 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
         position: Optional[np.ndarray] = None,
         **kwargs,
     ) -> np.ndarray:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ----------
@@ -357,16 +371,18 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
@@ -408,7 +424,8 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
         position: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
-        """Estimate policy value of an evaluation policy and return PyTorch Tensor.
+        """
+        Estimate the policy value of evaluation policy and return PyTorch Tensor.
         This is intended for being used with NNPolicyLearner.
 
         Parameters
@@ -417,16 +434,18 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: Tensor, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: Tensor, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         position: Tensor, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
@@ -479,20 +498,21 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities
-            by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -537,14 +557,75 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
             random_state=random_state,
         )
 
+    def _estimate_mse_score(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        **kwargs,
+    ) -> float:
+        """Estimate the MSE score of a given clipping hyperparameter to conduct hyperparameter tuning.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        Returns
+        ----------
+        estimated_mse_score: float
+            Estimated MSE score of a given clipping hyperparameter `lambda_`.
+            MSE score is the sum of (high probability) upper bound of bias and the sample variance.
+            This is estimated using the automatic hyperparameter tuning procedure
+            based on Section 5 of Su et al.(2020).
+
+        """
+        n_rounds = reward.shape[0]
+        # estimate the sample variance of IPW with clipping
+        sample_variance = np.var(
+            self._estimate_round_rewards(
+                reward=reward,
+                action=action,
+                pscore=pscore,
+                action_dist=action_dist,
+                position=position,
+            )
+        )
+        sample_variance /= n_rounds
+
+        # estimate the (high probability) upper bound of the bias of IPW with clipping
+        iw = action_dist[np.arange(n_rounds), action, position] / pscore
+        bias_upper_bound = estimate_high_probability_upper_bound_bias(
+            reward=reward,
+            iw=iw,
+            iw_hat=np.minimum(iw, self.lambda_),
+        )
+        estimated_mse_score = sample_variance + (bias_upper_bound ** 2)
+
+        return estimated_mse_score
+
 
 @dataclass
 class SelfNormalizedInverseProbabilityWeighting(InverseProbabilityWeighting):
-    """Estimate the policy value by Self-Normalized Inverse Probability Weighting (SNIPW).
+    """Self-Normalized Inverse Probability Weighting (SNIPW) Estimator.
 
     Note
     -------
-    Self-Normalized Inverse Probability Weighting (SNIPW) estimates the policy value of a given evaluation policy :math:`\\pi_e` by
+    Self-Normalized Inverse Probability Weighting (SNIPW) estimates the policy value of evaluation policy :math:`\\pi_e` by
 
     .. math::
 
@@ -563,7 +644,7 @@ class SelfNormalizedInverseProbabilityWeighting(InverseProbabilityWeighting):
     Parameters
     ----------
     estimator_name: str, default='snipw'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ----------
@@ -586,7 +667,7 @@ class SelfNormalizedInverseProbabilityWeighting(InverseProbabilityWeighting):
         position: Optional[Union[np.ndarray, torch.Tensor]] = None,
         **kwargs,
     ) -> Union[np.ndarray, torch.Tensor]:
-        """Estimate rewards for each round.
+        """Estimate round-wise (or sample-wise) rewards.
 
         Parameters
         ----------
@@ -594,21 +675,21 @@ class SelfNormalizedInverseProbabilityWeighting(InverseProbabilityWeighting):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like or Tensor, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like or Tensor, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like or Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         position: array-like or Tensor, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         Returns
         ----------
         estimated_rewards: array-like or Tensor, shape (n_rounds,)
-            Rewards estimated by the SNIPW estimator for each round.
+            Rewards of each round estimated by the SNIPW estimator.
 
         """
         if position is None:
@@ -619,7 +700,7 @@ class SelfNormalizedInverseProbabilityWeighting(InverseProbabilityWeighting):
 
 @dataclass
 class DirectMethod(BaseOffPolicyEstimator):
-    """Estimate the policy value by Direct Method (DM).
+    """Direct Method (DM).
 
     Note
     -------
@@ -647,7 +728,7 @@ class DirectMethod(BaseOffPolicyEstimator):
     Parameters
     ----------
     estimator_name: str, default='dm'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ----------
@@ -668,23 +749,25 @@ class DirectMethod(BaseOffPolicyEstimator):
         position: Optional[Union[np.ndarray, torch.Tensor]] = None,
         **kwargs,
     ) -> Union[np.ndarray, torch.Tensor]:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ----------
         action_dist: array-like or Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like or Tensor, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like or Tensor, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
         estimated_rewards: array-like or Tensor, shape (n_rounds,)
-            Rewards estimated by the DM estimator for each round.
+            Rewards of each round estimated by the DM estimator.
 
         """
         if position is None:
@@ -713,18 +796,20 @@ class DirectMethod(BaseOffPolicyEstimator):
         position: Optional[np.ndarray] = None,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ----------
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
@@ -756,19 +841,22 @@ class DirectMethod(BaseOffPolicyEstimator):
         position: Optional[Union[np.ndarray, torch.Tensor]] = None,
         **kwargs,
     ) -> torch.Tensor:
-        """Estimate policy value of an evaluation policy and return PyTorch Tensor.
+        """
+        Estimate the policy value of evaluation policy and return PyTorch Tensor.
         This is intended for being used with NNPolicyLearner.
 
         Parameters
         ----------
         action_dist: Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: Tensor, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like or Tensor, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
@@ -808,16 +896,18 @@ class DirectMethod(BaseOffPolicyEstimator):
         Parameters
         ----------
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -857,7 +947,7 @@ class DirectMethod(BaseOffPolicyEstimator):
 
 @dataclass
 class DoublyRobust(BaseOffPolicyEstimator):
-    """Estimate the policy value by Doubly Robust (DR).
+    """Doubly Robust (DR) Estimator.
 
     Note
     -------
@@ -892,11 +982,11 @@ class DoublyRobust(BaseOffPolicyEstimator):
     ----------
     lambda_: float, default=np.inf
         A maximum possible value of the importance weight.
-        When a positive finite value is given, then importance weights larger than `lambda_` will be clipped.
-        DoublyRobust with a finite positive `lambda_` corresponds to the Doubly Robust with pessimistic shrinkage stated in Su et al.(2020).
+        When a positive finite value is given, importance weights larger than `lambda_` will be clipped.
+        DoublyRobust with a finite positive `lambda_` corresponds to the Doubly Robust with pessimistic shrinkage of Su et al.(2020).
 
     estimator_name: str, default='dr'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ----------
@@ -935,7 +1025,7 @@ class DoublyRobust(BaseOffPolicyEstimator):
         position: Optional[Union[np.ndarray, torch.Tensor]] = None,
         **kwargs,
     ) -> Union[np.ndarray, torch.Tensor]:
-        """Estimate rewards for each round.
+        """Estimate round-wise (or sample-wise) rewards.
 
         Parameters
         ----------
@@ -943,24 +1033,26 @@ class DoublyRobust(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like or Tensor, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like or Tensor, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like or Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model or Tensor: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like or Tensor, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
         estimated_rewards: array-like or Tensor, shape (n_rounds,)
-            Rewards estimated by the DR estimator for each round.
+            Rewards of each round estimated by the DR estimator.
 
         """
         if position is None:
@@ -1001,7 +1093,7 @@ class DoublyRobust(BaseOffPolicyEstimator):
         estimated_rewards_by_reg_model: np.ndarray,
         position: Optional[np.ndarray] = None,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ----------
@@ -1009,24 +1101,26 @@ class DoublyRobust(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
         V_hat: float
-            Estimated policy value by the DR estimator.
+            Policy value estimated by the DR estimator.
 
         """
         if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
@@ -1068,7 +1162,8 @@ class DoublyRobust(BaseOffPolicyEstimator):
         position: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
-        """Estimate policy value of an evaluation policy and return PyTorch Tensor.
+        """
+        Estimate the policy value of evaluation policy and return PyTorch Tensor.
         This is intended for being used with NNPolicyLearner.
 
         Parameters
@@ -1077,24 +1172,26 @@ class DoublyRobust(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: Tensor, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: Tensor, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: Tensor, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: Tensor, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
         V_hat: Tensor
-            Estimated policy value by the DR estimator.
+            Policy value estimated by the DR estimator.
 
         """
         if not isinstance(estimated_rewards_by_reg_model, torch.Tensor):
@@ -1147,22 +1244,24 @@ class DoublyRobust(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -1211,14 +1310,82 @@ class DoublyRobust(BaseOffPolicyEstimator):
             random_state=random_state,
         )
 
+    def _estimate_mse_score(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+    ) -> float:
+        """Estimate the MSE score of a given clipping hyperparameter to conduct hyperparameter tuning.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        Returns
+        ----------
+        estimated_mse_score: float
+            Estimated MSE score of a given clipping hyperparameter `lambda_`.
+            MSE score is the sum of (high probability) upper bound of bias and the sample variance.
+            This is estimated using the automatic hyperparameter tuning procedure
+            based on Section 5 of Su et al.(2020).
+
+        """
+        n_rounds = reward.shape[0]
+        # estimate the sample variance of DR with clipping
+        sample_variance = np.var(
+            self._estimate_round_rewards(
+                reward=reward,
+                action=action,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                position=position,
+            )
+        )
+        sample_variance /= n_rounds
+
+        # estimate the (high probability) upper bound of the bias of DR with clipping
+        iw = action_dist[np.arange(n_rounds), action, position] / pscore
+        bias_upper_bound = estimate_high_probability_upper_bound_bias(
+            reward=reward,
+            iw=iw,
+            iw_hat=np.minimum(iw, self.lambda_),
+            q_hat=estimated_rewards_by_reg_model[np.arange(n_rounds), action, position],
+        )
+        estimated_mse_score = sample_variance + (bias_upper_bound ** 2)
+
+        return estimated_mse_score
+
 
 @dataclass
 class SelfNormalizedDoublyRobust(DoublyRobust):
-    """Estimate the policy value by Self-Normalized Doubly Robust (SNDR).
+    """Self-Normalized Doubly Robust (SNDR) Estimator.
 
     Note
     -------
-    Self-Normalized Doubly Robust estimates the policy value of a given evaluation policy :math:`\\pi_e` by
+    Self-Normalized Doubly Robust estimates the policy value of evaluation policy :math:`\\pi_e` by
 
     .. math::
 
@@ -1238,7 +1405,7 @@ class SelfNormalizedDoublyRobust(DoublyRobust):
     Parameters
     ----------
     estimator_name: str, default='sndr'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ----------
@@ -1262,7 +1429,7 @@ class SelfNormalizedDoublyRobust(DoublyRobust):
         position: Optional[Union[np.ndarray, torch.Tensor]] = None,
         **kwargs,
     ) -> Union[np.ndarray, torch.Tensor]:
-        """Estimate rewards for each round.
+        """Estimate round-wise (or sample-wise) rewards.
 
         Parameters
         ----------
@@ -1270,24 +1437,26 @@ class SelfNormalizedDoublyRobust(DoublyRobust):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like or Tensor, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like or Tensor, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like or Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like or Tensor, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like or Tensor, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
         estimated_rewards: array-like or Tensor, shape (n_rounds,)
-            Rewards estimated by the SNDR estimator for each round.
+            Rewards of each round estimated by the SNDR estimator.
 
         """
         n_rounds = action.shape[0]
@@ -1317,12 +1486,12 @@ class SelfNormalizedDoublyRobust(DoublyRobust):
 
 @dataclass
 class SwitchDoublyRobust(DoublyRobust):
-    """Estimate the policy value by Switch Doubly Robust (Switch-DR).
+    """Switch Doubly Robust (Switch-DR) Estimator.
 
     Note
     -------
-    Switch-DR aims to reduce the variance of the DR estimator by using direct method
-    when the importance weight is large. This estimator estimates the policy value of a given evaluation policy :math:`\\pi_e` by
+    Switch-DR aims to reduce the variance of the DR estimator by using direct method when the importance weight is large.
+    This estimator estimates the policy value of evaluation policy :math:`\\pi_e` by
 
     .. math::
 
@@ -1339,12 +1508,12 @@ class SwitchDoublyRobust(DoublyRobust):
 
     Parameters
     ----------
-    tau: float, default=1
-        Switching hyperparameter. When importance weight is larger than this parameter, the DM estimator is applied, otherwise the DR estimator is applied.
+    tau: float, default=np.inf
+        Switching hyperparameter. When importance weight is larger than this parameter, DM is applied, otherwise DR is used.
         This hyperparameter should be larger than or equal to 0., otherwise it is meaningless.
 
     estimator_name: str, default='switch-dr'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ----------
@@ -1354,9 +1523,12 @@ class SwitchDoublyRobust(DoublyRobust):
     Yu-Xiang Wang, Alekh Agarwal, and Miroslav Dudík.
     "Optimal and Adaptive Off-policy Evaluation in Contextual Bandits", 2016.
 
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
+
     """
 
-    tau: float = 1.0
+    tau: float = np.inf
     estimator_name: str = "switch-dr"
 
     def __post_init__(self) -> None:
@@ -1379,8 +1551,8 @@ class SwitchDoublyRobust(DoublyRobust):
         estimated_rewards_by_reg_model: np.ndarray,
         position: Optional[np.ndarray] = None,
         **kwargs,
-    ) -> float:
-        """Estimate rewards for each round.
+    ) -> np.ndarray:
+        """Estimate round-wise (or sample-wise) rewards.
 
         Parameters
         ----------
@@ -1388,24 +1560,26 @@ class SwitchDoublyRobust(DoublyRobust):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
         estimated_rewards: array-like, shape (n_rounds,)
-            Rewards estimated by the Switch-DR estimator for each round.
+            Rewards of each round estimated by the Switch-DR estimator.
 
         """
         n_rounds = action.shape[0]
@@ -1430,7 +1604,8 @@ class SwitchDoublyRobust(DoublyRobust):
         self,
         **kwargs,
     ) -> torch.Tensor:
-        """Estimate policy value of an evaluation policy and return PyTorch Tensor.
+        """
+        Estimate the policy value of evaluation policy and return PyTorch Tensor.
         This is intended for being used with NNPolicyLearner.
         This is not implemented because switching is indifferentiable.
         """
@@ -1438,10 +1613,78 @@ class SwitchDoublyRobust(DoublyRobust):
             "This is not implemented for Switch-DR because it is indifferentiable."
         )
 
+    def _estimate_mse_score(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+    ) -> float:
+        """Estimate the MSE score of a given switching hyperparameter to conduct hyperparameter tuning.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
+
+        Returns
+        ----------
+        estimated_mse_score: float
+            Estimated MSE score of a given switching hyperparameter `tau`.
+            MSE score is the sum of (high probability) upper bound of bias and the sample variance.
+            This is estimated using the automatic hyperparameter tuning procedure
+            based on Section 5 of Su et al.(2020).
+
+        """
+        n_rounds = reward.shape[0]
+        # estimate the sample variance of Switch-DR (Eq.(8) of Wang et al.(2017))
+        sample_variance = np.var(
+            self._estimate_round_rewards(
+                reward=reward,
+                action=action,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                position=position,
+            )
+        )
+        sample_variance /= n_rounds
+
+        # estimate the (high probability) upper bound of the bias of Switch-DR
+        iw = action_dist[np.arange(n_rounds), action, position] / pscore
+        bias_upper_bound = estimate_high_probability_upper_bound_bias(
+            reward=reward,
+            iw=iw,
+            iw_hat=iw * np.array(iw <= self.tau, dtype=int),
+            q_hat=estimated_rewards_by_reg_model[np.arange(n_rounds), action, position],
+        )
+        estimated_mse_score = sample_variance + (bias_upper_bound ** 2)
+
+        return estimated_mse_score
+
 
 @dataclass
 class DoublyRobustWithShrinkage(DoublyRobust):
-    """Estimate the policy value by Doubly Robust with optimistic shrinkage (DRos).
+    """Doubly Robust with optimistic shrinkage (DRos) Estimator.
 
     Note
     ------
@@ -1471,7 +1714,6 @@ class DoublyRobustWithShrinkage(DoublyRobust):
     In contrast, as :math:`\\lambda \\rightarrow \\infty`, :math:`w_{o} (x,a;\\lambda)` increases and in the limit becomes equal to
     the original importance weight, corresponding to the standard DR estimator.
 
-
     Parameters
     ----------
     lambda_: float
@@ -1479,7 +1721,7 @@ class DoublyRobustWithShrinkage(DoublyRobust):
         This hyperparameter should be larger than or equal to 0., otherwise it is meaningless.
 
     estimator_name: str, default='dr-os'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ----------
@@ -1515,7 +1757,7 @@ class DoublyRobustWithShrinkage(DoublyRobust):
         position: Optional[Union[np.ndarray, torch.Tensor]] = None,
         **kwargs,
     ) -> Union[np.ndarray, torch.Tensor]:
-        """Estimate rewards for each round.
+        """Estimate round-wise (or sample-wise) rewards.
 
         Parameters
         ----------
@@ -1523,29 +1765,34 @@ class DoublyRobustWithShrinkage(DoublyRobust):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like or Tensor, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like or Tensor, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like or Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like or Tensor, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like or Tensor, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+            When None is given, the effect of position on the reward will be ignored.
+            (If only one action is chosen and there is no posion, then you can just ignore this argument.)
 
         Returns
         ----------
         estimated_rewards: array-like or Tensor, shape (n_rounds,)
-            Rewards estimated by the DRos estimator for each round.
+            Rewards of each round estimated by the DRos estimator.
 
         """
         n_rounds = action.shape[0]
         iw = action_dist[np.arange(n_rounds), action, position] / pscore
-        shrinkage_weight = (self.lambda_ * iw) / (iw ** 2 + self.lambda_)
+        if self.lambda_ < np.inf:
+            iw_hat = (self.lambda_ * iw) / (iw ** 2 + self.lambda_)
+        else:
+            iw_hat = iw
         q_hat_at_position = estimated_rewards_by_reg_model[
             np.arange(n_rounds), :, position
         ]
@@ -1565,5 +1812,75 @@ class DoublyRobustWithShrinkage(DoublyRobust):
         else:
             raise ValueError("reward must be ndarray or Tensor")
 
-        estimated_rewards += shrinkage_weight * (reward - q_hat_factual)
+        estimated_rewards += iw_hat * (reward - q_hat_factual)
         return estimated_rewards
+
+    def _estimate_mse_score(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+    ) -> float:
+        """Estimate the MSE score of a given shrinkage hyperparameter to conduct hyperparameter tuning.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        Returns
+        ----------
+        estimated_mse_score: float
+            Estimated MSE score of a given shrinkage hyperparameter `lambda_`.
+            MSE score is the sum of (high probability) upper bound of bias and the sample variance.
+            This is estimated using the automatic hyperparameter tuning procedure
+            based on Section 5 of Su et al.(2020).
+
+        """
+        n_rounds = reward.shape[0]
+        # estimate the sample variance of DRos
+        sample_variance = np.var(
+            self._estimate_round_rewards(
+                reward=reward,
+                action=action,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                position=position,
+            )
+        )
+        sample_variance /= n_rounds
+
+        # estimate the (high probability) upper bound of the bias of DRos
+        iw = action_dist[np.arange(n_rounds), action, position] / pscore
+        if self.lambda_ < np.inf:
+            iw_hat = (self.lambda_ * iw) / (iw ** 2 + self.lambda_)
+        else:
+            iw_hat = iw
+        bias_upper_bound = estimate_high_probability_upper_bound_bias(
+            reward=reward,
+            iw=iw,
+            iw_hat=iw_hat,
+            q_hat=estimated_rewards_by_reg_model[np.arange(n_rounds), action, position],
+        )
+        estimated_mse_score = sample_variance + (bias_upper_bound ** 2)
+
+        return estimated_mse_score

--- a/obp/ope/estimators_tuning.py
+++ b/obp/ope/estimators_tuning.py
@@ -1,0 +1,934 @@
+# Copyright (c) Yuta Saito, Yusuke Narita, and ZOZO Technologies, Inc. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+"""Off-Policy Estimators with built-in hyperparameter tuning."""
+from dataclasses import dataclass, field
+from typing import Dict, Optional, List
+
+import numpy as np
+from sklearn.utils import check_scalar
+
+from .estimators import (
+    BaseOffPolicyEstimator,
+    InverseProbabilityWeighting,
+    DoublyRobust,
+    SwitchDoublyRobust,
+    DoublyRobustWithShrinkage,
+)
+from ..utils import check_ope_inputs
+
+
+@dataclass
+class BaseOffPolicyEstimatorTuning:
+    """Base Class for Off-Policy Estimator with built-in hyperparameter tuning
+
+    base_ope_estimator: BaseOffPolicyEstimator
+        An OPE estimator with a hyperparameter
+        (such as IPW/DR with clipping, Switch-DR, and DR with Shrinkage).
+
+    candidate_hyperparameter_list: List[float]
+        A list of candidate hyperparameter values.
+
+    References
+    ----------
+    Miroslav Dudík, Dumitru Erhan, John Langford, and Lihong Li.
+    "Doubly Robust Policy Evaluation and Optimization.", 2014.
+
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
+
+    """
+
+    base_ope_estimator: BaseOffPolicyEstimator = field(init=False)
+    candidate_hyperparameter_list: List[float] = field(init=False)
+
+    def __new__(cls, *args, **kwargs):
+        dataclass(cls)
+        return super().__new__(cls)
+
+    def _check_candidate_hyperparameter_list(self, hyperparam_name: str) -> None:
+        """Check type and value of candidate_hyperparameter_list."""
+        if isinstance(self.candidate_hyperparameter_list, list):
+            if len(self.candidate_hyperparameter_list) == 0:
+                raise ValueError(f"{hyperparam_name} must not be empty")
+            for hyperparam_ in self.candidate_hyperparameter_list:
+                check_scalar(
+                    hyperparam_,
+                    name=f"an element of {hyperparam_name}",
+                    target_type=(int, float),
+                    min_val=0.0,
+                )
+                if hyperparam_ != hyperparam_:
+                    raise ValueError(f"an element of {hyperparam_name} must not be nan")
+        else:
+            raise TypeError(f"{hyperparam_name} must be a list")
+
+    def _tune_hyperparam(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[np.ndarray] = None,
+        position: Optional[np.ndarray] = None,
+    ) -> None:
+        """Find the best hyperparameter value from the given candidate set."""
+        self.estimated_mse_score_dict = dict()
+        for hyperparam_ in self.candidate_hyperparameter_list:
+            estimated_mse_score = self.base_ope_estimator(
+                hyperparam_
+            )._estimate_mse_score(
+                reward=reward,
+                action=action,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                position=position,
+            )
+            self.estimated_mse_score_dict[hyperparam_] = estimated_mse_score
+        self.best_hyperparam = min(
+            self.estimated_mse_score_dict.items(), key=lambda x: x[1]
+        )[0]
+
+    def estimate_policy_value_with_tuning(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[np.ndarray] = None,
+        position: Optional[np.ndarray] = None,
+    ) -> float:
+        """Estimate the policy value of evaluation policy with a tuned hyperparameter.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        Returns
+        ----------
+        V_hat: float
+            Policy value estimated by the DR estimator.
+
+        """
+        # tune hyperparameter if necessary
+        if not hasattr(self, "best_hyperparam"):
+            self._tune_hyperparam(
+                reward=reward,
+                action=action,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                position=position,
+            )
+
+        return self.base_ope_estimator(self.best_hyperparam).estimate_policy_value(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+
+    def estimate_interval_with_tuning(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[np.ndarray] = None,
+        position: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        alpha: float, default=0.05
+            Significance level.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        # tune hyperparameter if necessary
+        if not hasattr(self, "best_hyperparam"):
+            self._tune_hyperparam(
+                reward=reward,
+                action=action,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                position=position,
+            )
+
+        return self.base_ope_estimator(self.best_hyperparam).estimate_interval(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+class InverseProbabilityWeightingTuning(BaseOffPolicyEstimatorTuning):
+    """Inverse Probability Weighting (IPW) with built-in hyperparameter tuning.
+
+    Parameters
+    ----------
+    lambdas: List[float]
+        A list of candidate clipping hyperparameters.
+        The automatic hyperparameter tuning proposed by Su et al.(2020)
+        will choose the best hyperparameter value from the data.
+
+    estimator_name: str, default='ipw'.
+        Name of the estimator.
+
+    References
+    ----------
+    Miroslav Dudík, Dumitru Erhan, John Langford, and Lihong Li.
+    "Doubly Robust Policy Evaluation and Optimization.", 2014.
+
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
+
+    """
+
+    lambdas: List[float] = None
+    estimator_name: str = "ipw"
+
+    def __post_init__(self) -> None:
+        """Initialize Class."""
+        self.base_ope_estimator = InverseProbabilityWeighting
+        self.candidate_hyperparameter_list = self.lambdas
+        super()._check_candidate_hyperparameter_list(hyperparam_name="lambdas")
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        **kwargs,
+    ) -> np.ndarray:
+        """Estimate the policy value of evaluation policy.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        Returns
+        ----------
+        V_hat: float
+            Estimated policy value (performance) of a given evaluation policy.
+
+        """
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        return super().estimate_policy_value_with_tuning(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+        )
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities
+            by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        alpha: float, default=0.05
+            Significance level.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        return super().estimate_interval_with_tuning(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@dataclass
+class DoublyRobustTuning(BaseOffPolicyEstimatorTuning):
+    """Doubly Robust (DR) with built-in hyperparameter tuning.
+
+    Parameters
+    ----------
+    lambdas: List[float]
+        A list of candidate clipping hyperparameters.
+        The automatic hyperparameter tuning proposed by Su et al.(2020)
+        will choose the best hyperparameter value from the data.
+
+    estimator_name: str, default='dr'.
+        Name of the estimator.
+
+    References
+    ----------
+    Miroslav Dudík, Dumitru Erhan, John Langford, and Lihong Li.
+    "Doubly Robust Policy Evaluation and Optimization.", 2014.
+
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
+
+    """
+
+    lambdas: List[float] = None
+    estimator_name: str = "dr"
+
+    def __post_init__(self) -> None:
+        """Initialize Class."""
+        self.base_ope_estimator = DoublyRobust
+        self.candidate_hyperparameter_list = self.lambdas
+        super()._check_candidate_hyperparameter_list(hyperparam_name="lambdas")
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+    ) -> float:
+        """Estimate the policy value of evaluation policy with a tuned hyperparameter.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        Returns
+        ----------
+        V_hat: float
+            Policy value estimated by the DR estimator.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        return super().estimate_policy_value_with_tuning(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        alpha: float, default=0.05
+            Significance level.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        return super().estimate_interval_with_tuning(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@dataclass
+class SwitchDoublyRobustTuning(BaseOffPolicyEstimatorTuning):
+    """Switch Doubly Robust (Switch-DR) with build-in hyperparameter tuning.
+
+    Parameters
+    ----------
+    taus: List[float]
+        A list of candidate switching hyperparameters.
+        The automatic hyperparameter tuning proposed by Su et al.(2020)
+        will choose the best hyperparameter value from the data.
+
+    estimator_name: str, default='switch-dr'.
+        Name of the estimator.
+
+    References
+    ----------
+    Miroslav Dudík, Dumitru Erhan, John Langford, and Lihong Li.
+    "Doubly Robust Policy Evaluation and Optimization.", 2014.
+
+    Yu-Xiang Wang, Alekh Agarwal, and Miroslav Dudík.
+    "Optimal and Adaptive Off-policy Evaluation in Contextual Bandits", 2016.
+
+    """
+
+    taus: List[float] = None
+    estimator_name: str = "switch-dr"
+
+    def __post_init__(self) -> None:
+        """Initialize Class."""
+        self.base_ope_estimator = SwitchDoublyRobust
+        self.candidate_hyperparameter_list = self.taus
+        super()._check_candidate_hyperparameter_list(hyperparam_name="taus")
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+    ) -> float:
+        """Estimate the policy value of evaluation policy with a tuned hyperparameter.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        Returns
+        ----------
+        V_hat: float
+            Policy value estimated by the DR estimator.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        return super().estimate_policy_value_with_tuning(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        alpha: float, default=0.05
+            Significance level.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        return super().estimate_interval_with_tuning(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@dataclass
+class DoublyRobustWithShrinkageTuning(BaseOffPolicyEstimatorTuning):
+    """Doubly Robust with optimistic shrinkage (DRos) with built-in hyperparameter tuning.
+
+    Parameters
+    ----------
+    lambdas: List[float]
+        A list of candidate shrinkage hyperparameters.
+        The automatic hyperparameter tuning proposed by Su et al.(2020)
+        will choose the best hyperparameter value from the data.
+
+    estimator_name: str, default='dr-os'.
+        Name of the estimator.
+
+    References
+    ----------
+    Miroslav Dudík, Dumitru Erhan, John Langford, and Lihong Li.
+    "Doubly Robust Policy Evaluation and Optimization.", 2014.
+
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
+
+    """
+
+    lambdas: List[float] = None
+    estimator_name: str = "dr-os"
+
+    def __post_init__(self) -> None:
+        """Initialize Class."""
+        self.base_ope_estimator = DoublyRobustWithShrinkage
+        self.candidate_hyperparameter_list = self.lambdas
+        super()._check_candidate_hyperparameter_list(hyperparam_name="lambdas")
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+    ) -> float:
+        """Estimate the policy value of evaluation policy with a tuned hyperparameter.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        Returns
+        ----------
+        V_hat: float
+            Policy value estimated by the DR estimator.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        return super().estimate_policy_value_with_tuning(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
+
+        alpha: float, default=0.05
+            Significance level.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        return super().estimate_interval_with_tuning(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )

--- a/obp/ope/helper.py
+++ b/obp/ope/helper.py
@@ -1,0 +1,65 @@
+# Copyright (c) Yuta Saito, Yusuke Narita, and ZOZO Technologies, Inc. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+from typing import Optional
+
+import numpy as np
+from sklearn.utils import check_scalar
+
+
+def estimate_high_probability_upper_bound_bias(
+    reward: np.ndarray,
+    iw: np.ndarray,
+    iw_hat: np.ndarray,
+    q_hat: Optional[np.ndarray] = None,
+    delta: float = 0.05,
+) -> float:
+    """Helper to estimate a high probability upper bound of bias in OPE.
+
+    Parameters
+    ----------
+    reward: array-like, shape (n_rounds,)
+        Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+    iw: array-like, shape (n_rounds,)
+        Importance weight in each round of the logged bandit feedback, i.e., :math:`w(x,a)=\\pi_e(a|x)/ \\pi_b(a|x)`.
+
+    iw_hat: array-like, shape (n_rounds,)
+        Importance weight (IW) modified by a hyparpareter. How IW is modified depends on the estimator as follows.
+            - clipping: :math:`\\hat{w}(x,a) := \\min \\{ \\lambda, w(x,a) \\}`
+            - switching: :math:`\\hat{w}(x,a) := w(x,a) \\cdot \\mathbb{I} \\{ w(x,a) < \\tau \\}`
+            - shrinkage: :math:`\\hat{w}(x,a) := (\\lambda w(x,a)) / (\\lambda + w^2(x,a))`
+        where :math:`\\tau` and :math:`\\lambda` are hyperparameters.
+
+    q_hat: array-like, shape (n_rounds,), default=None
+        Estimated expected reward given context :math:`x_t` and action :math:`a_t`.
+
+    delta: float, default=0.05
+        A confidence delta to construct a high probability upper bound based on the Bernstein’s inequality.
+
+    Returns
+    ----------
+    bias_upper_bound: float
+        Estimated (high probability) upper bound of the bias.
+        This upper bound is based on the direct bias estimation
+        stated on page 17 of Su et al.(2020).
+
+    References
+    ----------
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
+
+    """
+    check_scalar(
+        delta, name="delta", target_type=(int, float), max_val=1.0, min_val=0.0
+    )
+
+    n_rounds = reward.shape[0]
+    if q_hat is None:
+        q_hat = np.zeros(n_rounds)
+    bias_upper_bound_arr = (iw - iw_hat) * (reward - q_hat)
+    bias_upper_bound = np.abs(bias_upper_bound_arr.mean())
+    bias_upper_bound += np.sqrt((2 * (iw ** 2).mean() * np.log(2 / delta)) / n_rounds)
+    bias_upper_bound += (2 * iw.max() * np.log(2 / delta)) / (3 * n_rounds)
+
+    return bias_upper_bound

--- a/obp/ope/meta.py
+++ b/obp/ope/meta.py
@@ -21,12 +21,12 @@ logger = getLogger(__name__)
 
 @dataclass
 class OffPolicyEvaluation:
-    """Class to conduct off-policy evaluation by multiple off-policy estimators simultaneously.
+    """Class to conduct OPE by multiple estimators simultaneously.
 
     Parameters
     -----------
     bandit_feedback: BanditFeedback
-        Logged bandit feedback data used for off-policy evaluation.
+        Logged bandit feedback data used to conduct OPE.
 
     ope_estimators: List[BaseOffPolicyEstimator]
         List of OPE estimators used to evaluate the policy value of evaluation policy.
@@ -94,7 +94,7 @@ class OffPolicyEvaluation:
             Union[np.ndarray, Dict[str, np.ndarray]]
         ] = None,
     ) -> Dict[str, Dict[str, np.ndarray]]:
-        """Create input dictionary to estimate policy value by subclasses of `BaseOffPolicyEstimator`"""
+        """Create input dictionary to estimate policy value using subclasses of `BaseOffPolicyEstimator`"""
         if not isinstance(action_dist, np.ndarray):
             raise ValueError("action_dist must be ndarray")
         if action_dist.ndim != 3:
@@ -152,15 +152,15 @@ class OffPolicyEvaluation:
             Union[np.ndarray, Dict[str, np.ndarray]]
         ] = None,
     ) -> Dict[str, float]:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ------------
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given each round, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
@@ -193,21 +193,21 @@ class OffPolicyEvaluation:
         n_bootstrap_samples: int = 100,
         random_state: Optional[int] = None,
     ) -> Dict[str, Dict[str, float]]:
-        """Estimate confidence intervals of estimated policy values using a nonparametric bootstrap procedure.
+        """Estimate confidence intervals of estimated policy values by nonparametric bootstrap procedure.
 
         Parameters
         ------------
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -219,7 +219,7 @@ class OffPolicyEvaluation:
         ----------
         policy_value_interval_dict: Dict[str, Dict[str, float]]
             Dictionary containing confidence intervals of estimated policy value estimated
-            using a nonparametric bootstrap procedure.
+            by nonparametric bootstrap procedure.
 
         """
         check_confidence_interval_arguments(
@@ -252,21 +252,21 @@ class OffPolicyEvaluation:
         n_bootstrap_samples: int = 100,
         random_state: Optional[int] = None,
     ) -> Tuple[DataFrame, DataFrame]:
-        """Summarize policy values estimated by OPE estimators and their confidence intervals estimated by a nonparametric bootstrap procedure.
+        """Summarize policy values and their confidence intervals estimated by OPE estimators.
 
         Parameters
         ------------
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given each round, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -277,7 +277,7 @@ class OffPolicyEvaluation:
         Returns
         ----------
         (policy_value_df, policy_value_interval_df): Tuple[DataFrame, DataFrame]
-            Estimated policy values and their confidence intervals by OPE estimators.
+            Policy values and their confidence intervals Estimated by OPE estimators.
 
         """
         policy_value_df = DataFrame(
@@ -327,16 +327,16 @@ class OffPolicyEvaluation:
         Parameters
         ----------
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -406,11 +406,11 @@ class OffPolicyEvaluation:
         ] = None,
         metric: str = "relative-ee",
     ) -> Dict[str, float]:
-        """Evaluate estimation performances of OPE estimators.
+        """Evaluate estimation performance of OPE estimators.
 
         Note
         ------
-        Evaluate the estimation performances of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
+        Evaluate the estimation performance of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
 
         .. math ::
 
@@ -426,20 +426,20 @@ class OffPolicyEvaluation:
         Parameters
         ----------
         ground_truth policy value: float
-            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
-            With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as its ground-truth.
+            Ground_truth policy value of evaluation policy, i.e., :math:`V(\\pi_e)`.
+            With Open Bandit Dataset, we use an on-policy estimate of the policy value as its ground-truth.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         metric: str, default="relative-ee"
-            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
+            Evaluation metric used to evaluate and compare the estimation performance of OPE estimators.
             Must be "relative-ee" or "se".
 
         Returns
@@ -494,18 +494,18 @@ class OffPolicyEvaluation:
         Parameters
         ----------
         ground_truth policy value: float
-            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
-            With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as ground-truth.
+            Ground_truth policy value of evaluation policy, i.e., :math:`V(\\pi_e)`.
+            With Open Bandit Dataset, we use an on-policy estimate of the policy value as ground-truth.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         metric: str, default="relative-ee"
-            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
+            Evaluation metric used to evaluate and compare the estimation performance of OPE estimators.
             Must be either "relative-ee" or "se".
 
         Returns
@@ -550,13 +550,13 @@ class OffPolicyEvaluation:
             List of action choice probabilities by the evaluation policies (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of an estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.

--- a/obp/ope/meta_slate.py
+++ b/obp/ope/meta_slate.py
@@ -161,18 +161,18 @@ class SlateOffPolicyEvaluation:
         evaluation_policy_pscore_item_position: Optional[np.ndarray] = None,
         evaluation_policy_pscore_cascade: Optional[np.ndarray] = None,
     ) -> Dict[str, float]:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ------------
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         Returns
         ----------
@@ -202,21 +202,21 @@ class SlateOffPolicyEvaluation:
         n_bootstrap_samples: int = 100,
         random_state: Optional[int] = None,
     ) -> Dict[str, Dict[str, float]]:
-        """Estimate confidence intervals of estimated policy values using a nonparametric bootstrap procedure.
+        """Estimate confidence intervals of estimated policy values by nonparametric bootstrap procedure.
 
         Parameters
         ------------
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -228,7 +228,7 @@ class SlateOffPolicyEvaluation:
         ----------
         policy_value_interval_dict: Dict[str, Dict[str, float]]
             Dictionary containing confidence intervals of estimated policy value estimated
-            using a nonparametric bootstrap procedure.
+            by nonparametric bootstrap procedure.
 
         """
         check_confidence_interval_arguments(
@@ -266,16 +266,16 @@ class SlateOffPolicyEvaluation:
         Parameters
         ------------
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -286,7 +286,7 @@ class SlateOffPolicyEvaluation:
         Returns
         ----------
         (policy_value_df, policy_value_interval_df): Tuple[DataFrame, DataFrame]
-            Estimated policy values and their confidence intervals by OPE estimators.
+            Policy values and their confidence intervals Estimated by OPE estimators.
 
         """
         policy_value_df = DataFrame(
@@ -340,16 +340,16 @@ class SlateOffPolicyEvaluation:
         Parameters
         ----------
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -425,11 +425,11 @@ class SlateOffPolicyEvaluation:
         evaluation_policy_pscore_cascade: Optional[np.ndarray] = None,
         metric: str = "relative-ee",
     ) -> Dict[str, float]:
-        """Evaluate estimation performances of OPE estimators.
+        """Evaluate estimation performance of OPE estimators.
 
         Note
         ------
-        Evaluate the estimation performances of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
+        Evaluate the estimation performance of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
 
         .. math ::
 
@@ -445,20 +445,20 @@ class SlateOffPolicyEvaluation:
         Parameters
         ----------
         ground_truth_policy_value: float
-            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
+            Ground_truth policy value of evaluation policy, i.e., :math:`V(\\pi)`.
             With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as its ground-truth.
 
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         metric: str, default="relative-ee"
-            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
+            Evaluation metric used to evaluate and compare the estimation performance of OPE estimators.
             Must be "relative-ee" or "se".
 
         Returns
@@ -511,20 +511,20 @@ class SlateOffPolicyEvaluation:
         Parameters
         ----------
         ground_truth_policy_value: float
-            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
+            Ground_truth policy value of evaluation policy, i.e., :math:`V(\\pi)`.
             With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as ground-truth.
 
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         metric: str, default="relative-ee"
-            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
+            Evaluation metric used to evaluate and compare the estimation performance of OPE estimators.
             Must be either "relative-ee" or "se".
 
         Returns

--- a/obp/ope/regression_model.py
+++ b/obp/ope/regression_model.py
@@ -105,7 +105,7 @@ class RegressionModel(BaseEstimator):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -116,12 +116,12 @@ class RegressionModel(BaseEstimator):
             When None is given, the behavior policy is assumed to be a uniform one.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
             If None is set, a regression model assumes that there is only one position.
             When `len_list` > 1, this position argument has to be set.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
             When either of 'iw' or 'mrdr' is used as the 'fitting_method' argument, then `action_dist` must be given.
 
         """
@@ -249,7 +249,7 @@ class RegressionModel(BaseEstimator):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -260,12 +260,12 @@ class RegressionModel(BaseEstimator):
             When None is given, the the behavior policy is assumed to be a uniform one.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
             If None is set, a regression model assumes that there is only one position.
             When `len_list` > 1, this position argument has to be set.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
             When either of 'iw' or 'mrdr' is used as the 'fitting_method' argument, then `action_dist` must be given.
 
         n_folds: int, default=1
@@ -374,7 +374,7 @@ class RegressionModel(BaseEstimator):
             Context vectors in the training logged bandit feedback.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         action_context: array-like, shape shape (n_actions, dim_action_context)
             Context vector characterizing each action, vector representation of each action.

--- a/obp/policy/offline.py
+++ b/obp/policy/offline.py
@@ -77,7 +77,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -126,16 +126,16 @@ class IPWLearner(BaseOfflinePolicyLearner):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
 
         pscore: array-like, shape (n_rounds,), default=None
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
             If None is given, a learner assumes that there is only one position.
             When `len_list` > 1, position has to be set.
 
@@ -644,7 +644,7 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -654,10 +654,10 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
             in the given logged bandit feedback.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
             If None is given, a learner assumes that there is only one position.
 
         Returns
@@ -740,20 +740,20 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
 
         pscore: array-like, shape (n_rounds,), default=None
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             If None is given, a learner assumes that the estimated rewards are zero.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
             If None is given, a learner assumes that there is only one position.
             When `len_list` > 1, position has to be set.
             Currently, this feature is not supported.

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -20,7 +20,7 @@ def check_confidence_interval_arguments(
     Parameters
     ----------
     alpha: float, default=0.05
-        Significant level of confidence intervals.
+        Significance level.
 
     n_bootstrap_samples: int, default=10000
         Number of resampling performed in the bootstrap procedure.
@@ -62,7 +62,7 @@ def estimate_confidence_interval_by_bootstrap(
         Empirical observed samples to be used to estimate cumulative distribution function.
 
     alpha: float, default=0.05
-        Significant level of confidence intervals.
+        Significance level.
 
     n_bootstrap_samples: int, default=10000
         Number of resampling performed in the bootstrap procedure.
@@ -143,7 +143,7 @@ def check_bandit_feedback_inputs(
         Context vectors in each round, i.e., :math:`x_t`.
 
     action: array-like, shape (n_rounds,)
-        Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+        Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
     reward: array-like, shape (n_rounds,)
         Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -152,7 +152,7 @@ def check_bandit_feedback_inputs(
         Expected rewards (or outcome) in each round, i.e., :math:`\\mathbb{E}[r_t]`.
 
     position: array-like, shape (n_rounds,), default=None
-        Positions of each round in the given logged bandit feedback.
+        Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
     pscore: array-like, shape (n_rounds,), default=None
         Propensity scores, the probability of selecting each action by behavior policy,
@@ -249,13 +249,13 @@ def check_ope_inputs(
     Parameters
     -----------
     action_dist: array-like, shape (n_rounds, n_actions, len_list)
-        Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+        Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
     position: array-like, shape (n_rounds,), default=None
-        Positions of each round in the given logged bandit feedback.
+        Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
     action: array-like, shape (n_rounds,), default=None
-        Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+        Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
     reward: array-like, shape (n_rounds,), default=None
         Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -265,7 +265,7 @@ def check_ope_inputs(
         in the given logged bandit feedback.
 
     estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-        Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+        Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
     """
     # action_dist
@@ -346,16 +346,16 @@ def _check_slate_ope_inputs(
         Slate id observed in each round of the logged bandit feedback.
 
     reward: array-like, shape (<= n_rounds * len_list,)
-        Reward observed in each round and slot of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
+        Reward observed at each slot in each round of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
 
     position: array-like, shape (<= n_rounds * len_list,)
         Positions of each round and slot in the given logged bandit feedback.
 
     pscore: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities by a behavior policy (propensity scores).
+        Action choice probabilities of behavior policy (propensity scores).
 
     evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities by the evaluation policy (propensity scores).
+        Action choice probabilities of evaluation policy.
 
     pscore_type: str
         Either "pscore", "pscore_item_position", or "pscore_cascade".
@@ -427,16 +427,16 @@ def check_sips_inputs(
         Slate id observed in each round of the logged bandit feedback.
 
     reward: array-like, shape (<= n_rounds * len_list,)
-        Reward observed in each round and slot of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
+        Reward observed at each slot in each round of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
 
     position: array-like, shape (<= n_rounds * len_list,)
         Positions of each round and slot in the given logged bandit feedback.
 
     pscore: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+        Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
     evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+        Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
     """
     _check_slate_ope_inputs(
@@ -486,7 +486,7 @@ def check_iips_inputs(
         Slate id observed in each round of the logged bandit feedback.
 
     reward: array-like, shape (<= n_rounds * len_list,)
-        Reward observed in each round and slot of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
+        Reward observed at each slot in each round of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
 
     position: array-like, shape (<= n_rounds * len_list,)
         Positions of each round and slot in the given logged bandit feedback.
@@ -495,7 +495,7 @@ def check_iips_inputs(
         Marginal action choice probabilities of the slot (:math:`k`) by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_{t}(k) |x_t)`.
 
     evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-        Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t}(k) |x_t)`.
+        Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t}(k) |x_t)`.
 
     """
     _check_slate_ope_inputs(
@@ -530,16 +530,16 @@ def check_rips_inputs(
         Slate id observed in each round of the logged bandit feedback.
 
     reward: array-like, shape (<= n_rounds * len_list,)
-        Reward observed in each round and slot of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
+        Reward observed at each slot in each round of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
 
     position: array-like, shape (<= n_rounds * len_list,)
         Positions of each round and slot in the given logged bandit feedback.
 
     pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+        Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
     evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+        Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
     """
     _check_slate_ope_inputs(
@@ -609,13 +609,13 @@ def check_ope_inputs_tensor(
     Parameters
     -----------
     action_dist: Tensor, shape (n_rounds, n_actions, len_list)
-        Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+        Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
     position: Tensor, shape (n_rounds,), default=None
-        Positions of each round in the given logged bandit feedback.
+        Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
     action: Tensor, shape (n_rounds,), default=None
-        Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+        Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
     reward: Tensor, shape (n_rounds,), default=None
         Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -625,7 +625,7 @@ def check_ope_inputs_tensor(
         in the given logged bandit feedback.
 
     estimated_rewards_by_reg_model: Tensor, shape (n_rounds, n_actions, len_list), default=None
-        Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+        Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
     """
     # action_dist

--- a/tests/ope/test_all_estimators.py
+++ b/tests/ope/test_all_estimators.py
@@ -112,7 +112,7 @@ valid_input_of_estimation = [
         np.ones(5),
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
-        "all argumnents are given and len_list > 1",
+        "all arguments are given and len_list > 1",
     ),
     (
         generate_action_dist(5, 4, 1),
@@ -121,7 +121,7 @@ valid_input_of_estimation = [
         np.ones(5),
         np.zeros(5, dtype=int),
         np.zeros((5, 4, 1)),
-        "all argumnents are given and len_list == 1",
+        "all arguments are given and len_list == 1",
     ),
     (
         generate_action_dist(5, 4, 1),
@@ -130,7 +130,7 @@ valid_input_of_estimation = [
         np.ones(5),
         None,
         np.zeros((5, 4, 1)),
-        "position argumnent is None",
+        "position argument is None",
     ),
 ]
 
@@ -314,7 +314,7 @@ valid_input_of_estimation_tensor = [
         torch.from_numpy(np.ones(5)),
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.from_numpy(np.zeros((5, 4, 3))),
-        "all argumnents are given and len_list > 1",
+        "all arguments are given and len_list > 1",
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 1)),
@@ -323,7 +323,7 @@ valid_input_of_estimation_tensor = [
         torch.from_numpy(np.ones(5)),
         torch.from_numpy(np.zeros(5, dtype=int)),
         torch.from_numpy(np.zeros((5, 4, 1))),
-        "all argumnents are given and len_list == 1",
+        "all arguments are given and len_list == 1",
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 1)),
@@ -332,7 +332,7 @@ valid_input_of_estimation_tensor = [
         torch.from_numpy(np.ones(5)),
         None,
         torch.from_numpy(np.zeros((5, 4, 1))),
-        "position argumnent is None",
+        "position argument is None",
     ),
 ]
 

--- a/tests/ope/test_dm_estimators.py
+++ b/tests/ope/test_dm_estimators.py
@@ -15,19 +15,19 @@ invalid_input_of_dm = [
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        np.zeros((5, 4, 2)),
+        np.zeros((5, 4, 2)),  #
         "estimated_rewards_by_reg_model.shape must be the same as action_dist.shape",
     ),
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        None,
+        None,  #
         "estimated_rewards_by_reg_model must be ndarray",
     ),
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        "4",
+        "4",  #
         "estimated_rewards_by_reg_model must be ndarray",
     ),
 ]
@@ -58,23 +58,24 @@ def test_dm_using_invalid_input_data(
         )
 
 
+# action_dist, position, estimated_rewards_by_reg_model, description
 invalid_input_tensor_of_dm = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        torch.from_numpy(np.zeros((5, 4, 2))),
+        torch.from_numpy(np.zeros((5, 4, 2))),  #
         "estimated_rewards_by_reg_model.shape must be the same as action_dist.shape",
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        None,
+        None,  #
         "estimated_rewards_by_reg_model must be Tensor",
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        "4",
+        "4",  #
         "estimated_rewards_by_reg_model must be Tensor",
     ),
 ]

--- a/tests/ope/test_dr_estimators.py
+++ b/tests/ope/test_dr_estimators.py
@@ -27,6 +27,7 @@ invalid_input_of_dr_init = [
         r"`lambda_` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
     ),
     (-1.0, ValueError, "`lambda_`= -1.0, must be >= 0.0."),
+    (np.nan, ValueError, "lambda_ must not be nan"),
 ]
 
 
@@ -58,6 +59,7 @@ invalid_input_of_switch_dr_init = [
         r"`tau` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
     ),
     (-1.0, ValueError, "`tau`= -1.0, must be >= 0.0."),
+    (np.nan, ValueError, "tau must not be nan"),
 ]
 
 

--- a/tests/ope/test_dr_estimators.py
+++ b/tests/ope/test_dr_estimators.py
@@ -496,7 +496,7 @@ valid_input_of_dr_variants = [
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
         0.5,
-        "all argumnents are given and len_list > 1",
+        "all arguments are given and len_list > 1",
     )
 ]
 
@@ -540,7 +540,7 @@ valid_input_tensor_of_dr_variants = [
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.zeros((5, 4, 3)),
         0.5,
-        "all argumnents are given and len_list > 1",
+        "all arguments are given and len_list > 1",
     )
 ]
 

--- a/tests/ope/test_dr_estimators.py
+++ b/tests/ope/test_dr_estimators.py
@@ -14,6 +14,82 @@ from obp.ope import (
 )
 from conftest import generate_action_dist
 
+
+invalid_input_of_dr_init = [
+    (
+        "",
+        TypeError,
+        r"`lambda_` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
+    ),
+    (
+        None,
+        TypeError,
+        r"`lambda_` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
+    ),
+    (-1.0, ValueError, "`lambda_`= -1.0, must be >= 0.0."),
+]
+
+
+@pytest.mark.parametrize(
+    "lambda_, err, description",
+    invalid_input_of_dr_init,
+)
+def test_dr_init_using_invalid_inputs(
+    lambda_,
+    err,
+    description,
+):
+    with pytest.raises(err, match=f"{description}*"):
+        _ = DoublyRobust(lambda_=lambda_)
+
+    with pytest.raises(err, match=f"{description}*"):
+        _ = DoublyRobustWithShrinkage(lambda_=lambda_)
+
+
+invalid_input_of_switch_dr_init = [
+    (
+        "",
+        TypeError,
+        r"`tau` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
+    ),
+    (
+        None,
+        TypeError,
+        r"`tau` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
+    ),
+    (-1.0, ValueError, "`tau`= -1.0, must be >= 0.0."),
+]
+
+
+@pytest.mark.parametrize(
+    "tau, err, description",
+    invalid_input_of_switch_dr_init,
+)
+def test_switch_dr_init_using_invalid_inputs(
+    tau,
+    err,
+    description,
+):
+    with pytest.raises(err, match=f"{description}*"):
+        _ = SwitchDoublyRobust(tau=tau)
+
+
+valid_input_of_dr_init = [
+    (3.0, "float lambda_tau"),
+    (2, "integer lambda_tau"),
+]
+
+
+@pytest.mark.parametrize(
+    "lambda_tau, description",
+    valid_input_of_dr_init,
+)
+def test_shrinkage_using_valid_input_data(lambda_tau: float, description: str) -> None:
+    _ = DoublyRobust(lambda_=lambda_tau)
+    _ = DoublyRobustWithShrinkage(lambda_=lambda_tau)
+    _ = SwitchDoublyRobust(lambda_=lambda_tau)
+
+
 # prepare instances
 dm = DirectMethod()
 dr = DoublyRobust()
@@ -31,7 +107,7 @@ dr_estimators = [dr, dr_shrink_0, sndr, switch_dr_0]
 invalid_input_of_dr = [
     (
         generate_action_dist(5, 4, 3),
-        None,
+        None,  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -41,7 +117,7 @@ invalid_input_of_dr = [
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        None,
+        None,  #
         np.ones(5),
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
@@ -51,7 +127,7 @@ invalid_input_of_dr = [
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
         np.zeros(5, dtype=int),
-        None,
+        None,  #
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
         "pscore must be ndarray",
@@ -62,12 +138,12 @@ invalid_input_of_dr = [
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
-        None,
+        None,  #
         "estimated_rewards_by_reg_model must be ndarray",
     ),
     (
         generate_action_dist(5, 4, 3),
-        np.zeros(5, dtype=float),
+        np.zeros(5, dtype=float),  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -76,7 +152,7 @@ invalid_input_of_dr = [
     ),
     (
         generate_action_dist(5, 4, 3),
-        np.zeros(5, dtype=int) - 1,
+        np.zeros(5, dtype=int) - 1,  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -85,7 +161,7 @@ invalid_input_of_dr = [
     ),
     (
         generate_action_dist(5, 4, 3),
-        "4",
+        "4",  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -94,7 +170,7 @@ invalid_input_of_dr = [
     ),
     (
         generate_action_dist(5, 4, 3),
-        np.zeros((3, 2), dtype=int),
+        np.zeros((3, 2), dtype=int),  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -103,7 +179,7 @@ invalid_input_of_dr = [
     ),
     (
         generate_action_dist(5, 4, 3),
-        np.zeros(5, dtype=int) + 8,
+        np.zeros(5, dtype=int) + 8,  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -113,7 +189,7 @@ invalid_input_of_dr = [
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        "4",
+        "4",  #
         np.ones(5),
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
@@ -122,7 +198,7 @@ invalid_input_of_dr = [
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        np.zeros((3, 2), dtype=int),
+        np.zeros((3, 2), dtype=int),  #
         np.ones(5),
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
@@ -131,7 +207,7 @@ invalid_input_of_dr = [
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        np.zeros(4, dtype=int),
+        np.zeros(4, dtype=int),  #
         np.ones(5),
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
@@ -141,7 +217,7 @@ invalid_input_of_dr = [
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
         np.zeros(5, dtype=int),
-        "4",
+        "4",  #
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
         "pscore must be ndarray",
@@ -150,7 +226,7 @@ invalid_input_of_dr = [
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
         np.zeros(5, dtype=int),
-        np.ones((5, 3)),
+        np.ones((5, 3)),  #
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
         "pscore must be 1-dimensional",
@@ -159,7 +235,7 @@ invalid_input_of_dr = [
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
         np.zeros(5, dtype=int),
-        np.ones(4),
+        np.ones(4),  #
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
         "action, reward, and pscore must be the same size.",
@@ -168,7 +244,7 @@ invalid_input_of_dr = [
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
         np.zeros(5, dtype=int),
-        np.arange(5),
+        np.arange(5),  #
         np.random.choice(3, size=5),
         np.zeros((5, 4, 3)),
         "pscore must be positive",
@@ -179,7 +255,7 @@ invalid_input_of_dr = [
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
-        np.zeros((5, 4, 2)),
+        np.zeros((5, 4, 2)),  #
         "estimated_rewards_by_reg_model.shape must be the same as action_dist.shape",
     ),
     (
@@ -188,7 +264,7 @@ invalid_input_of_dr = [
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
-        "4",
+        "4",  #
         "estimated_rewards_by_reg_model must be ndarray",
     ),
 ]
@@ -234,7 +310,7 @@ def test_dr_using_invalid_input_data(
 invalid_input_tensor_of_dr = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        None,
+        None,  #
         torch.zeros(5, dtype=torch.int64),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -244,7 +320,7 @@ invalid_input_tensor_of_dr = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        None,
+        None,  #
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.zeros((5, 4, 3)),
@@ -254,7 +330,7 @@ invalid_input_tensor_of_dr = [
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
         torch.zeros(5, dtype=torch.int64),
-        None,
+        None,  #
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.zeros((5, 4, 3)),
         "pscore must be Tensor",
@@ -265,12 +341,12 @@ invalid_input_tensor_of_dr = [
         torch.zeros(5, dtype=torch.int64),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
-        None,
+        None,  #
         "estimated_rewards_by_reg_model must be Tensor",
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        torch.zeros(5, dtype=torch.float32),
+        torch.zeros(5, dtype=torch.float32),  #
         torch.zeros(5, dtype=torch.int64),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -279,7 +355,7 @@ invalid_input_tensor_of_dr = [
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        torch.zeros(5, dtype=torch.int64) - 1,
+        torch.zeros(5, dtype=torch.int64) - 1,  #
         torch.zeros(5, dtype=torch.int64),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -288,7 +364,7 @@ invalid_input_tensor_of_dr = [
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        "4",
+        "4",  #
         torch.zeros(5, dtype=torch.int64),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -297,7 +373,7 @@ invalid_input_tensor_of_dr = [
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        torch.zeros((3, 2), dtype=torch.int64),
+        torch.zeros((3, 2), dtype=torch.int64),  #
         torch.zeros(5, dtype=torch.int64),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -306,7 +382,7 @@ invalid_input_tensor_of_dr = [
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        torch.zeros(5, dtype=torch.int64) + 8,
+        torch.zeros(5, dtype=torch.int64) + 8,  #
         torch.zeros(5, dtype=torch.int64),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -316,7 +392,7 @@ invalid_input_tensor_of_dr = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        "4",
+        "4",  #
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.zeros((5, 4, 3)),
@@ -325,7 +401,7 @@ invalid_input_tensor_of_dr = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        torch.zeros((3, 2), dtype=torch.int64),
+        torch.zeros((3, 2), dtype=torch.int64),  #
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.zeros((5, 4, 3)),
@@ -334,7 +410,7 @@ invalid_input_tensor_of_dr = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        torch.zeros(4, dtype=torch.int64),
+        torch.zeros(4, dtype=torch.int64),  #
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.zeros((5, 4, 3)),
@@ -344,7 +420,7 @@ invalid_input_tensor_of_dr = [
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
         torch.zeros(5, dtype=torch.int64),
-        "4",
+        "4",  #
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.zeros((5, 4, 3)),
         "pscore must be Tensor",
@@ -353,7 +429,7 @@ invalid_input_tensor_of_dr = [
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
         torch.zeros(5, dtype=torch.int64),
-        torch.ones((5, 3)),
+        torch.ones((5, 3)),  #
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.zeros((5, 4, 3)),
         "pscore must be 1-dimensional",
@@ -362,7 +438,7 @@ invalid_input_tensor_of_dr = [
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
         torch.zeros(5, dtype=torch.int64),
-        torch.ones(4),
+        torch.ones(4),  #
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.zeros((5, 4, 3)),
         "action, reward, and pscore must be the same size.",
@@ -371,7 +447,7 @@ invalid_input_tensor_of_dr = [
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
         torch.zeros(5, dtype=torch.int64),
-        torch.from_numpy(np.arange(5)),
+        torch.from_numpy(np.arange(5)),  #
         torch.from_numpy(np.random.choice(3, size=5)),
         torch.zeros((5, 4, 3)),
         "pscore must be positive",
@@ -382,7 +458,7 @@ invalid_input_tensor_of_dr = [
         torch.zeros(5, dtype=torch.int64),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
-        torch.zeros((5, 4, 2)),
+        torch.zeros((5, 4, 2)),  #
         "estimated_rewards_by_reg_model.shape must be the same as action_dist.shape",
     ),
     (
@@ -391,7 +467,7 @@ invalid_input_tensor_of_dr = [
         torch.zeros(5, dtype=torch.int64),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
-        "4",
+        "4",  #
         "estimated_rewards_by_reg_model must be Tensor",
     ),
 ]
@@ -421,69 +497,6 @@ def test_dr_using_invalid_input_tensor_data(
                 position=position,
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
             )
-
-
-# switch-dr
-
-invalid_input_of_switch = [
-    ("a", "switching hyperparameter must be float or integer"),
-    (-1.0, "switching hyperparameter must be larger than or equal to zero"),
-    (np.nan, "switching hyperparameter must not be nan"),
-]
-
-
-@pytest.mark.parametrize(
-    "tau, description",
-    invalid_input_of_switch,
-)
-def test_switch_using_invalid_input_data(tau: float, description: str) -> None:
-    with pytest.raises(ValueError, match=f"{description}*"):
-        _ = SwitchDoublyRobust(tau=tau)
-
-
-valid_input_of_switch = [
-    (3.0, "float tau"),
-    (2, "integer tau"),
-]
-
-
-@pytest.mark.parametrize(
-    "tau, description",
-    valid_input_of_switch,
-)
-def test_switch_using_valid_input_data(tau: float, description: str) -> None:
-    _ = SwitchDoublyRobust(tau=tau)
-
-
-# dr-os
-invalid_input_of_shrinkage = [
-    ("a", "shrinkage hyperparameter must be float or integer"),
-    (-1.0, "shrinkage hyperparameter must be larger than or equal to zero"),
-    (np.nan, "shrinkage hyperparameter must not be nan"),
-]
-
-
-@pytest.mark.parametrize(
-    "lambda_, description",
-    invalid_input_of_shrinkage,
-)
-def test_shrinkage_using_invalid_input_data(lambda_: float, description: str) -> None:
-    with pytest.raises(ValueError, match=f"{description}*"):
-        _ = DoublyRobustWithShrinkage(lambda_=lambda_)
-
-
-valid_input_of_shrinkage = [
-    (3.0, "float lambda_"),
-    (2, "integer lambda_"),
-]
-
-
-@pytest.mark.parametrize(
-    "lambda_, description",
-    valid_input_of_shrinkage,
-)
-def test_shrinkage_using_valid_input_data(lambda_: float, description: str) -> None:
-    _ = DoublyRobustWithShrinkage(lambda_=lambda_)
 
 
 # dr variants
@@ -589,7 +602,7 @@ def test_dr_using_random_evaluation_policy(
     }
     input_dict["action_dist"] = action_dist
     input_dict["estimated_rewards_by_reg_model"] = expected_reward
-    # dr estimtors require all arguments
+    # dr estimators require all arguments
     for estimator in dr_estimators:
         estimated_policy_value = estimator.estimate_policy_value(**input_dict)
         assert isinstance(
@@ -619,13 +632,13 @@ def test_dr_using_random_evaluation_policy(
     input_tensor_dict["estimated_rewards_by_reg_model"] = torch.from_numpy(
         expected_reward
     )
-    # dr estimtors require all arguments
+    # dr estimators require all arguments
     for estimator in dr_estimators:
         if estimator.estimator_name == "switch-dr":
             with pytest.raises(
                 NotImplementedError,
                 match=re.escape(
-                    "This is not implemented for Swtich-DR because it is indifferentiable."
+                    "This is not implemented for Switch-DR because it is indifferentiable."
                 ),
             ):
                 _ = estimator.estimate_policy_value_tensor(**input_tensor_dict)
@@ -646,7 +659,7 @@ def test_dr_using_random_evaluation_policy(
             with pytest.raises(
                 NotImplementedError,
                 match=re.escape(
-                    "This is not implemented for Swtich-DR because it is indifferentiable."
+                    "This is not implemented for Switch-DR because it is indifferentiable."
                 ),
             ):
                 _ = estimator.estimate_policy_value_tensor(**input_tensor_dict)

--- a/tests/ope/test_ipw_estimators.py
+++ b/tests/ope/test_ipw_estimators.py
@@ -29,6 +29,9 @@ def test_ipw_init():
     with pytest.raises(ValueError, match=r"`lambda_`= -1.0, must be >= 0.0."):
         InverseProbabilityWeighting(lambda_=-1.0)
 
+    with pytest.raises(ValueError, match=r"lambda_ must not be nan"):
+        InverseProbabilityWeighting(lambda_=np.nan)
+
 
 # prepare ipw instances
 ipw = InverseProbabilityWeighting()

--- a/tests/ope/test_ipw_estimators.py
+++ b/tests/ope/test_ipw_estimators.py
@@ -356,7 +356,7 @@ def test_ipw_using_random_evaluation_policy(
         if k in ["reward", "action", "pscore", "position"]
     }
     input_dict["action_dist"] = action_dist
-    # ipw estimtors can be used without estimated_rewards_by_reg_model
+    # ipw estimators can be used without estimated_rewards_by_reg_model
     for estimator in [ipw, snipw]:
         estimated_policy_value = estimator.estimate_policy_value(**input_dict)
         assert isinstance(

--- a/tests/ope/test_ipw_estimators.py
+++ b/tests/ope/test_ipw_estimators.py
@@ -8,6 +8,7 @@ from obp.types import BanditFeedback
 from obp.ope import (
     InverseProbabilityWeighting,
     SelfNormalizedInverseProbabilityWeighting,
+    InverseProbabilityWeightingTuning,
 )
 from conftest import generate_action_dist
 
@@ -32,10 +33,41 @@ def test_ipw_init():
     with pytest.raises(ValueError, match=r"lambda_ must not be nan"):
         InverseProbabilityWeighting(lambda_=np.nan)
 
+    # lambdas
+    with pytest.raises(
+        TypeError,
+        match=r"`an element of lambdas` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
+    ):
+        InverseProbabilityWeightingTuning(lambdas=[None])
+
+    with pytest.raises(
+        TypeError,
+        match=r"`an element of lambdas` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
+    ):
+        InverseProbabilityWeightingTuning(lambdas=[""])
+
+    with pytest.raises(
+        ValueError, match="`an element of lambdas`= -1.0, must be >= 0.0."
+    ):
+        InverseProbabilityWeightingTuning(lambdas=[-1.0])
+
+    with pytest.raises(ValueError, match="an element of lambdas must not be nan"):
+        InverseProbabilityWeightingTuning(lambdas=[np.nan])
+
+    with pytest.raises(ValueError, match="lambdas must not be empty"):
+        InverseProbabilityWeightingTuning(lambdas=[])
+
+    with pytest.raises(TypeError, match="lambdas must be a list"):
+        InverseProbabilityWeightingTuning(lambdas="")
+
+    with pytest.raises(TypeError, match="lambdas must be a list"):
+        InverseProbabilityWeightingTuning(lambdas=None)
+
 
 # prepare ipw instances
 ipw = InverseProbabilityWeighting()
 snipw = SelfNormalizedInverseProbabilityWeighting()
+ipw_tuning = InverseProbabilityWeightingTuning(lambdas=[10, 1000])
 
 
 # action_dist, action, reward, pscore, position, description
@@ -201,6 +233,22 @@ def test_ipw_using_invalid_input_data(
         )
     with pytest.raises(ValueError, match=f"{description}*"):
         _ = snipw.estimate_interval(
+            action_dist=action_dist,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            position=position,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ipw_tuning.estimate_policy_value(
+            action_dist=action_dist,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            position=position,
+        )
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = ipw_tuning.estimate_interval(
             action_dist=action_dist,
             action=action,
             reward=reward,
@@ -379,7 +427,7 @@ def test_ipw_using_random_evaluation_policy(
     }
     input_dict["action_dist"] = action_dist
     # ipw estimators can be used without estimated_rewards_by_reg_model
-    for estimator in [ipw, snipw]:
+    for estimator in [ipw, snipw, ipw_tuning]:
         estimated_policy_value = estimator.estimate_policy_value(**input_dict)
         assert isinstance(
             estimated_policy_value, float

--- a/tests/ope/test_ipw_estimators.py
+++ b/tests/ope/test_ipw_estimators.py
@@ -11,6 +11,25 @@ from obp.ope import (
 )
 from conftest import generate_action_dist
 
+
+def test_ipw_init():
+    # lambda_
+    with pytest.raises(
+        TypeError,
+        match=r"`lambda_` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
+    ):
+        InverseProbabilityWeighting(lambda_=None)
+
+    with pytest.raises(
+        TypeError,
+        match=r"`lambda_` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
+    ):
+        InverseProbabilityWeighting(lambda_="")
+
+    with pytest.raises(ValueError, match=r"`lambda_`= -1.0, must be >= 0.0."):
+        InverseProbabilityWeighting(lambda_=-1.0)
+
+
 # prepare ipw instances
 ipw = InverseProbabilityWeighting()
 snipw = SelfNormalizedInverseProbabilityWeighting()
@@ -20,7 +39,7 @@ snipw = SelfNormalizedInverseProbabilityWeighting()
 invalid_input_of_ipw = [
     (
         generate_action_dist(5, 4, 3),
-        None,
+        None,  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -29,7 +48,7 @@ invalid_input_of_ipw = [
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        None,
+        None,  #
         np.ones(5),
         np.random.choice(3, size=5),
         "reward must be ndarray",
@@ -38,13 +57,13 @@ invalid_input_of_ipw = [
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
         np.zeros(5, dtype=int),
-        None,
+        None,  #
         np.random.choice(3, size=5),
         "pscore must be ndarray",
     ),
     (
         generate_action_dist(5, 4, 3),
-        np.zeros(5, dtype=float),
+        np.zeros(5, dtype=float),  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -52,7 +71,7 @@ invalid_input_of_ipw = [
     ),
     (
         generate_action_dist(5, 4, 3),
-        np.zeros(5, dtype=int) - 1,
+        np.zeros(5, dtype=int) - 1,  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -60,7 +79,7 @@ invalid_input_of_ipw = [
     ),
     (
         generate_action_dist(5, 4, 3),
-        "4",
+        "4",  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -68,7 +87,7 @@ invalid_input_of_ipw = [
     ),
     (
         generate_action_dist(5, 4, 3),
-        np.zeros((3, 2), dtype=int),
+        np.zeros((3, 2), dtype=int),  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -76,7 +95,7 @@ invalid_input_of_ipw = [
     ),
     (
         generate_action_dist(5, 4, 3),
-        np.zeros(5, dtype=int) + 8,
+        np.zeros(5, dtype=int) + 8,  #
         np.zeros(5, dtype=int),
         np.ones(5),
         np.random.choice(3, size=5),
@@ -85,7 +104,7 @@ invalid_input_of_ipw = [
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        "4",
+        "4",  #
         np.ones(5),
         np.random.choice(3, size=5),
         "reward must be ndarray",
@@ -93,7 +112,7 @@ invalid_input_of_ipw = [
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        np.zeros((3, 2), dtype=int),
+        np.zeros((3, 2), dtype=int),  #
         np.ones(5),
         np.random.choice(3, size=5),
         "reward must be 1-dimensional",
@@ -101,7 +120,7 @@ invalid_input_of_ipw = [
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        np.zeros(4, dtype=int),
+        np.zeros(4, dtype=int),  #
         np.ones(5),
         np.random.choice(3, size=5),
         "action and reward must be the same size.",
@@ -110,7 +129,7 @@ invalid_input_of_ipw = [
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
         np.zeros(5, dtype=int),
-        "4",
+        "4",  #
         np.random.choice(3, size=5),
         "pscore must be ndarray",
     ),
@@ -118,7 +137,7 @@ invalid_input_of_ipw = [
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
         np.zeros(5, dtype=int),
-        np.ones((5, 3)),
+        np.ones((5, 3)),  #
         np.random.choice(3, size=5),
         "pscore must be 1-dimensional",
     ),
@@ -126,7 +145,7 @@ invalid_input_of_ipw = [
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
         np.zeros(5, dtype=int),
-        np.ones(4),
+        np.ones(4),  #
         np.random.choice(3, size=5),
         "action, reward, and pscore must be the same size.",
     ),
@@ -134,7 +153,7 @@ invalid_input_of_ipw = [
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
         np.zeros(5, dtype=int),
-        np.arange(5),
+        np.arange(5),  #
         np.random.choice(3, size=5),
         "pscore must be positive",
     ),
@@ -191,7 +210,7 @@ def test_ipw_using_invalid_input_data(
 invalid_input_tensor_of_ipw = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        None,
+        None,  #
         torch.zeros(5, dtype=torch.float32),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -200,7 +219,7 @@ invalid_input_tensor_of_ipw = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        None,
+        None,  #
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
         "reward must be Tensor",
@@ -209,13 +228,13 @@ invalid_input_tensor_of_ipw = [
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
         torch.zeros(5, dtype=torch.float32),
-        None,
+        None,  #
         torch.from_numpy(np.random.choice(3, size=5)),
         "pscore must be Tensor",
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        torch.zeros(5, dtype=torch.float64),
+        torch.zeros(5, dtype=torch.float64),  #
         torch.zeros(5, dtype=torch.float32),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -223,7 +242,7 @@ invalid_input_tensor_of_ipw = [
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        torch.zeros(5, dtype=torch.float64) - 1,
+        torch.zeros(5, dtype=torch.float64) - 1,  #
         torch.zeros(5, dtype=torch.float32),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -231,7 +250,7 @@ invalid_input_tensor_of_ipw = [
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        "4",
+        "4",  #
         torch.zeros(5, dtype=torch.float32),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -239,7 +258,7 @@ invalid_input_tensor_of_ipw = [
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        torch.zeros((3, 2), dtype=torch.int64),
+        torch.zeros((3, 2), dtype=torch.int64),  #
         torch.zeros(5, dtype=torch.float32),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -247,7 +266,7 @@ invalid_input_tensor_of_ipw = [
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
-        torch.zeros(5, dtype=torch.int64) + 8,
+        torch.zeros(5, dtype=torch.int64) + 8,  #
         torch.zeros(5, dtype=torch.float32),
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
@@ -256,7 +275,7 @@ invalid_input_tensor_of_ipw = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        "4",
+        "4",  #
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
         "reward must be Tensor",
@@ -264,7 +283,7 @@ invalid_input_tensor_of_ipw = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        torch.zeros((3, 2), dtype=torch.float32),
+        torch.zeros((3, 2), dtype=torch.float32),  #
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
         "reward must be 1-dimensional",
@@ -272,7 +291,7 @@ invalid_input_tensor_of_ipw = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        torch.zeros(4, dtype=torch.float32),
+        torch.zeros(4, dtype=torch.float32),  #
         torch.ones(5),
         torch.from_numpy(np.random.choice(3, size=5)),
         "action and reward must be the same size.",
@@ -281,7 +300,7 @@ invalid_input_tensor_of_ipw = [
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
         torch.zeros(5, dtype=torch.float32),
-        "4",
+        "4",  #
         torch.from_numpy(np.random.choice(3, size=5)),
         "pscore must be Tensor",
     ),
@@ -289,7 +308,7 @@ invalid_input_tensor_of_ipw = [
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
         torch.zeros(5, dtype=torch.float32),
-        torch.ones((5, 3)),
+        torch.ones((5, 3)),  #
         torch.from_numpy(np.random.choice(3, size=5)),
         "pscore must be 1-dimensional",
     ),
@@ -297,7 +316,7 @@ invalid_input_tensor_of_ipw = [
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
         torch.zeros(5, dtype=torch.float32),
-        torch.ones(4),
+        torch.ones(4),  #
         torch.from_numpy(np.random.choice(3, size=5)),
         "action, reward, and pscore must be the same size.",
     ),
@@ -305,7 +324,7 @@ invalid_input_tensor_of_ipw = [
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
         torch.zeros(5, dtype=torch.float32),
-        torch.from_numpy(np.arange(5)),
+        torch.from_numpy(np.arange(5)),  #
         torch.from_numpy(np.random.choice(3, size=5)),
         "pscore must be positive",
     ),

--- a/tests/ope/test_meta.py
+++ b/tests/ope/test_meta.py
@@ -44,18 +44,18 @@ class DirectMethodMock(BaseOffPolicyEstimator):
         estimated_rewards_by_reg_model: np.ndarray,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ----------
         position: array-like, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -70,19 +70,19 @@ class DirectMethodMock(BaseOffPolicyEstimator):
         estimated_rewards_by_reg_model: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        """Estimate policy value of an evaluation policy and return PyTorch Tensor.
+        """Estimate the policy value of evaluation policy and return PyTorch Tensor.
         This is intended for being used with NNPolicyLearner.
 
         Parameters
         ----------
         position: Tensor, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         action_dist: Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: Tensor, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -105,16 +105,16 @@ class DirectMethodMock(BaseOffPolicyEstimator):
         Parameters
         ----------
         position: array-like, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -160,7 +160,7 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
         action_dist: np.ndarray,
         **kwargs,
     ) -> np.ndarray:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ----------
@@ -168,16 +168,16 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         Returns
         ----------
@@ -195,7 +195,7 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
         action_dist: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        """Estimate policy value of an evaluation policy and return PyTorch Tensor.
+        """Estimate the policy value of evaluation policy and return PyTorch Tensor.
         This is intended for being used with NNPolicyLearner.
 
         Parameters
@@ -204,16 +204,16 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: Tensor, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: Tensor, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         pscore: Tensor, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         Returns
         ----------
@@ -242,20 +242,20 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
             Action choice probabilities
             by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.

--- a/tests/ope/test_meta_slate.py
+++ b/tests/ope/test_meta_slate.py
@@ -43,7 +43,7 @@ class SlateStandardIPSMock(SlateStandardIPS):
         evaluation_policy_pscore: np.ndarray,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Returns
         ----------
@@ -95,7 +95,7 @@ class SlateIndependentIPSMock(SlateIndependentIPS):
         evaluation_policy_pscore_item_position: np.ndarray,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Returns
         ----------
@@ -147,7 +147,7 @@ class SlateRewardInteractionIPSMock(SlateRewardInteractionIPS):
         evaluation_policy_pscore_cascade: np.ndarray,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Returns
         ----------

--- a/tests/ope/test_offline_estimation_performance.py
+++ b/tests/ope/test_offline_estimation_performance.py
@@ -21,16 +21,20 @@ from obp.ope import (
     RegressionModel,
     OffPolicyEvaluation,
     InverseProbabilityWeighting,
+    InverseProbabilityWeightingTuning,
     SelfNormalizedInverseProbabilityWeighting,
     DirectMethod,
     DoublyRobust,
+    DoublyRobustTuning,
     SelfNormalizedDoublyRobust,
     SwitchDoublyRobust,
+    SwitchDoublyRobustTuning,
     DoublyRobustWithShrinkage,
+    DoublyRobustWithShrinkageTuning,
 )
 
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 hyperparams = {
     "lightgbm": {
         "max_iter": 500,
@@ -116,7 +120,7 @@ class RandomOffPolicyEstimator(BaseOffPolicyEstimator):
         action_dist: np.ndarray,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy."""
+        """Estimate the policy value of evaluation policy."""
         return self._estimate_round_rewards(action_dist=action_dist).mean()
 
     def estimate_policy_value_tensor(self, **kwargs) -> torch.Tensor:
@@ -131,13 +135,23 @@ ope_estimators = [
     RandomOffPolicyEstimator(),
     DirectMethod(),
     InverseProbabilityWeighting(),
+    InverseProbabilityWeightingTuning(
+        lambdas=[100, 1000, np.inf], estimator_name="ipw (tuning)"
+    ),
     SelfNormalizedInverseProbabilityWeighting(),
     DoublyRobust(),
+    DoublyRobustTuning(lambdas=[100, 1000, np.inf], estimator_name="dr (tuning)"),
     SelfNormalizedDoublyRobust(),
     SwitchDoublyRobust(tau=1.0, estimator_name="switch-dr (tau=1)"),
     SwitchDoublyRobust(tau=100.0, estimator_name="switch-dr (tau=100)"),
+    SwitchDoublyRobustTuning(
+        taus=[100, 1000, np.inf], estimator_name="switch-dr (tuning)"
+    ),
     DoublyRobustWithShrinkage(lambda_=1.0, estimator_name="dr-os (lambda=1)"),
     DoublyRobustWithShrinkage(lambda_=100.0, estimator_name="dr-os (lambda=100)"),
+    DoublyRobustWithShrinkageTuning(
+        lambdas=[100, 1000, np.inf], estimator_name="dr-os (tuning)"
+    ),
 ]
 
 
@@ -230,10 +244,14 @@ def test_offline_estimation_performance(
 
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["dm"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["ipw"]
+    assert relative_ee_df_mean["random"] > relative_ee_df_mean["ipw (tuning)"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["snipw"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["dr"]
+    assert relative_ee_df_mean["random"] > relative_ee_df_mean["dr (tuning)"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["sndr"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["switch-dr (tau=1)"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["switch-dr (tau=100)"]
+    assert relative_ee_df_mean["random"] > relative_ee_df_mean["switch-dr (tuning)"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["dr-os (lambda=1)"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["dr-os (lambda=100)"]
+    assert relative_ee_df_mean["random"] > relative_ee_df_mean["dr-os (tuning)"]

--- a/tests/ope/test_regression_models.py
+++ b/tests/ope/test_regression_models.py
@@ -95,7 +95,6 @@ invalid_input_of_initializing_regression_models = [
 
 
 # context, action, reward, pscore, position, action_context, n_actions, len_list, fitting_method, base_model, action_dist, description
-
 invalid_input_of_fitting_regression_models = [
     (
         None,  #

--- a/tests/policy/test_offline_learner_performance.py
+++ b/tests/policy/test_offline_learner_performance.py
@@ -20,7 +20,7 @@ from obp.policy import IPWLearner, NNPolicyLearner
 from obp.ope import DoublyRobust, RegressionModel
 
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 hyperparams = {
     "lightgbm": {
         "max_iter": 500,


### PR DESCRIPTION
## new feature
- add weight clipping to the following estimators
    - [InverseProbabilityWeighting](https://github.com/st-tech/zr-obp/blob/526c159c8c8e8f7a2a4e7647984ca5631a66d557/obp/ope/estimators.py#L247)
    - [DoublyRobust](https://github.com/st-tech/zr-obp/blob/526c159c8c8e8f7a2a4e7647984ca5631a66d557/obp/ope/estimators.py#L855)

These above estimators now have a new hyperparameter `lambda_`. 
When a finite positive value is given to `lambda_`, then importance weights larger than this hyperparameter will be clipped.

## tests
- add some tests of initialization of OPE estimators such as 
    - [test_ipw_init](https://github.com/st-tech/zr-obp/blob/526c159c8c8e8f7a2a4e7647984ca5631a66d557/tests/ope/test_ipw_estimators.py#L15)
    - [test_dr_init_using_invalid_inputs](https://github.com/st-tech/zr-obp/blob/526c159c8c8e8f7a2a4e7647984ca5631a66d557/tests/ope/test_dr_estimators.py#L37)
    - [test_switch_dr_init_using_invalid_inputs](https://github.com/st-tech/zr-obp/blob/526c159c8c8e8f7a2a4e7647984ca5631a66d557/tests/ope/test_dr_estimators.py#L68)

## refactor
- fix some typos
- use `sklearn.utils.check_scalar` to check hyperparameters of `DoublyRobustWithShrinkage` and `SwitchDoublyRobust`