### PR TITLE
Feature: Implementing Automatic Hyperparameter Tuning

### DIFF
--- a/benchmark/cf_policy_search/run_cf_policy_search.py
+++ b/benchmark/cf_policy_search/run_cf_policy_search.py
@@ -14,7 +14,7 @@ from custom_dataset import OBDWithInteractionFeatures
 from obp.policy import IPWLearner
 from obp.ope import InverseProbabilityWeighting
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 with open("./conf/hyperparams.yaml", "rb") as f:
     hyperparams = yaml.safe_load(f)
 

--- a/examples/multiclass/evaluate_off_policy_estimators.py
+++ b/examples/multiclass/evaluate_off_policy_estimators.py
@@ -24,7 +24,7 @@ from obp.ope import (
 )
 
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 with open("./conf/hyperparams.yaml", "rb") as f:
     hyperparams = yaml.safe_load(f)
 

--- a/examples/obd/evaluate_off_policy_estimators.py
+++ b/examples/obd/evaluate_off_policy_estimators.py
@@ -21,7 +21,7 @@ from obp.ope import (
 
 evaluation_policy_dict = dict(bts=BernoulliTS, random=Random)
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 with open("./conf/hyperparams.yaml", "rb") as f:
     hyperparams = yaml.safe_load(f)
 

--- a/examples/opl/evaluate_off_policy_learners.py
+++ b/examples/opl/evaluate_off_policy_learners.py
@@ -24,7 +24,7 @@ from obp.ope import (
 )
 
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 with open("./conf/hyperparams.yaml", "rb") as f:
     hyperparams = yaml.safe_load(f)
 

--- a/examples/synthetic/evaluate_off_policy_estimators.py
+++ b/examples/synthetic/evaluate_off_policy_estimators.py
@@ -28,7 +28,7 @@ from obp.ope import (
 )
 
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 with open("./conf/hyperparams.yaml", "rb") as f:
     hyperparams = yaml.safe_load(f)
 

--- a/obp/dataset/synthetic.py
+++ b/obp/dataset/synthetic.py
@@ -324,7 +324,7 @@ class SyntheticBanditDataset(BaseBanditDataset):
             This is often the expected_reward of the test set of logged bandit feedback data.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         Returns
         ----------

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -747,7 +747,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         Parameters
         -----------
         reward: array-like, shape (<= n_rounds * len_list,)
-            Reward observed in each round and slot of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
+            Reward observed at each slot in each round of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
 
         slate_id: array-like, shape (<= n_rounds * len_list,)
             Slate ids of the logged bandit feedback.

--- a/obp/ope/__init__.py
+++ b/obp/ope/__init__.py
@@ -7,6 +7,10 @@ from obp.ope.estimators import DoublyRobust
 from obp.ope.estimators import SelfNormalizedDoublyRobust
 from obp.ope.estimators import SwitchDoublyRobust
 from obp.ope.estimators import DoublyRobustWithShrinkage
+from obp.ope.estimators_tuning import InverseProbabilityWeightingTuning
+from obp.ope.estimators_tuning import DoublyRobustTuning
+from obp.ope.estimators_tuning import SwitchDoublyRobustTuning
+from obp.ope.estimators_tuning import DoublyRobustWithShrinkageTuning
 from obp.ope.estimators_slate import SlateStandardIPS
 from obp.ope.estimators_slate import SlateIndependentIPS
 from obp.ope.estimators_slate import SlateRewardInteractionIPS
@@ -24,6 +28,10 @@ __all__ = [
     "SelfNormalizedDoublyRobust",
     "SwitchDoublyRobust",
     "DoublyRobustWithShrinkage",
+    "InverseProbabilityWeightingTuning",
+    "DoublyRobustTuning",
+    "SwitchDoublyRobustTuning",
+    "DoublyRobustWithShrinkageTuning",
     "OffPolicyEvaluation",
     "SlateOffPolicyEvaluation",
     "RegressionModel",

--- a/obp/ope/__init__.py
+++ b/obp/ope/__init__.py
@@ -50,3 +50,11 @@ __all_estimators__ = [
     "SwitchDoublyRobust",
     "SelfNormalizedDoublyRobust",
 ]
+
+
+__all_estimators_tuning__ = [
+    "InverseProbabilityWeightingTuning",
+    "DoublyRobustTuning",
+    "SwitchDoublyRobustTuning",
+    "DoublyRobustWithShrinkageTuning",
+]

--- a/obp/ope/estimators.py
+++ b/obp/ope/estimators.py
@@ -205,7 +205,7 @@ class ReplayMethod(BaseOffPolicyEstimator):
             Positions of each round in the given logged bandit feedback.
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -496,7 +496,7 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
             Positions of each round in the given logged bandit feedback.
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -882,7 +882,7 @@ class DirectMethod(BaseOffPolicyEstimator):
             Positions of each round in the given logged bandit feedback.
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -1227,7 +1227,7 @@ class DoublyRobust(BaseOffPolicyEstimator):
             Positions of each round in the given logged bandit feedback.
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.

--- a/obp/ope/estimators.py
+++ b/obp/ope/estimators.py
@@ -572,7 +572,7 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
         Returns
         ----------
         estimated_mse_score: float
-            Estimated MSE score with a given clipping hyperparameter `lambda_`.
+            Estimated MSE score of a given clipping hyperparameter `lambda_`.
             MSE score is the sum of (high probability) upper bound of bias and the sample variance.
             This is estimated using the automatic hyperparameter tuning procedure
             based on Section 5 of Su et al.(2020).
@@ -1310,7 +1310,7 @@ class DoublyRobust(BaseOffPolicyEstimator):
         Returns
         ----------
         estimated_mse_score: float
-            Estimated MSE score with a given clipping hyperparameter `lambda_`.
+            Estimated MSE score of a given clipping hyperparameter `lambda_`.
             MSE score is the sum of (high probability) upper bound of bias and the sample variance.
             This is estimated using the automatic hyperparameter tuning procedure
             based on Section 5 of Su et al.(2020).
@@ -1607,7 +1607,7 @@ class SwitchDoublyRobust(DoublyRobust):
         Returns
         ----------
         estimated_mse_score: float
-            Estimated MSE score with a given switching hyperparameter `tau`.
+            Estimated MSE score of a given switching hyperparameter `tau`.
             MSE score is the sum of (high probability) upper bound of bias and the sample variance.
             This is estimated using the automatic hyperparameter tuning procedure
             based on Section 5 of Su et al.(2020).
@@ -1806,7 +1806,7 @@ class DoublyRobustWithShrinkage(DoublyRobust):
         Returns
         ----------
         estimated_mse_score: float
-            Estimated MSE score with a given shrinkage hyperparameter `lambda_`.
+            Estimated MSE score of a given shrinkage hyperparameter `lambda_`.
             MSE score is the sum of (high probability) upper bound of bias and the sample variance.
             This is estimated using the automatic hyperparameter tuning procedure
             based on Section 5 of Su et al.(2020).

--- a/obp/ope/estimators.py
+++ b/obp/ope/estimators.py
@@ -593,7 +593,11 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
         iw = action_dist[np.arange(n_rounds), action, position] / pscore
         iw_hat = np.minimum(iw, self.lambda_)
         bias_upper_bound_arr = (iw - iw_hat) * reward
-        bias_upper_bound = bias_upper_bound_arr.mean()
+        bias_upper_bound = np.abs(bias_upper_bound_arr.mean())
+        bias_upper_bound += np.sqrt(
+            (2 * (iw ** 2).mean() * np.log(40)) / n_rounds
+        )  # \delta=0.05
+        bias_upper_bound += (2 * iw.max() * np.log(40)) / (3 * n_rounds)
 
         estimated_mse_upper_bound = var_hat + (bias_upper_bound ** 2)
         return estimated_mse_upper_bound
@@ -1328,11 +1332,13 @@ class DoublyRobust(BaseOffPolicyEstimator):
         # estimate the upper bound of the bias of DR with clipping
         iw = action_dist[np.arange(n_rounds), action, position] / pscore
         iw_hat = np.minimum(iw, self.lambda_)
-        q_hat = estimated_rewards_by_reg_model[
-            np.arange(n_rounds), action, position
-        ]
+        q_hat = estimated_rewards_by_reg_model[np.arange(n_rounds), action, position]
         bias_upper_bound_arr = (iw - iw_hat) * (reward - q_hat)
-        bias_upper_bound = bias_upper_bound_arr.mean()
+        bias_upper_bound = np.abs(bias_upper_bound_arr.mean())
+        bias_upper_bound += np.sqrt(
+            (2 * (iw ** 2).mean() * np.log(40)) / n_rounds
+        )  # \delta=0.05
+        bias_upper_bound += (2 * iw.max() * np.log(40)) / (3 * n_rounds)
 
         estimated_mse_upper_bound = var_hat + (bias_upper_bound ** 2)
         return estimated_mse_upper_bound
@@ -1624,11 +1630,13 @@ class SwitchDoublyRobust(DoublyRobust):
         # estimate the upper bound of the bias of Switch-DR
         iw = action_dist[np.arange(n_rounds), action, position] / pscore
         iw_hat = iw * np.array(iw <= self.tau, dtype=int)
-        q_hat = estimated_rewards_by_reg_model[
-            np.arange(n_rounds), action, position
-        ]
+        q_hat = estimated_rewards_by_reg_model[np.arange(n_rounds), action, position]
         bias_upper_bound_arr = (iw - iw_hat) * (reward - q_hat)
-        bias_upper_bound = bias_upper_bound_arr.mean()
+        bias_upper_bound = np.abs(bias_upper_bound_arr.mean())
+        bias_upper_bound += np.sqrt(
+            (2 * (iw ** 2).mean() * np.log(40)) / n_rounds
+        )  # \delta=0.05
+        bias_upper_bound += (2 * iw.max() * np.log(40)) / (3 * n_rounds)
 
         estimated_mse_upper_bound = var_hat + (bias_upper_bound ** 2)
         return estimated_mse_upper_bound
@@ -1825,11 +1833,13 @@ class DoublyRobustWithShrinkage(DoublyRobust):
             iw_hat = (self.lambda_ * iw) / (iw ** 2 + self.lambda_)
         else:
             iw_hat = iw
-        q_hat = estimated_rewards_by_reg_model[
-            np.arange(n_rounds), action, position
-        ]
+        q_hat = estimated_rewards_by_reg_model[np.arange(n_rounds), action, position]
         bias_upper_bound_arr = (iw - iw_hat) * (reward - q_hat)
-        bias_upper_bound = bias_upper_bound_arr.mean()
+        bias_upper_bound = np.abs(bias_upper_bound_arr.mean())
+        bias_upper_bound += np.sqrt(
+            (2 * (iw ** 2).mean() * np.log(40)) / n_rounds
+        )  # \delta=0.05
+        bias_upper_bound += (2 * iw.max() * np.log(40)) / (3 * n_rounds)
 
         estimated_mse_upper_bound = var_hat + (bias_upper_bound ** 2)
         return estimated_mse_upper_bound

--- a/obp/ope/estimators_tuning.py
+++ b/obp/ope/estimators_tuning.py
@@ -99,7 +99,7 @@ class BaseOffPolicyEstimatorTuning:
         estimated_rewards_by_reg_model: Optional[np.ndarray] = None,
         position: Optional[np.ndarray] = None,
     ) -> float:
-        """Estimate policy value of an evaluation policy with a tuned hyperparameter.
+        """Estimate the policy value of evaluation policy with a tuned hyperparameter.
 
         Parameters
         ----------
@@ -107,24 +107,24 @@ class BaseOffPolicyEstimatorTuning:
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         Returns
         ----------
         V_hat: float
-            Estimated policy value by the DR estimator.
+            Policy value estimated by the DR estimator.
 
         """
         # tune hyperparameter if necessary
@@ -168,19 +168,19 @@ class BaseOffPolicyEstimatorTuning:
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         alpha: float, default=0.05
             Significance level.
@@ -232,7 +232,7 @@ class InverseProbabilityWeightingTuning(BaseOffPolicyEstimatorTuning):
         will choose the best hyperparameter value from the data.
 
     estimator_name: str, default='ipw'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ----------
@@ -262,7 +262,7 @@ class InverseProbabilityWeightingTuning(BaseOffPolicyEstimatorTuning):
         position: Optional[np.ndarray] = None,
         **kwargs,
     ) -> np.ndarray:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ----------
@@ -270,16 +270,16 @@ class InverseProbabilityWeightingTuning(BaseOffPolicyEstimatorTuning):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         Returns
         ----------
@@ -332,17 +332,17 @@ class InverseProbabilityWeightingTuning(BaseOffPolicyEstimatorTuning):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
             Action choice probabilities
             by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         alpha: float, default=0.05
             Significance level.
@@ -400,7 +400,7 @@ class DoublyRobustTuning(BaseOffPolicyEstimatorTuning):
         will choose the best hyperparameter value from the data.
 
     estimator_name: str, default='dr'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ----------
@@ -430,7 +430,7 @@ class DoublyRobustTuning(BaseOffPolicyEstimatorTuning):
         estimated_rewards_by_reg_model: np.ndarray,
         position: Optional[np.ndarray] = None,
     ) -> float:
-        """Estimate policy value of an evaluation policy with a tuned hyperparameter.
+        """Estimate the policy value of evaluation policy with a tuned hyperparameter.
 
         Parameters
         ----------
@@ -438,24 +438,24 @@ class DoublyRobustTuning(BaseOffPolicyEstimatorTuning):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         Returns
         ----------
         V_hat: float
-            Estimated policy value by the DR estimator.
+            Policy value estimated by the DR estimator.
 
         """
         if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
@@ -508,19 +508,19 @@ class DoublyRobustTuning(BaseOffPolicyEstimatorTuning):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         alpha: float, default=0.05
             Significance level.
@@ -582,7 +582,7 @@ class SwitchDoublyRobustTuning(BaseOffPolicyEstimatorTuning):
         will choose the best hyperparameter value from the data.
 
     estimator_name: str, default='switch-dr'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ----------
@@ -612,7 +612,7 @@ class SwitchDoublyRobustTuning(BaseOffPolicyEstimatorTuning):
         estimated_rewards_by_reg_model: np.ndarray,
         position: Optional[np.ndarray] = None,
     ) -> float:
-        """Estimate policy value of an evaluation policy with a tuned hyperparameter.
+        """Estimate the policy value of evaluation policy with a tuned hyperparameter.
 
         Parameters
         ----------
@@ -620,24 +620,24 @@ class SwitchDoublyRobustTuning(BaseOffPolicyEstimatorTuning):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         Returns
         ----------
         V_hat: float
-            Estimated policy value by the DR estimator.
+            Policy value estimated by the DR estimator.
 
         """
         if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
@@ -690,19 +690,19 @@ class SwitchDoublyRobustTuning(BaseOffPolicyEstimatorTuning):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         alpha: float, default=0.05
             Significance level.
@@ -764,7 +764,7 @@ class DoublyRobustWithShrinkageTuning(BaseOffPolicyEstimatorTuning):
         will choose the best hyperparameter value from the data.
 
     estimator_name: str, default='dr-os'.
-        Name of off-policy estimator.
+        Name of the estimator.
 
     References
     ----------
@@ -794,7 +794,7 @@ class DoublyRobustWithShrinkageTuning(BaseOffPolicyEstimatorTuning):
         estimated_rewards_by_reg_model: np.ndarray,
         position: Optional[np.ndarray] = None,
     ) -> float:
-        """Estimate policy value of an evaluation policy with a tuned hyperparameter.
+        """Estimate the policy value of evaluation policy with a tuned hyperparameter.
 
         Parameters
         ----------
@@ -802,24 +802,24 @@ class DoublyRobustWithShrinkageTuning(BaseOffPolicyEstimatorTuning):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         Returns
         ----------
         V_hat: float
-            Estimated policy value by the DR estimator.
+            Policy value estimated by the DR estimator.
 
         """
         if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
@@ -841,24 +841,6 @@ class DoublyRobustWithShrinkageTuning(BaseOffPolicyEstimatorTuning):
         )
         if position is None:
             position = np.zeros(action_dist.shape[0], dtype=int)
-
-        # tune the shrinkage hyperparameter
-        self.estimated_mse_score_dict = dict()
-        for lambda_ in self.lambdas:
-            estimated_mse_score = DoublyRobustWithShrinkage(
-                lambda_=lambda_
-            )._estimate_mse_score(
-                reward=reward,
-                action=action,
-                position=position,
-                pscore=pscore,
-                action_dist=action_dist,
-                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
-            )
-            self.estimated_mse_score_dict[lambda_] = estimated_mse_score
-        self.best_lambda_ = min(
-            self.estimated_mse_score_dict.items(), key=lambda x: x[1]
-        )[0]
 
         return super().estimate_policy_value_with_tuning(
             reward=reward,
@@ -890,19 +872,19 @@ class DoublyRobustWithShrinkageTuning(BaseOffPolicyEstimatorTuning):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         alpha: float, default=0.05
             Significance level.
@@ -938,24 +920,6 @@ class DoublyRobustWithShrinkageTuning(BaseOffPolicyEstimatorTuning):
         )
         if position is None:
             position = np.zeros(action_dist.shape[0], dtype=int)
-
-        # tune the shrinkage hyperparameter
-        self.estimated_mse_score_dict = dict()
-        for lambda_ in self.lambdas:
-            estimated_mse_score = DoublyRobustWithShrinkage(
-                lambda_=lambda_
-            )._estimate_mse_score(
-                reward=reward,
-                action=action,
-                position=position,
-                pscore=pscore,
-                action_dist=action_dist,
-                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
-            )
-            self.estimated_mse_score_dict[lambda_] = estimated_mse_score
-        self.best_lambda_ = min(
-            self.estimated_mse_score_dict.items(), key=lambda x: x[1]
-        )[0]
 
         return super().estimate_interval_with_tuning(
             reward=reward,

--- a/obp/ope/estimators_tuning.py
+++ b/obp/ope/estimators_tuning.py
@@ -3,7 +3,7 @@
 
 """Off-Policy Estimators with built-in hyperparameter tuning."""
 from dataclasses import dataclass
-from typing import Dict, Optional, Union, List
+from typing import Dict, Optional, List
 
 import numpy as np
 from sklearn.utils import check_scalar

--- a/obp/ope/estimators_tuning.py
+++ b/obp/ope/estimators_tuning.py
@@ -22,7 +22,7 @@ from ..utils import (
 
 @dataclass
 class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
-    """Inverse Probability Weighting (IPW) with built in hyperparameter tuning.
+    """Inverse Probability Weighting (IPW) with built-in hyperparameter tuning.
 
     Parameters
     ----------
@@ -125,7 +125,7 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the clipping hyperparameter
-        estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_list = []
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = InverseProbabilityWeighting(
                 lambda_=lambda_
@@ -137,8 +137,8 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
                 action_dist=action_dist,
                 max_reward_value=self.max_reward_value,
             )
-            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
 
         return (
             InverseProbabilityWeighting(lambda_=self.best_lambda_)
@@ -217,7 +217,7 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the clipping hyperparameter
-        estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_list = []
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = InverseProbabilityWeighting(
                 lambda_=lambda_
@@ -229,8 +229,8 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
                 action_dist=action_dist,
                 max_reward_value=self.max_reward_value,
             )
-            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
 
         estimated_round_rewards = InverseProbabilityWeighting(
             lambda_=self.best_lambda_
@@ -251,7 +251,7 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
 
 @dataclass
 class DoublyRobustTuning(DoublyRobust):
-    """Doubly Robust (DR) with built in hyperparameter tuning.
+    """Doubly Robust (DR) with built-in hyperparameter tuning.
 
     Parameters
     ----------
@@ -360,7 +360,7 @@ class DoublyRobustTuning(DoublyRobust):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the clipping hyperparameter
-        estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_list = []
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = DoublyRobust(
                 lambda_=lambda_
@@ -373,8 +373,8 @@ class DoublyRobustTuning(DoublyRobust):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
 
         return (
             DoublyRobust(lambda_=self.best_lambda_)
@@ -460,7 +460,7 @@ class DoublyRobustTuning(DoublyRobust):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the clipping hyperparameter
-        estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_list = []
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = DoublyRobust(
                 lambda_=lambda_
@@ -473,8 +473,8 @@ class DoublyRobustTuning(DoublyRobust):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
 
         estimated_round_rewards = DoublyRobust(
             lambda_=self.best_lambda_
@@ -606,7 +606,7 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the switching hyperparameter
-        estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_list = []
         for tau_ in self.taus:
             estimated_mse_upper_bound = SwitchDoublyRobust(
                 tau=tau_
@@ -619,8 +619,8 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_tau = self.taus[estimated_mse_upper_bound.argmin()]
+            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_tau = self.taus[np.argmin(self.estimated_mse_upper_bound_list)]
 
         return (
             SwitchDoublyRobust(tau=self.best_tau)
@@ -706,7 +706,7 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the switching hyperparameter
-        estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_list = []
         for tau_ in self.taus:
             estimated_mse_upper_bound = SwitchDoublyRobust(
                 tau=tau_
@@ -719,8 +719,8 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_tau = self.taus[estimated_mse_upper_bound.argmin()]
+            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_tau = self.taus[np.argmin(self.estimated_mse_upper_bound_list)]
 
         estimated_round_rewards = SwitchDoublyRobust(
             tau=self.best_tau
@@ -742,7 +742,7 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
 
 @dataclass
 class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
-    """Doubly Robust with optimistic shrinkage (DRos) with built in hyperparameter tuning.
+    """Doubly Robust with optimistic shrinkage (DRos) with built-in hyperparameter tuning.
 
     Parameters
     ----------
@@ -851,7 +851,7 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the shrinkage hyperparameter
-        estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_list = []
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = DoublyRobustWithShrinkage(
                 lambda_=lambda_
@@ -864,8 +864,8 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
 
         return (
             DoublyRobustWithShrinkage(lambda_=self.best_lambda_)
@@ -951,7 +951,7 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the shrinkage hyperparameter
-        estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_list = []
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = DoublyRobustWithShrinkage(
                 lambda_=lambda_
@@ -964,8 +964,8 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
 
         estimated_round_rewards = DoublyRobustWithShrinkage(
             lambda_=self.best_lambda_

--- a/obp/ope/estimators_tuning.py
+++ b/obp/ope/estimators_tuning.py
@@ -28,10 +28,8 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
     ----------
     lambdas: List[float]
         A list of candidate clipping hyperparameters.
-        The automatic hyperparameter tuning proposed by Wang et al.(2017) will choose the best hyperparameter value from the data.
-
-    max_reward_value: int or float, default=None
-        A maximum possible reward, which is necessary for the hyperparameter tuning.
+        The automatic hyperparameter tuning proposed by Su et al.(2020)
+        will choose the best hyperparameter value from the data.
 
     estimator_name: str, default='ipw'.
         Name of off-policy estimator.
@@ -47,7 +45,6 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
     """
 
     lambdas: List[float] = None
-    max_reward_value: Optional[Union[int, float]] = None
     estimator_name = "ipw"
 
     def __post_init__(self) -> None:
@@ -66,12 +63,6 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
                     raise ValueError("an element of lambdas must not be nan")
         else:
             raise TypeError("lambdas must be a list")
-        if self.max_reward_value is not None:
-            check_scalar(
-                self.max_reward_value,
-                name="max_reward_value",
-                target_type=(int, float),
-            )
 
     def estimate_policy_value(
         self,
@@ -135,7 +126,6 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
                 position=position,
                 pscore=pscore,
                 action_dist=action_dist,
-                max_reward_value=self.max_reward_value,
             )
             self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
         self.best_lambda_ = min(
@@ -229,7 +219,6 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
                 position=position,
                 pscore=pscore,
                 action_dist=action_dist,
-                max_reward_value=self.max_reward_value,
             )
             self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
         self.best_lambda_ = min(
@@ -261,10 +250,8 @@ class DoublyRobustTuning(DoublyRobust):
     ----------
     lambdas: List[float]
         A list of candidate clipping hyperparameters.
-        The automatic hyperparameter tuning proposed by Wang et al.(2017) will choose the best hyperparameter value from the data.
-
-    max_reward_value: int or float, default=None
-            A maximum possible reward, which is necessary for the hyperparameter tuning.
+        The automatic hyperparameter tuning proposed by Su et al.(2020)
+        will choose the best hyperparameter value from the data.
 
     estimator_name: str, default='dr'.
         Name of off-policy estimator.
@@ -280,7 +267,6 @@ class DoublyRobustTuning(DoublyRobust):
     """
 
     lambdas: List[float] = None
-    max_reward_value: Optional[Union[int, float]] = None
     estimator_name = "dr"
 
     def __post_init__(self) -> None:
@@ -299,12 +285,6 @@ class DoublyRobustTuning(DoublyRobust):
                     raise ValueError("an element of lambdas must not be nan")
         else:
             raise TypeError("lambdas must be a list")
-        if self.max_reward_value is not None:
-            check_scalar(
-                self.max_reward_value,
-                name="max_reward_value",
-                target_type=(int, float),
-            )
 
     def estimate_policy_value(
         self,
@@ -375,7 +355,6 @@ class DoublyRobustTuning(DoublyRobust):
                 pscore=pscore,
                 action_dist=action_dist,
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
-                max_reward_value=self.max_reward_value,
             )
             self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
         self.best_lambda_ = min(
@@ -477,7 +456,6 @@ class DoublyRobustTuning(DoublyRobust):
                 pscore=pscore,
                 action_dist=action_dist,
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
-                max_reward_value=self.max_reward_value,
             )
             self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
         self.best_lambda_ = min(
@@ -510,11 +488,8 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
     ----------
     taus: List[float]
         A list of candidate switching hyperparameters.
-        The automatic hyperparameter tuning proposed by Wang et al.(2017) will choose the best hyperparameter value from the data.
-
-    max_reward_value: int or float, default=None
-            A maximum possible reward, which is necessary for the hyperparameter tuning.
-            If None is given, `reward.max()` is used.
+        The automatic hyperparameter tuning proposed by Su et al.(2020)
+        will choose the best hyperparameter value from the data.
 
     estimator_name: str, default='switch-dr'.
         Name of off-policy estimator.
@@ -530,7 +505,6 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
     """
 
     taus: List[float] = None
-    max_reward_value: Optional[float] = None
     estimator_name: str = "switch-dr"
 
     def __post_init__(self) -> None:
@@ -549,12 +523,6 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
                     raise ValueError("an element of taus must not be nan")
         else:
             raise TypeError("taus must be a list")
-        if self.max_reward_value is not None:
-            check_scalar(
-                self.max_reward_value,
-                name="max_reward_value",
-                target_type=(int, float),
-            )
 
     def estimate_policy_value(
         self,
@@ -625,7 +593,6 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
                 pscore=pscore,
                 action_dist=action_dist,
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
-                max_reward_value=self.max_reward_value,
             )
             self.estimated_mse_upper_bound_dict[tau_] = estimated_mse_upper_bound
         self.best_tau = min(
@@ -727,7 +694,6 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
                 pscore=pscore,
                 action_dist=action_dist,
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
-                max_reward_value=self.max_reward_value,
             )
             self.estimated_mse_upper_bound_dict[tau_] = estimated_mse_upper_bound
         self.best_tau = min(
@@ -760,10 +726,8 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
     ----------
     lambdas: List[float]
         A list of candidate shrinkage hyperparameters.
-        The automatic hyperparameter tuning proposed by Wang et al.(2017) will choose the best hyperparameter value from the data.
-
-    max_reward_value: int or float, default=None
-            A maximum possible reward, which is necessary for the hyperparameter tuning.
+        The automatic hyperparameter tuning proposed by Su et al.(2020)
+        will choose the best hyperparameter value from the data.
 
     estimator_name: str, default='dr-os'.
         Name of off-policy estimator.
@@ -779,7 +743,6 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
     """
 
     lambdas: List[float] = None
-    max_reward_value: Optional[Union[int, float]] = None
     estimator_name = "dr-os"
 
     def __post_init__(self) -> None:
@@ -798,12 +761,6 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
                     raise ValueError("an element of lambdas must not be nan")
         else:
             raise TypeError("lambdas must be a list")
-        if self.max_reward_value is not None:
-            check_scalar(
-                self.max_reward_value,
-                name="max_reward_value",
-                target_type=(int, float),
-            )
 
     def estimate_policy_value(
         self,
@@ -874,7 +831,6 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
                 pscore=pscore,
                 action_dist=action_dist,
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
-                max_reward_value=self.max_reward_value,
             )
             self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
         self.best_lambda_ = min(
@@ -976,7 +932,6 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
                 pscore=pscore,
                 action_dist=action_dist,
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
-                max_reward_value=self.max_reward_value,
             )
             self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
         self.best_lambda_ = min(

--- a/obp/ope/estimators_tuning.py
+++ b/obp/ope/estimators_tuning.py
@@ -125,7 +125,7 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the clipping hyperparameter
-        self.estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_dict = dict()
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = InverseProbabilityWeighting(
                 lambda_=lambda_
@@ -137,8 +137,10 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
                 action_dist=action_dist,
                 max_reward_value=self.max_reward_value,
             )
-            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
+            self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
+        self.best_lambda_ = min(
+            self.estimated_mse_upper_bound_dict.items(), key=lambda x: x[1]
+        )[0]
 
         return (
             InverseProbabilityWeighting(lambda_=self.best_lambda_)
@@ -217,7 +219,7 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the clipping hyperparameter
-        self.estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_dict = dict()
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = InverseProbabilityWeighting(
                 lambda_=lambda_
@@ -229,8 +231,10 @@ class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
                 action_dist=action_dist,
                 max_reward_value=self.max_reward_value,
             )
-            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
+            self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
+        self.best_lambda_ = min(
+            self.estimated_mse_upper_bound_dict.items(), key=lambda x: x[1]
+        )[0]
 
         estimated_round_rewards = InverseProbabilityWeighting(
             lambda_=self.best_lambda_
@@ -360,7 +364,7 @@ class DoublyRobustTuning(DoublyRobust):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the clipping hyperparameter
-        self.estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_dict = dict()
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = DoublyRobust(
                 lambda_=lambda_
@@ -373,8 +377,10 @@ class DoublyRobustTuning(DoublyRobust):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
+            self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
+        self.best_lambda_ = min(
+            self.estimated_mse_upper_bound_dict.items(), key=lambda x: x[1]
+        )[0]
 
         return (
             DoublyRobust(lambda_=self.best_lambda_)
@@ -460,7 +466,7 @@ class DoublyRobustTuning(DoublyRobust):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the clipping hyperparameter
-        self.estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_dict = dict()
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = DoublyRobust(
                 lambda_=lambda_
@@ -473,8 +479,10 @@ class DoublyRobustTuning(DoublyRobust):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
+            self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
+        self.best_lambda_ = min(
+            self.estimated_mse_upper_bound_dict.items(), key=lambda x: x[1]
+        )[0]
 
         estimated_round_rewards = DoublyRobust(
             lambda_=self.best_lambda_
@@ -606,7 +614,7 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the switching hyperparameter
-        self.estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_dict = dict()
         for tau_ in self.taus:
             estimated_mse_upper_bound = SwitchDoublyRobust(
                 tau=tau_
@@ -619,8 +627,10 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_tau = self.taus[np.argmin(self.estimated_mse_upper_bound_list)]
+            self.estimated_mse_upper_bound_dict[tau_] = estimated_mse_upper_bound
+        self.best_tau = min(
+            self.estimated_mse_upper_bound_dict.items(), key=lambda x: x[1]
+        )[0]
 
         return (
             SwitchDoublyRobust(tau=self.best_tau)
@@ -706,7 +716,7 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the switching hyperparameter
-        self.estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_dict = dict()
         for tau_ in self.taus:
             estimated_mse_upper_bound = SwitchDoublyRobust(
                 tau=tau_
@@ -719,8 +729,10 @@ class SwitchDoublyRobustTuning(SwitchDoublyRobust):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_tau = self.taus[np.argmin(self.estimated_mse_upper_bound_list)]
+            self.estimated_mse_upper_bound_dict[tau_] = estimated_mse_upper_bound
+        self.best_tau = min(
+            self.estimated_mse_upper_bound_dict.items(), key=lambda x: x[1]
+        )[0]
 
         estimated_round_rewards = SwitchDoublyRobust(
             tau=self.best_tau
@@ -851,7 +863,7 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the shrinkage hyperparameter
-        self.estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_dict = dict()
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = DoublyRobustWithShrinkage(
                 lambda_=lambda_
@@ -864,8 +876,10 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
+            self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
+        self.best_lambda_ = min(
+            self.estimated_mse_upper_bound_dict.items(), key=lambda x: x[1]
+        )[0]
 
         return (
             DoublyRobustWithShrinkage(lambda_=self.best_lambda_)
@@ -951,7 +965,7 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
             position = np.zeros(action_dist.shape[0], dtype=int)
 
         # tune the shrinkage hyperparameter
-        self.estimated_mse_upper_bound_list = []
+        self.estimated_mse_upper_bound_dict = dict()
         for lambda_ in self.lambdas:
             estimated_mse_upper_bound = DoublyRobustWithShrinkage(
                 lambda_=lambda_
@@ -964,8 +978,10 @@ class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
                 estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
                 max_reward_value=self.max_reward_value,
             )
-            self.estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
-        self.best_lambda_ = self.lambdas[np.argmin(self.estimated_mse_upper_bound_list)]
+            self.estimated_mse_upper_bound_dict[lambda_] = estimated_mse_upper_bound
+        self.best_lambda_ = min(
+            self.estimated_mse_upper_bound_dict.items(), key=lambda x: x[1]
+        )[0]
 
         estimated_round_rewards = DoublyRobustWithShrinkage(
             lambda_=self.best_lambda_

--- a/obp/ope/estimators_tuning.py
+++ b/obp/ope/estimators_tuning.py
@@ -183,7 +183,7 @@ class BaseOffPolicyEstimatorTuning:
             Positions of each round in the given logged bandit feedback.
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -345,7 +345,7 @@ class InverseProbabilityWeightingTuning(BaseOffPolicyEstimatorTuning):
             Positions of each round in the given logged bandit feedback.
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -523,7 +523,7 @@ class DoublyRobustTuning(BaseOffPolicyEstimatorTuning):
             Positions of each round in the given logged bandit feedback.
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -705,7 +705,7 @@ class SwitchDoublyRobustTuning(BaseOffPolicyEstimatorTuning):
             Positions of each round in the given logged bandit feedback.
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -905,7 +905,7 @@ class DoublyRobustWithShrinkageTuning(BaseOffPolicyEstimatorTuning):
             Positions of each round in the given logged bandit feedback.
 
         alpha: float, default=0.05
-            P-value.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.

--- a/obp/ope/estimators_tuning.py
+++ b/obp/ope/estimators_tuning.py
@@ -1,0 +1,985 @@
+# Copyright (c) Yuta Saito, Yusuke Narita, and ZOZO Technologies, Inc. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+"""Off-Policy Estimators with built-in hyperparameter tuning."""
+from dataclasses import dataclass
+from typing import Dict, Optional, Union, List
+
+import numpy as np
+from sklearn.utils import check_scalar
+
+from .estimators import (
+    InverseProbabilityWeighting,
+    DoublyRobust,
+    SwitchDoublyRobust,
+    DoublyRobustWithShrinkage,
+)
+from ..utils import (
+    estimate_confidence_interval_by_bootstrap,
+    check_ope_inputs,
+)
+
+
+@dataclass
+class InverseProbabilityWeightingTuning(InverseProbabilityWeighting):
+    """Inverse Probability Weighting (IPW) with built in hyperparameter tuning.
+
+    Parameters
+    ----------
+    lambdas: List[float]
+        A list of candidate clipping hyperparameters.
+        The automatic hyperparameter tuning proposed by Wang et al.(2017) will choose the best hyperparameter value from the data.
+
+    max_reward_value: int or float, default=None
+        A maximum possible reward, which is necessary for the hyperparameter tuning.
+
+    estimator_name: str, default='ipw'.
+        Name of off-policy estimator.
+
+    References
+    ----------
+    Miroslav Dudík, Dumitru Erhan, John Langford, and Lihong Li.
+    "Doubly Robust Policy Evaluation and Optimization.", 2014.
+
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
+
+    """
+
+    lambdas: List[float] = None
+    max_reward_value: Optional[Union[int, float]] = None
+    estimator_name = "ipw"
+
+    def __post_init__(self) -> None:
+        """Initialize Class."""
+        if isinstance(self.lambdas, list):
+            if len(self.lambdas) == 0:
+                raise ValueError("lambdas must not be empty")
+            for lambda_ in self.lambdas:
+                check_scalar(
+                    lambda_,
+                    name="an element of lambdas",
+                    target_type=(int, float),
+                    min_val=0.0,
+                )
+                if lambda_ != lambda_:
+                    raise ValueError("an element of lambdas must not be nan")
+        else:
+            raise TypeError("lambdas must be a list")
+        if self.max_reward_value is not None:
+            check_scalar(
+                self.max_reward_value,
+                name="max_reward_value",
+                target_type=(int, float),
+            )
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        **kwargs,
+    ) -> np.ndarray:
+        """Estimate policy value of an evaluation policy.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Positions of each round in the given logged bandit feedback.
+
+        Returns
+        ----------
+        V_hat: float
+            Estimated policy value (performance) of a given evaluation policy.
+
+        """
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        # tune the clipping hyperparameter
+        estimated_mse_upper_bound_list = []
+        for lambda_ in self.lambdas:
+            estimated_mse_upper_bound = InverseProbabilityWeighting(
+                lambda_=lambda_
+            )._estimate_mse_upper_bound(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                max_reward_value=self.max_reward_value,
+            )
+            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+
+        return (
+            InverseProbabilityWeighting(lambda_=self.best_lambda_)
+            ._estimate_round_rewards(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+            )
+            .mean()
+        )
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities
+            by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Positions of each round in the given logged bandit feedback.
+
+        alpha: float, default=0.05
+            P-value.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        # tune the clipping hyperparameter
+        estimated_mse_upper_bound_list = []
+        for lambda_ in self.lambdas:
+            estimated_mse_upper_bound = InverseProbabilityWeighting(
+                lambda_=lambda_
+            )._estimate_mse_upper_bound(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                max_reward_value=self.max_reward_value,
+            )
+            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+
+        estimated_round_rewards = InverseProbabilityWeighting(
+            lambda_=self.best_lambda_
+        )._estimate_round_rewards(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+        )
+        return estimate_confidence_interval_by_bootstrap(
+            samples=estimated_round_rewards,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@dataclass
+class DoublyRobustTuning(DoublyRobust):
+    """Doubly Robust (DR) with built in hyperparameter tuning.
+
+    Parameters
+    ----------
+    lambdas: List[float]
+        A list of candidate clipping hyperparameters.
+        The automatic hyperparameter tuning proposed by Wang et al.(2017) will choose the best hyperparameter value from the data.
+
+    max_reward_value: int or float, default=None
+            A maximum possible reward, which is necessary for the hyperparameter tuning.
+
+    estimator_name: str, default='dr'.
+        Name of off-policy estimator.
+
+    References
+    ----------
+    Miroslav Dudík, Dumitru Erhan, John Langford, and Lihong Li.
+    "Doubly Robust Policy Evaluation and Optimization.", 2014.
+
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
+
+    """
+
+    lambdas: List[float] = None
+    max_reward_value: Optional[Union[int, float]] = None
+    estimator_name = "dr"
+
+    def __post_init__(self) -> None:
+        """Initialize Class."""
+        if isinstance(self.lambdas, list):
+            if len(self.lambdas) == 0:
+                raise ValueError("lambdas must not be empty")
+            for lambda_ in self.lambdas:
+                check_scalar(
+                    lambda_,
+                    name="an element of lambdas",
+                    target_type=(int, float),
+                    min_val=0.0,
+                )
+                if lambda_ != lambda_:
+                    raise ValueError("an element of lambdas must not be nan")
+        else:
+            raise TypeError("lambdas must be a list")
+        if self.max_reward_value is not None:
+            check_scalar(
+                self.max_reward_value,
+                name="max_reward_value",
+                target_type=(int, float),
+            )
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+    ) -> float:
+        """Estimate policy value of an evaluation policy with a tuned hyperparameter.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Positions of each round in the given logged bandit feedback.
+
+        Returns
+        ----------
+        V_hat: float
+            Estimated policy value by the DR estimator.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        # tune the clipping hyperparameter
+        estimated_mse_upper_bound_list = []
+        for lambda_ in self.lambdas:
+            estimated_mse_upper_bound = DoublyRobust(
+                lambda_=lambda_
+            )._estimate_mse_upper_bound(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                max_reward_value=self.max_reward_value,
+            )
+            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+
+        return (
+            DoublyRobust(lambda_=self.best_lambda_)
+            ._estimate_round_rewards(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            )
+            .mean()
+        )
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Positions of each round in the given logged bandit feedback.
+
+        alpha: float, default=0.05
+            P-value.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        # tune the clipping hyperparameter
+        estimated_mse_upper_bound_list = []
+        for lambda_ in self.lambdas:
+            estimated_mse_upper_bound = DoublyRobust(
+                lambda_=lambda_
+            )._estimate_mse_upper_bound(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                max_reward_value=self.max_reward_value,
+            )
+            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+
+        estimated_round_rewards = DoublyRobust(
+            lambda_=self.best_lambda_
+        )._estimate_round_rewards(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        return estimate_confidence_interval_by_bootstrap(
+            samples=estimated_round_rewards,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@dataclass
+class SwitchDoublyRobustTuning(SwitchDoublyRobust):
+    """Switch Doubly Robust (Switch-DR) with build-in hyperparameter tuning.
+
+    Parameters
+    ----------
+    taus: List[float]
+        A list of candidate switching hyperparameters.
+        The automatic hyperparameter tuning proposed by Wang et al.(2017) will choose the best hyperparameter value from the data.
+
+    max_reward_value: int or float, default=None
+            A maximum possible reward, which is necessary for the hyperparameter tuning.
+            If None is given, `reward.max()` is used.
+
+    estimator_name: str, default='switch-dr'.
+        Name of off-policy estimator.
+
+    References
+    ----------
+    Miroslav Dudík, Dumitru Erhan, John Langford, and Lihong Li.
+    "Doubly Robust Policy Evaluation and Optimization.", 2014.
+
+    Yu-Xiang Wang, Alekh Agarwal, and Miroslav Dudík.
+    "Optimal and Adaptive Off-policy Evaluation in Contextual Bandits", 2016.
+
+    """
+
+    taus: List[float] = None
+    max_reward_value: Optional[float] = None
+    estimator_name: str = "switch-dr"
+
+    def __post_init__(self) -> None:
+        """Initialize Class."""
+        if isinstance(self.taus, list):
+            if len(self.taus) == 0:
+                raise ValueError("taus must not be empty")
+            for tau in self.taus:
+                check_scalar(
+                    tau,
+                    name="an element of taus",
+                    target_type=(int, float),
+                    min_val=0.0,
+                )
+                if tau != tau:
+                    raise ValueError("an element of taus must not be nan")
+        else:
+            raise TypeError("taus must be a list")
+        if self.max_reward_value is not None:
+            check_scalar(
+                self.max_reward_value,
+                name="max_reward_value",
+                target_type=(int, float),
+            )
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+    ) -> float:
+        """Estimate policy value of an evaluation policy with a tuned hyperparameter.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Positions of each round in the given logged bandit feedback.
+
+        Returns
+        ----------
+        V_hat: float
+            Estimated policy value by the DR estimator.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        # tune the switching hyperparameter
+        estimated_mse_upper_bound_list = []
+        for tau_ in self.taus:
+            estimated_mse_upper_bound = SwitchDoublyRobust(
+                tau=tau_
+            )._estimate_mse_upper_bound(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                max_reward_value=self.max_reward_value,
+            )
+            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_tau = self.taus[estimated_mse_upper_bound.argmin()]
+
+        return (
+            SwitchDoublyRobust(tau=self.best_tau)
+            ._estimate_round_rewards(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            )
+            .mean()
+        )
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Positions of each round in the given logged bandit feedback.
+
+        alpha: float, default=0.05
+            P-value.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        # tune the switching hyperparameter
+        estimated_mse_upper_bound_list = []
+        for tau_ in self.taus:
+            estimated_mse_upper_bound = SwitchDoublyRobust(
+                tau=tau_
+            )._estimate_mse_upper_bound(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                max_reward_value=self.max_reward_value,
+            )
+            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_tau = self.taus[estimated_mse_upper_bound.argmin()]
+
+        estimated_round_rewards = SwitchDoublyRobust(
+            tau=self.best_tau
+        )._estimate_round_rewards(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        return estimate_confidence_interval_by_bootstrap(
+            samples=estimated_round_rewards,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )
+
+
+@dataclass
+class DoublyRobustWithShrinkageTuning(DoublyRobustWithShrinkage):
+    """Doubly Robust with optimistic shrinkage (DRos) with built in hyperparameter tuning.
+
+    Parameters
+    ----------
+    lambdas: List[float]
+        A list of candidate shrinkage hyperparameters.
+        The automatic hyperparameter tuning proposed by Wang et al.(2017) will choose the best hyperparameter value from the data.
+
+    max_reward_value: int or float, default=None
+            A maximum possible reward, which is necessary for the hyperparameter tuning.
+
+    estimator_name: str, default='dr-os'.
+        Name of off-policy estimator.
+
+    References
+    ----------
+    Miroslav Dudík, Dumitru Erhan, John Langford, and Lihong Li.
+    "Doubly Robust Policy Evaluation and Optimization.", 2014.
+
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
+
+    """
+
+    lambdas: List[float] = None
+    max_reward_value: Optional[Union[int, float]] = None
+    estimator_name = "dr-os"
+
+    def __post_init__(self) -> None:
+        """Initialize Class."""
+        if isinstance(self.lambdas, list):
+            if len(self.lambdas) == 0:
+                raise ValueError("lambdas must not be empty")
+            for lambda_ in self.lambdas:
+                check_scalar(
+                    lambda_,
+                    name="an element of lambdas",
+                    target_type=(int, float),
+                    min_val=0.0,
+                )
+                if lambda_ != lambda_:
+                    raise ValueError("an element of lambdas must not be nan")
+        else:
+            raise TypeError("lambdas must be a list")
+        if self.max_reward_value is not None:
+            check_scalar(
+                self.max_reward_value,
+                name="max_reward_value",
+                target_type=(int, float),
+            )
+
+    def estimate_policy_value(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+    ) -> float:
+        """Estimate policy value of an evaluation policy with a tuned hyperparameter.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Positions of each round in the given logged bandit feedback.
+
+        Returns
+        ----------
+        V_hat: float
+            Estimated policy value by the DR estimator.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        # tune the shrinkage hyperparameter
+        estimated_mse_upper_bound_list = []
+        for lambda_ in self.lambdas:
+            estimated_mse_upper_bound = DoublyRobustWithShrinkage(
+                lambda_=lambda_
+            )._estimate_mse_upper_bound(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                max_reward_value=self.max_reward_value,
+            )
+            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+
+        return (
+            DoublyRobustWithShrinkage(lambda_=self.best_lambda_)
+            ._estimate_round_rewards(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+            )
+            .mean()
+        )
+
+    def estimate_interval(
+        self,
+        reward: np.ndarray,
+        action: np.ndarray,
+        pscore: np.ndarray,
+        action_dist: np.ndarray,
+        estimated_rewards_by_reg_model: np.ndarray,
+        position: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap_samples: int = 10000,
+        random_state: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, float]:
+        """Estimate confidence interval of policy value by nonparametric bootstrap procedure.
+
+        Parameters
+        ----------
+        reward: array-like, shape (n_rounds,)
+            Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+        action: array-like, shape (n_rounds,)
+            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+
+        pscore: array-like, shape (n_rounds,)
+            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+
+        action_dist: array-like, shape (n_rounds, n_actions, len_list)
+            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+
+        estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
+            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+
+        position: array-like, shape (n_rounds,), default=None
+            Positions of each round in the given logged bandit feedback.
+
+        alpha: float, default=0.05
+            P-value.
+
+        n_bootstrap_samples: int, default=10000
+            Number of resampling performed in the bootstrap procedure.
+
+        random_state: int, default=None
+            Controls the random seed in bootstrap sampling.
+
+        Returns
+        ----------
+        estimated_confidence_interval: Dict[str, float]
+            Dictionary storing the estimated mean and upper-lower confidence bounds.
+
+        """
+        if not isinstance(estimated_rewards_by_reg_model, np.ndarray):
+            raise ValueError("estimated_rewards_by_reg_model must be ndarray")
+        if not isinstance(reward, np.ndarray):
+            raise ValueError("reward must be ndarray")
+        if not isinstance(action, np.ndarray):
+            raise ValueError("action must be ndarray")
+        if not isinstance(pscore, np.ndarray):
+            raise ValueError("pscore must be ndarray")
+
+        check_ope_inputs(
+            action_dist=action_dist,
+            position=position,
+            action=action,
+            reward=reward,
+            pscore=pscore,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        if position is None:
+            position = np.zeros(action_dist.shape[0], dtype=int)
+
+        # tune the shrinkage hyperparameter
+        estimated_mse_upper_bound_list = []
+        for lambda_ in self.lambdas:
+            estimated_mse_upper_bound = DoublyRobustWithShrinkage(
+                lambda_=lambda_
+            )._estimate_mse_upper_bound(
+                reward=reward,
+                action=action,
+                position=position,
+                pscore=pscore,
+                action_dist=action_dist,
+                estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+                max_reward_value=self.max_reward_value,
+            )
+            estimated_mse_upper_bound_list.append(estimated_mse_upper_bound)
+        self.best_lambda_ = self.lambdas[estimated_mse_upper_bound.argmin()]
+
+        estimated_round_rewards = DoublyRobustWithShrinkage(
+            lambda_=self.best_lambda_
+        )._estimate_round_rewards(
+            reward=reward,
+            action=action,
+            position=position,
+            pscore=pscore,
+            action_dist=action_dist,
+            estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
+        )
+        return estimate_confidence_interval_by_bootstrap(
+            samples=estimated_round_rewards,
+            alpha=alpha,
+            n_bootstrap_samples=n_bootstrap_samples,
+            random_state=random_state,
+        )

--- a/obp/ope/estimators_tuning.py
+++ b/obp/ope/estimators_tuning.py
@@ -22,6 +22,12 @@ from ..utils import check_ope_inputs
 class BaseOffPolicyEstimatorTuning:
     """Base Class for Off-Policy Estimator with built-in hyperparameter tuning
 
+    base_ope_estimator: BaseOffPolicyEstimator
+        An OPE estimator with a hyperparameter
+        (such as IPW/DR with clipping, Switch-DR, and DR with Shrinkage).
+
+    candidate_hyperparameter_list: List[float]
+        A list of candidate hyperparameter values.
 
     References
     ----------
@@ -122,7 +128,7 @@ class BaseOffPolicyEstimatorTuning:
 
         """
         # tune hyperparameter if necessary
-        if not hasattr(self, "best_hyperparam_"):
+        if not hasattr(self, "best_hyperparam"):
             self._tune_hyperparam(
                 reward=reward,
                 action=action,
@@ -147,7 +153,7 @@ class BaseOffPolicyEstimatorTuning:
         action: np.ndarray,
         pscore: np.ndarray,
         action_dist: np.ndarray,
-        estimated_rewards_by_reg_model: np.ndarray,
+        estimated_rewards_by_reg_model: Optional[np.ndarray] = None,
         position: Optional[np.ndarray] = None,
         alpha: float = 0.05,
         n_bootstrap_samples: int = 10000,
@@ -192,7 +198,7 @@ class BaseOffPolicyEstimatorTuning:
 
         """
         # tune hyperparameter if necessary
-        if not hasattr(self, "best_hyperparam_"):
+        if not hasattr(self, "best_hyperparam"):
             self._tune_hyperparam(
                 reward=reward,
                 action=action,

--- a/obp/ope/helper.py
+++ b/obp/ope/helper.py
@@ -56,7 +56,7 @@ def estimate_high_probability_upper_bound_bias(
 
     n_rounds = reward.shape[0]
     if q_hat is None:
-        q_hat = np.zeros_like(n_rounds)
+        q_hat = np.zeros(n_rounds)
     bias_upper_bound_arr = (iw - iw_hat) * (reward - q_hat)
     bias_upper_bound = np.abs(bias_upper_bound_arr.mean())
     bias_upper_bound += np.sqrt((2 * (iw ** 2).mean() * np.log(2 / delta)) / n_rounds)

--- a/obp/ope/helper.py
+++ b/obp/ope/helper.py
@@ -1,0 +1,65 @@
+# Copyright (c) Yuta Saito, Yusuke Narita, and ZOZO Technologies, Inc. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+from typing import Optional
+
+import numpy as np
+from sklearn.utils import check_scalar
+
+
+def estimate_high_probability_upper_bound_bias(
+    reward: np.ndarray,
+    iw: np.ndarray,
+    iw_hat: np.ndarray,
+    q_hat: Optional[np.ndarray] = None,
+    delta: float = 0.05,
+) -> float:
+    """Helper to estimate a high probability upper bound of bias in OPE.
+
+    Parameters
+    ----------
+    reward: array-like, shape (n_rounds,)
+        Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
+
+    iw: array-like, shape (n_rounds,)
+        Importance weight in each round of the logged bandit feedback, i.e., :math:`w(x,a)=\\pi_e(a|x)/ \\pi_b(a|x)`.
+
+    iw_hat: array-like, shape (n_rounds,)
+        Importance weight (IW) modified by a hyparpareter. How IW is modified depends on the estimator as follows.
+            - clipping: :math:`\\hat{w}(x,a) := \\min \\{ \\lambda, w(x,a) \\}`
+            - switching: :math:`\\hat{w}(x,a) := w(x,a) \\cdot \\mathbb{I} \\{ w(x,a) < \\tau \\}`
+            - shrinkage: :math:`\\hat{w}(x,a) := (\\lambda w(x,a)) / (\\lambda + w^2(x,a))`
+        where :math:`\\tau` and :math:`\\lambda` are hyperparameters.
+
+    q_hat: array-like, shape (n_rounds,), default=None
+        Estimated expected reward given context :math:`x_t` and action :math:`a_t`.
+
+    delta: float, default=0.05
+        A confidence delta to construct a high probability upper bound based on the Bernstein’s inequality.
+
+    Returns
+    ----------
+    bias_upper_bound: float
+        Estimated (high probability) upper bound of the bias.
+        This upper bound is based on the direct bias estimation
+        stated on page 17 of Su et al.(2020).
+
+    References
+    ----------
+    Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
+    "Doubly Robust Off-Policy Evaluation with Shrinkage.", 2020.
+
+    """
+    check_scalar(
+        delta, name="delta", target_type=(int, float), max_val=1.0, min_val=0.0
+    )
+
+    n_rounds = reward.shape[0]
+    if q_hat is None:
+        q_hat = np.zeros_like(n_rounds)
+    bias_upper_bound_arr = (iw - iw_hat) * (reward - q_hat)
+    bias_upper_bound = np.abs(bias_upper_bound_arr.mean())
+    bias_upper_bound += np.sqrt((2 * (iw ** 2).mean() * np.log(2 / delta)) / n_rounds)
+    bias_upper_bound += (2 * iw.max() * np.log(2 / delta)) / (3 * n_rounds)
+
+    return bias_upper_bound

--- a/obp/ope/meta.py
+++ b/obp/ope/meta.py
@@ -21,12 +21,12 @@ logger = getLogger(__name__)
 
 @dataclass
 class OffPolicyEvaluation:
-    """Class to conduct off-policy evaluation by multiple off-policy estimators simultaneously.
+    """Class to conduct OPE by multiple estimators simultaneously.
 
     Parameters
     -----------
     bandit_feedback: BanditFeedback
-        Logged bandit feedback data used for off-policy evaluation.
+        Logged bandit feedback data used to conduct OPE.
 
     ope_estimators: List[BaseOffPolicyEstimator]
         List of OPE estimators used to evaluate the policy value of evaluation policy.
@@ -94,7 +94,7 @@ class OffPolicyEvaluation:
             Union[np.ndarray, Dict[str, np.ndarray]]
         ] = None,
     ) -> Dict[str, Dict[str, np.ndarray]]:
-        """Create input dictionary to estimate policy value by subclasses of `BaseOffPolicyEstimator`"""
+        """Create input dictionary to estimate policy value using subclasses of `BaseOffPolicyEstimator`"""
         if not isinstance(action_dist, np.ndarray):
             raise ValueError("action_dist must be ndarray")
         if action_dist.ndim != 3:
@@ -152,15 +152,15 @@ class OffPolicyEvaluation:
             Union[np.ndarray, Dict[str, np.ndarray]]
         ] = None,
     ) -> Dict[str, float]:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ------------
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given each round, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
@@ -193,21 +193,21 @@ class OffPolicyEvaluation:
         n_bootstrap_samples: int = 100,
         random_state: Optional[int] = None,
     ) -> Dict[str, Dict[str, float]]:
-        """Estimate confidence intervals of estimated policy values using a nonparametric bootstrap procedure.
+        """Estimate confidence intervals of estimated policy values by nonparametric bootstrap procedure.
 
         Parameters
         ------------
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -219,7 +219,7 @@ class OffPolicyEvaluation:
         ----------
         policy_value_interval_dict: Dict[str, Dict[str, float]]
             Dictionary containing confidence intervals of estimated policy value estimated
-            using a nonparametric bootstrap procedure.
+            by nonparametric bootstrap procedure.
 
         """
         check_confidence_interval_arguments(
@@ -252,21 +252,21 @@ class OffPolicyEvaluation:
         n_bootstrap_samples: int = 100,
         random_state: Optional[int] = None,
     ) -> Tuple[DataFrame, DataFrame]:
-        """Summarize policy values estimated by OPE estimators and their confidence intervals estimated by a nonparametric bootstrap procedure.
+        """Summarize policy values and their confidence intervals estimated by OPE estimators.
 
         Parameters
         ------------
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given each round, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -277,7 +277,7 @@ class OffPolicyEvaluation:
         Returns
         ----------
         (policy_value_df, policy_value_interval_df): Tuple[DataFrame, DataFrame]
-            Estimated policy values and their confidence intervals by OPE estimators.
+            Policy values and their confidence intervals Estimated by OPE estimators.
 
         """
         policy_value_df = DataFrame(
@@ -327,16 +327,16 @@ class OffPolicyEvaluation:
         Parameters
         ----------
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -406,11 +406,11 @@ class OffPolicyEvaluation:
         ] = None,
         metric: str = "relative-ee",
     ) -> Dict[str, float]:
-        """Evaluate estimation performances of OPE estimators.
+        """Evaluate estimation performance of OPE estimators.
 
         Note
         ------
-        Evaluate the estimation performances of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
+        Evaluate the estimation performance of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
 
         .. math ::
 
@@ -426,20 +426,20 @@ class OffPolicyEvaluation:
         Parameters
         ----------
         ground_truth policy value: float
-            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
-            With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as its ground-truth.
+            Ground_truth policy value of evaluation policy, i.e., :math:`V(\\pi_e)`.
+            With Open Bandit Dataset, we use an on-policy estimate of the policy value as its ground-truth.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of a estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         metric: str, default="relative-ee"
-            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
+            Evaluation metric used to evaluate and compare the estimation performance of OPE estimators.
             Must be "relative-ee" or "se".
 
         Returns
@@ -494,18 +494,18 @@ class OffPolicyEvaluation:
         Parameters
         ----------
         ground_truth policy value: float
-            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
-            With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as ground-truth.
+            Ground_truth policy value of evaluation policy, i.e., :math:`V(\\pi_e)`.
+            With Open Bandit Dataset, we use an on-policy estimate of the policy value as ground-truth.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         metric: str, default="relative-ee"
-            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
+            Evaluation metric used to evaluate and compare the estimation performance of OPE estimators.
             Must be either "relative-ee" or "se".
 
         Returns
@@ -550,13 +550,13 @@ class OffPolicyEvaluation:
             List of action choice probabilities by the evaluation policies (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list) or Dict[str, array-like], default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             When an array-like is given, all OPE estimators use it.
             When a dict is given, if the dict has the name of an estimator as a key, the corresponding value is used.
             When it is not given, model-dependent estimators such as DM and DR cannot be used.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.

--- a/obp/ope/meta_slate.py
+++ b/obp/ope/meta_slate.py
@@ -161,18 +161,18 @@ class SlateOffPolicyEvaluation:
         evaluation_policy_pscore_item_position: Optional[np.ndarray] = None,
         evaluation_policy_pscore_cascade: Optional[np.ndarray] = None,
     ) -> Dict[str, float]:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ------------
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         Returns
         ----------
@@ -202,21 +202,21 @@ class SlateOffPolicyEvaluation:
         n_bootstrap_samples: int = 100,
         random_state: Optional[int] = None,
     ) -> Dict[str, Dict[str, float]]:
-        """Estimate confidence intervals of estimated policy values using a nonparametric bootstrap procedure.
+        """Estimate confidence intervals of estimated policy values by nonparametric bootstrap procedure.
 
         Parameters
         ------------
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -228,7 +228,7 @@ class SlateOffPolicyEvaluation:
         ----------
         policy_value_interval_dict: Dict[str, Dict[str, float]]
             Dictionary containing confidence intervals of estimated policy value estimated
-            using a nonparametric bootstrap procedure.
+            by nonparametric bootstrap procedure.
 
         """
         check_confidence_interval_arguments(
@@ -266,16 +266,16 @@ class SlateOffPolicyEvaluation:
         Parameters
         ------------
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -286,7 +286,7 @@ class SlateOffPolicyEvaluation:
         Returns
         ----------
         (policy_value_df, policy_value_interval_df): Tuple[DataFrame, DataFrame]
-            Estimated policy values and their confidence intervals by OPE estimators.
+            Policy values and their confidence intervals Estimated by OPE estimators.
 
         """
         policy_value_df = DataFrame(
@@ -340,16 +340,16 @@ class SlateOffPolicyEvaluation:
         Parameters
         ----------
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=100
             Number of resampling performed in the bootstrap procedure.
@@ -425,11 +425,11 @@ class SlateOffPolicyEvaluation:
         evaluation_policy_pscore_cascade: Optional[np.ndarray] = None,
         metric: str = "relative-ee",
     ) -> Dict[str, float]:
-        """Evaluate estimation performances of OPE estimators.
+        """Evaluate estimation performance of OPE estimators.
 
         Note
         ------
-        Evaluate the estimation performances of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
+        Evaluate the estimation performance of OPE estimators by relative estimation error (relative-EE) or squared error (SE):
 
         .. math ::
 
@@ -445,20 +445,20 @@ class SlateOffPolicyEvaluation:
         Parameters
         ----------
         ground_truth_policy_value: float
-            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
+            Ground_truth policy value of evaluation policy, i.e., :math:`V(\\pi)`.
             With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as its ground-truth.
 
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         metric: str, default="relative-ee"
-            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
+            Evaluation metric used to evaluate and compare the estimation performance of OPE estimators.
             Must be "relative-ee" or "se".
 
         Returns
@@ -511,20 +511,20 @@ class SlateOffPolicyEvaluation:
         Parameters
         ----------
         ground_truth_policy_value: float
-            Ground_truth policy value of an evaluation policy, i.e., :math:`V(\\pi)`.
+            Ground_truth policy value of evaluation policy, i.e., :math:`V(\\pi)`.
             With Open Bandit Dataset, in general, we use an on-policy estimate of the policy value as ground-truth.
 
         evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
         evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
+            Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t, k}|x_t)`.
 
         evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-            Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+            Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
         metric: str, default="relative-ee"
-            Evaluation metric to evaluate and compare the estimation performance of OPE estimators.
+            Evaluation metric used to evaluate and compare the estimation performance of OPE estimators.
             Must be either "relative-ee" or "se".
 
         Returns

--- a/obp/ope/regression_model.py
+++ b/obp/ope/regression_model.py
@@ -105,7 +105,7 @@ class RegressionModel(BaseEstimator):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -116,12 +116,12 @@ class RegressionModel(BaseEstimator):
             When None is given, the behavior policy is assumed to be a uniform one.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
             If None is set, a regression model assumes that there is only one position.
             When `len_list` > 1, this position argument has to be set.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
             When either of 'iw' or 'mrdr' is used as the 'fitting_method' argument, then `action_dist` must be given.
 
         """
@@ -249,7 +249,7 @@ class RegressionModel(BaseEstimator):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -260,12 +260,12 @@ class RegressionModel(BaseEstimator):
             When None is given, the the behavior policy is assumed to be a uniform one.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
             If None is set, a regression model assumes that there is only one position.
             When `len_list` > 1, this position argument has to be set.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
             When either of 'iw' or 'mrdr' is used as the 'fitting_method' argument, then `action_dist` must be given.
 
         n_folds: int, default=1
@@ -374,7 +374,7 @@ class RegressionModel(BaseEstimator):
             Context vectors in the training logged bandit feedback.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         action_context: array-like, shape shape (n_actions, dim_action_context)
             Context vector characterizing each action, vector representation of each action.

--- a/obp/policy/offline.py
+++ b/obp/policy/offline.py
@@ -77,7 +77,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -126,16 +126,16 @@ class IPWLearner(BaseOfflinePolicyLearner):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
 
         pscore: array-like, shape (n_rounds,), default=None
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
             If None is given, a learner assumes that there is only one position.
             When `len_list` > 1, position has to be set.
 
@@ -644,7 +644,7 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -654,10 +654,10 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
             in the given logged bandit feedback.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
             If None is given, a learner assumes that there is only one position.
 
         Returns
@@ -740,20 +740,20 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
             Context vectors in each round, i.e., :math:`x_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         reward: array-like, shape (n_rounds,)
             Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
 
         pscore: array-like, shape (n_rounds,), default=None
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
             If None is given, a learner assumes that the estimated rewards are zero.
 
         position: array-like, shape (n_rounds,), default=None
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
             If None is given, a learner assumes that there is only one position.
             When `len_list` > 1, position has to be set.
             Currently, this feature is not supported.

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -20,7 +20,7 @@ def check_confidence_interval_arguments(
     Parameters
     ----------
     alpha: float, default=0.05
-        Significant level of confidence intervals.
+        Significance level.
 
     n_bootstrap_samples: int, default=10000
         Number of resampling performed in the bootstrap procedure.
@@ -62,7 +62,7 @@ def estimate_confidence_interval_by_bootstrap(
         Empirical observed samples to be used to estimate cumulative distribution function.
 
     alpha: float, default=0.05
-        Significant level of confidence intervals.
+        Significance level.
 
     n_bootstrap_samples: int, default=10000
         Number of resampling performed in the bootstrap procedure.
@@ -143,7 +143,7 @@ def check_bandit_feedback_inputs(
         Context vectors in each round, i.e., :math:`x_t`.
 
     action: array-like, shape (n_rounds,)
-        Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+        Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
     reward: array-like, shape (n_rounds,)
         Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -152,7 +152,7 @@ def check_bandit_feedback_inputs(
         Expected rewards (or outcome) in each round, i.e., :math:`\\mathbb{E}[r_t]`.
 
     position: array-like, shape (n_rounds,), default=None
-        Positions of each round in the given logged bandit feedback.
+        Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
     pscore: array-like, shape (n_rounds,), default=None
         Propensity scores, the probability of selecting each action by behavior policy,
@@ -249,13 +249,13 @@ def check_ope_inputs(
     Parameters
     -----------
     action_dist: array-like, shape (n_rounds, n_actions, len_list)
-        Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+        Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
     position: array-like, shape (n_rounds,), default=None
-        Positions of each round in the given logged bandit feedback.
+        Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
     action: array-like, shape (n_rounds,), default=None
-        Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+        Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
     reward: array-like, shape (n_rounds,), default=None
         Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -265,7 +265,7 @@ def check_ope_inputs(
         in the given logged bandit feedback.
 
     estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list), default=None
-        Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+        Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
     """
     # action_dist
@@ -346,16 +346,16 @@ def _check_slate_ope_inputs(
         Slate id observed in each round of the logged bandit feedback.
 
     reward: array-like, shape (<= n_rounds * len_list,)
-        Reward observed in each round and slot of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
+        Reward observed at each slot in each round of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
 
     position: array-like, shape (<= n_rounds * len_list,)
         Positions of each round and slot in the given logged bandit feedback.
 
     pscore: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities by a behavior policy (propensity scores).
+        Action choice probabilities of behavior policy (propensity scores).
 
     evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities by the evaluation policy (propensity scores).
+        Action choice probabilities of evaluation policy.
 
     pscore_type: str
         Either "pscore", "pscore_item_position", or "pscore_cascade".
@@ -427,16 +427,16 @@ def check_sips_inputs(
         Slate id observed in each round of the logged bandit feedback.
 
     reward: array-like, shape (<= n_rounds * len_list,)
-        Reward observed in each round and slot of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
+        Reward observed at each slot in each round of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
 
     position: array-like, shape (<= n_rounds * len_list,)
         Positions of each round and slot in the given logged bandit feedback.
 
     pscore: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+        Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
     evaluation_policy_pscore: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_t|x_t)`.
+        Action choice probabilities of evaluation policy, i.e., :math:`\\pi_e(a_t|x_t)`.
 
     """
     _check_slate_ope_inputs(
@@ -486,7 +486,7 @@ def check_iips_inputs(
         Slate id observed in each round of the logged bandit feedback.
 
     reward: array-like, shape (<= n_rounds * len_list,)
-        Reward observed in each round and slot of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
+        Reward observed at each slot in each round of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
 
     position: array-like, shape (<= n_rounds * len_list,)
         Positions of each round and slot in the given logged bandit feedback.
@@ -495,7 +495,7 @@ def check_iips_inputs(
         Marginal action choice probabilities of the slot (:math:`k`) by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_{t}(k) |x_t)`.
 
     evaluation_policy_pscore_item_position: array-like, shape (<= n_rounds * len_list,)
-        Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(a_{t}(k) |x_t)`.
+        Marginal action choice probabilities of the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(a_{t}(k) |x_t)`.
 
     """
     _check_slate_ope_inputs(
@@ -530,16 +530,16 @@ def check_rips_inputs(
         Slate id observed in each round of the logged bandit feedback.
 
     reward: array-like, shape (<= n_rounds * len_list,)
-        Reward observed in each round and slot of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
+        Reward observed at each slot in each round of the logged bandit feedback, i.e., :math:`r_{t}(k)`.
 
     position: array-like, shape (<= n_rounds * len_list,)
         Positions of each round and slot in the given logged bandit feedback.
 
     pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+        Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
     evaluation_policy_pscore_cascade: array-like, shape (<= n_rounds * len_list,)
-        Action choice probabilities above the slot (:math:`k`) by the evaluation policy (propensity scores), i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
+        Action choice probabilities above the slot (:math:`k`) by the evaluation policy, i.e., :math:`\\pi_e(\\{a_{t, j}\\}_{j \\le k}|x_t)`.
 
     """
     _check_slate_ope_inputs(
@@ -609,13 +609,13 @@ def check_ope_inputs_tensor(
     Parameters
     -----------
     action_dist: Tensor, shape (n_rounds, n_actions, len_list)
-        Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+        Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
     position: Tensor, shape (n_rounds,), default=None
-        Positions of each round in the given logged bandit feedback.
+        Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
     action: Tensor, shape (n_rounds,), default=None
-        Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+        Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
     reward: Tensor, shape (n_rounds,), default=None
         Observed rewards (or outcome) in each round, i.e., :math:`r_t`.
@@ -625,7 +625,7 @@ def check_ope_inputs_tensor(
         in the given logged bandit feedback.
 
     estimated_rewards_by_reg_model: Tensor, shape (n_rounds, n_actions, len_list), default=None
-        Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+        Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
     """
     # action_dist

--- a/tests/ope/test_dm_estimators.py
+++ b/tests/ope/test_dm_estimators.py
@@ -15,19 +15,19 @@ invalid_input_of_dm = [
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        np.zeros((5, 4, 2)),
+        np.zeros((5, 4, 2)),  #
         "estimated_rewards_by_reg_model.shape must be the same as action_dist.shape",
     ),
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        None,
+        None,  #
         "estimated_rewards_by_reg_model must be ndarray",
     ),
     (
         generate_action_dist(5, 4, 3),
         np.zeros(5, dtype=int),
-        "4",
+        "4",  #
         "estimated_rewards_by_reg_model must be ndarray",
     ),
 ]
@@ -58,23 +58,24 @@ def test_dm_using_invalid_input_data(
         )
 
 
+# action_dist, position, estimated_rewards_by_reg_model, description
 invalid_input_tensor_of_dm = [
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        torch.from_numpy(np.zeros((5, 4, 2))),
+        torch.from_numpy(np.zeros((5, 4, 2))),  #
         "estimated_rewards_by_reg_model.shape must be the same as action_dist.shape",
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        None,
+        None,  #
         "estimated_rewards_by_reg_model must be Tensor",
     ),
     (
         torch.from_numpy(generate_action_dist(5, 4, 3)),
         torch.zeros(5, dtype=torch.int64),
-        "4",
+        "4",  #
         "estimated_rewards_by_reg_model must be Tensor",
     ),
 ]

--- a/tests/ope/test_dr_estimators.py
+++ b/tests/ope/test_dr_estimators.py
@@ -8,8 +8,11 @@ from obp.types import BanditFeedback
 from obp.ope import (
     DirectMethod,
     DoublyRobust,
+    DoublyRobustTuning,
     DoublyRobustWithShrinkage,
+    DoublyRobustWithShrinkageTuning,
     SwitchDoublyRobust,
+    SwitchDoublyRobustTuning,
     SelfNormalizedDoublyRobust,
 )
 from conftest import generate_action_dist
@@ -47,6 +50,53 @@ def test_dr_init_using_invalid_inputs(
         _ = DoublyRobustWithShrinkage(lambda_=lambda_)
 
 
+invalid_input_of_dr_tuning_init = [
+    (
+        "",
+        TypeError,
+        "lambdas must be a list",
+    ),
+    (
+        None,
+        TypeError,
+        "lambdas must be a list",
+    ),
+    (
+        [""],
+        TypeError,
+        r"`an element of lambdas` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
+    ),
+    (
+        [None],
+        TypeError,
+        r"`an element of lambdas` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
+    ),
+    (
+        [],
+        ValueError,
+        "lambdas must not be empty",
+    ),
+    ([-1.0], ValueError, "`an element of lambdas`= -1.0, must be >= 0.0."),
+    ([np.nan], ValueError, "an element of lambdas must not be nan"),
+]
+
+
+@pytest.mark.parametrize(
+    "lambdas, err, description",
+    invalid_input_of_dr_tuning_init,
+)
+def test_dr_tuning_init_using_invalid_inputs(
+    lambdas,
+    err,
+    description,
+):
+    with pytest.raises(err, match=f"{description}*"):
+        _ = DoublyRobustTuning(lambdas=lambdas)
+
+    with pytest.raises(err, match=f"{description}*"):
+        _ = DoublyRobustWithShrinkageTuning(lambdas=lambdas)
+
+
 invalid_input_of_switch_dr_init = [
     (
         "",
@@ -76,7 +126,52 @@ def test_switch_dr_init_using_invalid_inputs(
         _ = SwitchDoublyRobust(tau=tau)
 
 
+invalid_input_of_switch_dr_tuning_init = [
+    (
+        "",
+        TypeError,
+        "taus must be a list",
+    ),
+    (
+        None,
+        TypeError,
+        "taus must be a list",
+    ),
+    (
+        [""],
+        TypeError,
+        r"`an element of taus` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
+    ),
+    (
+        [None],
+        TypeError,
+        r"`an element of taus` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
+    ),
+    (
+        [],
+        ValueError,
+        "taus must not be empty",
+    ),
+    ([-1.0], ValueError, "`an element of taus`= -1.0, must be >= 0.0."),
+    ([np.nan], ValueError, "an element of taus must not be nan"),
+]
+
+
+@pytest.mark.parametrize(
+    "taus, err, description",
+    invalid_input_of_switch_dr_tuning_init,
+)
+def test_switch_dr_tuning_init_using_invalid_inputs(
+    taus,
+    err,
+    description,
+):
+    with pytest.raises(err, match=f"{description}*"):
+        _ = SwitchDoublyRobustTuning(taus=taus)
+
+
 valid_input_of_dr_init = [
+    (np.inf, "infinite lambda_tau"),
     (3.0, "float lambda_tau"),
     (2, "integer lambda_tau"),
 ]
@@ -86,22 +181,49 @@ valid_input_of_dr_init = [
     "lambda_tau, description",
     valid_input_of_dr_init,
 )
-def test_shrinkage_using_valid_input_data(lambda_tau: float, description: str) -> None:
+def test_dr_init_using_valid_input_data(lambda_tau: float, description: str) -> None:
     _ = DoublyRobust(lambda_=lambda_tau)
     _ = DoublyRobustWithShrinkage(lambda_=lambda_tau)
-    _ = SwitchDoublyRobust(lambda_=lambda_tau)
+    _ = SwitchDoublyRobust(tau=lambda_tau)
+
+
+valid_input_of_dr_tuning_init = [
+    ([3.0, np.inf, 100.0], "float lambda_tau"),
+    ([2], "integer lambda_tau"),
+]
+
+
+@pytest.mark.parametrize(
+    "lambdas_taus, description",
+    valid_input_of_dr_tuning_init,
+)
+def test_dr_tuning_init_using_valid_input_data(lambdas_taus, description):
+    _ = DoublyRobustTuning(lambdas=lambdas_taus)
+    _ = DoublyRobustWithShrinkageTuning(lambdas=lambdas_taus)
+    _ = SwitchDoublyRobustTuning(taus=lambdas_taus)
 
 
 # prepare instances
 dm = DirectMethod()
 dr = DoublyRobust()
+dr_tuning = DoublyRobustTuning(lambdas=[1, 100])
 dr_shrink_0 = DoublyRobustWithShrinkage(lambda_=0.0)
+dr_shrink_tuning = DoublyRobustWithShrinkageTuning(lambdas=[1, 100])
 dr_shrink_max = DoublyRobustWithShrinkage(lambda_=1e10)
 sndr = SelfNormalizedDoublyRobust()
 switch_dr_0 = SwitchDoublyRobust(tau=0.0)
+switch_dr_tuning = SwitchDoublyRobustTuning(taus=[1, 100])
 switch_dr_max = SwitchDoublyRobust(tau=1e10)
 
-dr_estimators = [dr, dr_shrink_0, sndr, switch_dr_0]
+dr_estimators = [
+    dr,
+    dr_tuning,
+    dr_shrink_0,
+    dr_shrink_tuning,
+    sndr,
+    switch_dr_0,
+    switch_dr_tuning,
+]
 
 
 # dr and self-normalized dr
@@ -286,7 +408,7 @@ def test_dr_using_invalid_input_data(
     description: str,
 ) -> None:
     # estimate_intervals function raises ValueError of all estimators
-    for estimator in [dr, sndr]:
+    for estimator in [dr, sndr, dr_tuning]:
         with pytest.raises(ValueError, match=f"{description}*"):
             _ = estimator.estimate_policy_value(
                 action_dist=action_dist,

--- a/tests/ope/test_dr_estimators.py
+++ b/tests/ope/test_dr_estimators.py
@@ -215,13 +215,17 @@ def test_dr_tuning_init_using_valid_input_data(lambdas_taus, description):
 # prepare instances
 dm = DirectMethod()
 dr = DoublyRobust()
-dr_tuning = DoublyRobustTuning(lambdas=[1, 100])
+dr_tuning = DoublyRobustTuning(lambdas=[1, 100], estimator_name="dr_tuning")
 dr_os_0 = DoublyRobustWithShrinkage(lambda_=0.0)
-dr_os_tuning = DoublyRobustWithShrinkageTuning(lambdas=[1, 100])
+dr_os_tuning = DoublyRobustWithShrinkageTuning(
+    lambdas=[1, 100], estimator_name="dr_os_tuning"
+)
 dr_os_max = DoublyRobustWithShrinkage(lambda_=np.inf)
 sndr = SelfNormalizedDoublyRobust()
 switch_dr_0 = SwitchDoublyRobust(tau=0.0)
-switch_dr_tuning = SwitchDoublyRobustTuning(taus=[1, 100])
+switch_dr_tuning = SwitchDoublyRobustTuning(
+    taus=[1, 100], estimator_name="switch_dr_tuning"
+)
 switch_dr_max = SwitchDoublyRobust(tau=np.inf)
 
 dr_estimators = [
@@ -781,7 +785,7 @@ def test_dr_using_random_evaluation_policy(
                 ),
             ):
                 _ = estimator.estimate_policy_value_tensor(**input_tensor_dict)
-        else:
+        elif "tuning" not in estimator.estimator_name:
             estimated_policy_value = estimator.estimate_policy_value_tensor(
                 **input_tensor_dict
             )
@@ -802,7 +806,7 @@ def test_dr_using_random_evaluation_policy(
                 ),
             ):
                 _ = estimator.estimate_policy_value_tensor(**input_tensor_dict)
-        else:
+        elif "tuning" not in estimator.estimator_name:
             with pytest.raises(
                 TypeError,
                 match=re.escape(

--- a/tests/ope/test_dr_estimators.py
+++ b/tests/ope/test_dr_estimators.py
@@ -50,65 +50,53 @@ def test_dr_init_using_invalid_inputs(
         _ = DoublyRobustWithShrinkage(lambda_=lambda_)
 
 
-# lambdas, max_reward_value, err, description
+# lambdas, err, description
 invalid_input_of_dr_tuning_init = [
     (
-        "",  #
-        10,
+        "",
         TypeError,
         "lambdas must be a list",
     ),
     (
-        None,  #
-        10,
+        None,
         TypeError,
         "lambdas must be a list",
     ),
     (
-        [""],  #
-        10,
+        [""],
         TypeError,
         r"`an element of lambdas` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
     ),
     (
-        [None],  #
-        10,
+        [None],
         TypeError,
         r"`an element of lambdas` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
     ),
     (
-        [],  #
-        10,
+        [],
         ValueError,
         "lambdas must not be empty",
     ),
-    ([-1.0], 10, ValueError, "`an element of lambdas`= -1.0, must be >= 0.0."),  #
-    ([np.nan], 10, ValueError, "an element of lambdas must not be nan"),  #
-    (
-        [1, 100],
-        "",  #
-        TypeError,
-        r"`max_reward_value` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
-    ),
+    ([-1.0], ValueError, "`an element of lambdas`= -1.0, must be >= 0.0."),
+    ([np.nan], ValueError, "an element of lambdas must not be nan"),
 ]
 
 
 @pytest.mark.parametrize(
-    "lambdas, max_reward_value, err, description",
+    "lambdas, err, description",
     invalid_input_of_dr_tuning_init,
 )
 def test_dr_tuning_init_using_invalid_inputs(
     lambdas,
-    max_reward_value,
     err,
     description,
 ):
     with pytest.raises(err, match=f"{description}*"):
-        _ = DoublyRobustTuning(lambdas=lambdas, max_reward_value=max_reward_value)
+        _ = DoublyRobustTuning(lambdas=lambdas)
 
     with pytest.raises(err, match=f"{description}*"):
         _ = DoublyRobustWithShrinkageTuning(
-            lambdas=lambdas, max_reward_value=max_reward_value
+            lambdas=lambdas,
         )
 
 
@@ -142,61 +130,49 @@ def test_switch_dr_init_using_invalid_inputs(
         _ = SwitchDoublyRobust(tau=tau)
 
 
-# taus, max_reward_value, err, description
+# taus, err, description
 invalid_input_of_switch_dr_tuning_init = [
     (
-        "",  #
-        10,
+        "",
         TypeError,
         "taus must be a list",
     ),
     (
-        None,  #
-        10,
+        None,
         TypeError,
         "taus must be a list",
     ),
     (
-        [""],  #
-        10,
+        [""],
         TypeError,
         r"`an element of taus` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
     ),
     (
-        [None],  #
-        10,
+        [None],
         TypeError,
         r"`an element of taus` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
     ),
     (
-        [],  #
-        10,
+        [],
         ValueError,
         "taus must not be empty",
     ),
-    ([-1.0], 10, ValueError, "`an element of taus`= -1.0, must be >= 0.0."),  #
-    ([np.nan], 10, ValueError, "an element of taus must not be nan"),  #
-    (
-        [1, 100],
-        "",  #
-        TypeError,
-        r"`max_reward_value` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
-    ),
+    ([-1.0], ValueError, "`an element of taus`= -1.0, must be >= 0.0."),
+    ([np.nan], ValueError, "an element of taus must not be nan"),
 ]
 
 
 @pytest.mark.parametrize(
-    "taus, max_reward_value, err, description",
+    "taus, err, description",
     invalid_input_of_switch_dr_tuning_init,
 )
 def test_switch_dr_tuning_init_using_invalid_inputs(
     taus,
-    max_reward_value,
     err,
     description,
 ):
     with pytest.raises(err, match=f"{description}*"):
-        _ = SwitchDoublyRobustTuning(taus=taus, max_reward_value=max_reward_value)
+        _ = SwitchDoublyRobustTuning(taus=taus)
 
 
 valid_input_of_dr_init = [
@@ -217,23 +193,23 @@ def test_dr_init_using_valid_input_data(lambda_tau: float, description: str) -> 
 
 
 valid_input_of_dr_tuning_init = [
-    ([3.0, np.inf, 100.0], 10.0, "float lambda_tau"),
-    ([2], 10, "integer lambda_tau"),
+    ([3.0, np.inf, 100.0], "float lambda_tau"),
+    ([2], "integer lambda_tau"),
 ]
 
 
 @pytest.mark.parametrize(
-    "lambdas_taus, max_reward_value, description",
+    "lambdas_taus, description",
     valid_input_of_dr_tuning_init,
 )
-def test_dr_tuning_init_using_valid_input_data(
-    lambdas_taus, max_reward_value, description
-):
-    _ = DoublyRobustTuning(lambdas=lambdas_taus, max_reward_value=max_reward_value)
+def test_dr_tuning_init_using_valid_input_data(lambdas_taus, description):
+    _ = DoublyRobustTuning(lambdas=lambdas_taus)
     _ = DoublyRobustWithShrinkageTuning(
-        lambdas=lambdas_taus, max_reward_value=max_reward_value
+        lambdas=lambdas_taus,
     )
-    _ = SwitchDoublyRobustTuning(taus=lambdas_taus, max_reward_value=max_reward_value)
+    _ = SwitchDoublyRobustTuning(
+        taus=lambdas_taus,
+    )
 
 
 # prepare instances

--- a/tests/ope/test_dr_estimators.py
+++ b/tests/ope/test_dr_estimators.py
@@ -17,7 +17,7 @@ from obp.ope import (
 )
 from conftest import generate_action_dist
 
-
+# lambda_, err, description
 invalid_input_of_dr_init = [
     (
         "",
@@ -50,53 +50,69 @@ def test_dr_init_using_invalid_inputs(
         _ = DoublyRobustWithShrinkage(lambda_=lambda_)
 
 
+# lambdas, max_reward_value, err, description
 invalid_input_of_dr_tuning_init = [
     (
-        "",
+        "",  #
+        10,
         TypeError,
         "lambdas must be a list",
     ),
     (
-        None,
+        None,  #
+        10,
         TypeError,
         "lambdas must be a list",
     ),
     (
-        [""],
+        [""],  #
+        10,
         TypeError,
         r"`an element of lambdas` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
     ),
     (
-        [None],
+        [None],  #
+        10,
         TypeError,
         r"`an element of lambdas` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
     ),
     (
-        [],
+        [],  #
+        10,
         ValueError,
         "lambdas must not be empty",
     ),
-    ([-1.0], ValueError, "`an element of lambdas`= -1.0, must be >= 0.0."),
-    ([np.nan], ValueError, "an element of lambdas must not be nan"),
+    ([-1.0], 10, ValueError, "`an element of lambdas`= -1.0, must be >= 0.0."),  #
+    ([np.nan], 10, ValueError, "an element of lambdas must not be nan"),  #
+    (
+        [1, 100],
+        "",  #
+        TypeError,
+        r"`max_reward_value` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
+    ),
 ]
 
 
 @pytest.mark.parametrize(
-    "lambdas, err, description",
+    "lambdas, max_reward_value, err, description",
     invalid_input_of_dr_tuning_init,
 )
 def test_dr_tuning_init_using_invalid_inputs(
     lambdas,
+    max_reward_value,
     err,
     description,
 ):
     with pytest.raises(err, match=f"{description}*"):
-        _ = DoublyRobustTuning(lambdas=lambdas)
+        _ = DoublyRobustTuning(lambdas=lambdas, max_reward_value=max_reward_value)
 
     with pytest.raises(err, match=f"{description}*"):
-        _ = DoublyRobustWithShrinkageTuning(lambdas=lambdas)
+        _ = DoublyRobustWithShrinkageTuning(
+            lambdas=lambdas, max_reward_value=max_reward_value
+        )
 
 
+# tau, err, description
 invalid_input_of_switch_dr_init = [
     (
         "",
@@ -126,48 +142,61 @@ def test_switch_dr_init_using_invalid_inputs(
         _ = SwitchDoublyRobust(tau=tau)
 
 
+# taus, max_reward_value, err, description
 invalid_input_of_switch_dr_tuning_init = [
     (
-        "",
+        "",  #
+        10,
         TypeError,
         "taus must be a list",
     ),
     (
-        None,
+        None,  #
+        10,
         TypeError,
         "taus must be a list",
     ),
     (
-        [""],
+        [""],  #
+        10,
         TypeError,
         r"`an element of taus` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
     ),
     (
-        [None],
+        [None],  #
+        10,
         TypeError,
         r"`an element of taus` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'NoneType'>.",
     ),
     (
-        [],
+        [],  #
+        10,
         ValueError,
         "taus must not be empty",
     ),
-    ([-1.0], ValueError, "`an element of taus`= -1.0, must be >= 0.0."),
-    ([np.nan], ValueError, "an element of taus must not be nan"),
+    ([-1.0], 10, ValueError, "`an element of taus`= -1.0, must be >= 0.0."),  #
+    ([np.nan], 10, ValueError, "an element of taus must not be nan"),  #
+    (
+        [1, 100],
+        "",  #
+        TypeError,
+        r"`max_reward_value` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
+    ),
 ]
 
 
 @pytest.mark.parametrize(
-    "taus, err, description",
+    "taus, max_reward_value, err, description",
     invalid_input_of_switch_dr_tuning_init,
 )
 def test_switch_dr_tuning_init_using_invalid_inputs(
     taus,
+    max_reward_value,
     err,
     description,
 ):
     with pytest.raises(err, match=f"{description}*"):
-        _ = SwitchDoublyRobustTuning(taus=taus)
+        _ = SwitchDoublyRobustTuning(taus=taus, max_reward_value=max_reward_value)
 
 
 valid_input_of_dr_init = [
@@ -188,19 +217,23 @@ def test_dr_init_using_valid_input_data(lambda_tau: float, description: str) -> 
 
 
 valid_input_of_dr_tuning_init = [
-    ([3.0, np.inf, 100.0], "float lambda_tau"),
-    ([2], "integer lambda_tau"),
+    ([3.0, np.inf, 100.0], 10.0, "float lambda_tau"),
+    ([2], 10, "integer lambda_tau"),
 ]
 
 
 @pytest.mark.parametrize(
-    "lambdas_taus, description",
+    "lambdas_taus, max_reward_value, description",
     valid_input_of_dr_tuning_init,
 )
-def test_dr_tuning_init_using_valid_input_data(lambdas_taus, description):
-    _ = DoublyRobustTuning(lambdas=lambdas_taus)
-    _ = DoublyRobustWithShrinkageTuning(lambdas=lambdas_taus)
-    _ = SwitchDoublyRobustTuning(taus=lambdas_taus)
+def test_dr_tuning_init_using_valid_input_data(
+    lambdas_taus, max_reward_value, description
+):
+    _ = DoublyRobustTuning(lambdas=lambdas_taus, max_reward_value=max_reward_value)
+    _ = DoublyRobustWithShrinkageTuning(
+        lambdas=lambdas_taus, max_reward_value=max_reward_value
+    )
+    _ = SwitchDoublyRobustTuning(taus=lambdas_taus, max_reward_value=max_reward_value)
 
 
 # prepare instances
@@ -209,11 +242,11 @@ dr = DoublyRobust()
 dr_tuning = DoublyRobustTuning(lambdas=[1, 100])
 dr_os_0 = DoublyRobustWithShrinkage(lambda_=0.0)
 dr_os_tuning = DoublyRobustWithShrinkageTuning(lambdas=[1, 100])
-dr_os_max = DoublyRobustWithShrinkage(lambda_=1e10)
+dr_os_max = DoublyRobustWithShrinkage(lambda_=np.inf)
 sndr = SelfNormalizedDoublyRobust()
 switch_dr_0 = SwitchDoublyRobust(tau=0.0)
 switch_dr_tuning = SwitchDoublyRobustTuning(taus=[1, 100])
-switch_dr_max = SwitchDoublyRobust(tau=1e10)
+switch_dr_max = SwitchDoublyRobust(tau=np.inf)
 
 dr_estimators = [
     dr,
@@ -654,9 +687,13 @@ def test_dr_variants_using_valid_input_data(
 ) -> None:
     # check dr variants
     switch_dr = SwitchDoublyRobust(tau=hyperparameter)
-    switch_dr_tuning = SwitchDoublyRobustTuning(taus=[hyperparameter, hyperparameter * 10])
+    switch_dr_tuning = SwitchDoublyRobustTuning(
+        taus=[hyperparameter, hyperparameter * 10]
+    )
     dr_os = DoublyRobustWithShrinkage(lambda_=hyperparameter)
-    dr_os_tuning = DoublyRobustWithShrinkageTuning(lambdas=[hyperparameter, hyperparameter * 10])
+    dr_os_tuning = DoublyRobustWithShrinkageTuning(
+        lambdas=[hyperparameter, hyperparameter * 10]
+    )
     for estimator in [switch_dr, switch_dr_tuning, dr_os, dr_os_tuning]:
         est = estimator.estimate_policy_value(
             action_dist=action_dist,
@@ -880,9 +917,7 @@ def test_dr_osage_using_random_evaluation_policy(
     dm_value = dm.estimate_policy_value_tensor(**input_tensor_dict)
     dr_value = dr.estimate_policy_value_tensor(**input_tensor_dict)
     dr_os_0_value = dr_os_0.estimate_policy_value_tensor(**input_tensor_dict)
-    dr_os_max_value = dr_os_max.estimate_policy_value_tensor(
-        **input_tensor_dict
-    )
+    dr_os_max_value = dr_os_max.estimate_policy_value_tensor(**input_tensor_dict)
     assert (
         dm_value.item() == dr_os_0_value.item()
     ), "DoublyRobustWithShrinkage (lambda=0) should be the same as DirectMethod"

--- a/tests/ope/test_dr_estimators.py
+++ b/tests/ope/test_dr_estimators.py
@@ -207,9 +207,9 @@ def test_dr_tuning_init_using_valid_input_data(lambdas_taus, description):
 dm = DirectMethod()
 dr = DoublyRobust()
 dr_tuning = DoublyRobustTuning(lambdas=[1, 100])
-dr_shrink_0 = DoublyRobustWithShrinkage(lambda_=0.0)
-dr_shrink_tuning = DoublyRobustWithShrinkageTuning(lambdas=[1, 100])
-dr_shrink_max = DoublyRobustWithShrinkage(lambda_=1e10)
+dr_os_0 = DoublyRobustWithShrinkage(lambda_=0.0)
+dr_os_tuning = DoublyRobustWithShrinkageTuning(lambdas=[1, 100])
+dr_os_max = DoublyRobustWithShrinkage(lambda_=1e10)
 sndr = SelfNormalizedDoublyRobust()
 switch_dr_0 = SwitchDoublyRobust(tau=0.0)
 switch_dr_tuning = SwitchDoublyRobustTuning(taus=[1, 100])
@@ -218,8 +218,8 @@ switch_dr_max = SwitchDoublyRobust(tau=1e10)
 dr_estimators = [
     dr,
     dr_tuning,
-    dr_shrink_0,
-    dr_shrink_tuning,
+    dr_os_0,
+    dr_os_tuning,
     sndr,
     switch_dr_0,
     switch_dr_tuning,
@@ -654,8 +654,10 @@ def test_dr_variants_using_valid_input_data(
 ) -> None:
     # check dr variants
     switch_dr = SwitchDoublyRobust(tau=hyperparameter)
+    switch_dr_tuning = SwitchDoublyRobustTuning(taus=[hyperparameter, hyperparameter * 10])
     dr_os = DoublyRobustWithShrinkage(lambda_=hyperparameter)
-    for estimator in [switch_dr, dr_os]:
+    dr_os_tuning = DoublyRobustWithShrinkageTuning(lambdas=[hyperparameter, hyperparameter * 10])
+    for estimator in [switch_dr, switch_dr_tuning, dr_os, dr_os_tuning]:
         est = estimator.estimate_policy_value(
             action_dist=action_dist,
             action=action,
@@ -838,7 +840,7 @@ def test_boundedness_of_sndr_using_random_evaluation_policy(
     ), f"estimated policy value of sndr should be smaller than or equal to 2 (because of its 2-boundedness), but the value is: {estimated_policy_value.item()}"
 
 
-def test_dr_shrinkage_using_random_evaluation_policy(
+def test_dr_osage_using_random_evaluation_policy(
     synthetic_bandit_feedback: BanditFeedback, random_action_dist: np.ndarray
 ) -> None:
     """
@@ -856,13 +858,13 @@ def test_dr_shrinkage_using_random_evaluation_policy(
     input_dict["estimated_rewards_by_reg_model"] = expected_reward
     dm_value = dm.estimate_policy_value(**input_dict)
     dr_value = dr.estimate_policy_value(**input_dict)
-    dr_shrink_0_value = dr_shrink_0.estimate_policy_value(**input_dict)
-    dr_shrink_max_value = dr_shrink_max.estimate_policy_value(**input_dict)
+    dr_os_0_value = dr_os_0.estimate_policy_value(**input_dict)
+    dr_os_max_value = dr_os_max.estimate_policy_value(**input_dict)
     assert (
-        dm_value == dr_shrink_0_value
+        dm_value == dr_os_0_value
     ), "DoublyRobustWithShrinkage (lambda=0) should be the same as DirectMethod"
     assert (
-        np.abs(dr_value - dr_shrink_max_value) < 1e-5
+        np.abs(dr_value - dr_os_max_value) < 1e-5
     ), "DoublyRobustWithShrinkage (lambda=inf) should be almost the same as DoublyRobust"
 
     # prepare input dict
@@ -877,15 +879,15 @@ def test_dr_shrinkage_using_random_evaluation_policy(
     )
     dm_value = dm.estimate_policy_value_tensor(**input_tensor_dict)
     dr_value = dr.estimate_policy_value_tensor(**input_tensor_dict)
-    dr_shrink_0_value = dr_shrink_0.estimate_policy_value_tensor(**input_tensor_dict)
-    dr_shrink_max_value = dr_shrink_max.estimate_policy_value_tensor(
+    dr_os_0_value = dr_os_0.estimate_policy_value_tensor(**input_tensor_dict)
+    dr_os_max_value = dr_os_max.estimate_policy_value_tensor(
         **input_tensor_dict
     )
     assert (
-        dm_value.item() == dr_shrink_0_value.item()
+        dm_value.item() == dr_os_0_value.item()
     ), "DoublyRobustWithShrinkage (lambda=0) should be the same as DirectMethod"
     assert (
-        np.abs(dr_value.item() - dr_shrink_max_value.item()) < 1e-5
+        np.abs(dr_value.item() - dr_os_max_value.item()) < 1e-5
     ), "DoublyRobustWithShrinkage (lambda=inf) should be almost the same as DoublyRobust"
 
 

--- a/tests/ope/test_ipw_estimators.py
+++ b/tests/ope/test_ipw_estimators.py
@@ -63,13 +63,6 @@ def test_ipw_init():
     with pytest.raises(TypeError, match="lambdas must be a list"):
         InverseProbabilityWeightingTuning(lambdas=None)
 
-    # max_reward_value
-    with pytest.raises(
-        TypeError,
-        match=r"`max_reward_value` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
-    ):
-        InverseProbabilityWeightingTuning(lambdas=[1, 100], max_reward_value="")
-
 
 # prepare ipw instances
 ipw = InverseProbabilityWeighting()

--- a/tests/ope/test_ipw_estimators.py
+++ b/tests/ope/test_ipw_estimators.py
@@ -47,21 +47,28 @@ def test_ipw_init():
         InverseProbabilityWeightingTuning(lambdas=[""])
 
     with pytest.raises(
-        ValueError, match=r"`an element of lambdas`= -1.0, must be >= 0.0."
+        ValueError, match="`an element of lambdas`= -1.0, must be >= 0.0."
     ):
         InverseProbabilityWeightingTuning(lambdas=[-1.0])
 
-    with pytest.raises(ValueError, match=r"an element of lambdas must not be nan"):
+    with pytest.raises(ValueError, match="an element of lambdas must not be nan"):
         InverseProbabilityWeightingTuning(lambdas=[np.nan])
 
-    with pytest.raises(ValueError, match=r"lambdas must not be empty"):
+    with pytest.raises(ValueError, match="lambdas must not be empty"):
         InverseProbabilityWeightingTuning(lambdas=[])
 
-    with pytest.raises(TypeError, match=r"lambdas must be a list"):
+    with pytest.raises(TypeError, match="lambdas must be a list"):
         InverseProbabilityWeightingTuning(lambdas="")
 
-    with pytest.raises(TypeError, match=r"lambdas must be a list"):
+    with pytest.raises(TypeError, match="lambdas must be a list"):
         InverseProbabilityWeightingTuning(lambdas=None)
+
+    # max_reward_value
+    with pytest.raises(
+        TypeError,
+        match=r"`max_reward_value` must be an instance of \(<class 'int'>, <class 'float'>\), not <class 'str'>.",
+    ):
+        InverseProbabilityWeightingTuning(lambdas=[1, 100], max_reward_value="")
 
 
 # prepare ipw instances
@@ -404,14 +411,6 @@ def test_ipw_using_invalid_input_tensor_data(
         )
     with pytest.raises(ValueError, match=f"{description}*"):
         _ = snipw.estimate_policy_value_tensor(
-            action_dist=action_dist,
-            action=action,
-            reward=reward,
-            pscore=pscore,
-            position=position,
-        )
-    with pytest.raises(ValueError, match=f"{description}*"):
-        _ = ipw_tuning.estimate_policy_value_tensor(
             action_dist=action_dist,
             action=action,
             reward=reward,

--- a/tests/ope/test_meta.py
+++ b/tests/ope/test_meta.py
@@ -44,18 +44,18 @@ class DirectMethodMock(BaseOffPolicyEstimator):
         estimated_rewards_by_reg_model: np.ndarray,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ----------
         position: array-like, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -70,19 +70,19 @@ class DirectMethodMock(BaseOffPolicyEstimator):
         estimated_rewards_by_reg_model: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        """Estimate policy value of an evaluation policy and return PyTorch Tensor.
+        """Estimate the policy value of evaluation policy and return PyTorch Tensor.
         This is intended for being used with NNPolicyLearner.
 
         Parameters
         ----------
         position: Tensor, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         action_dist: Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: Tensor, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         Returns
         ----------
@@ -105,16 +105,16 @@ class DirectMethodMock(BaseOffPolicyEstimator):
         Parameters
         ----------
         position: array-like, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         estimated_rewards_by_reg_model: array-like, shape (n_rounds, n_actions, len_list)
-            Expected rewards for each round, action, and position estimated by a regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
+            Expected rewards given context, action, and position estimated by regression model, i.e., :math:`\\hat{q}(x_t,a_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.
@@ -160,7 +160,7 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
         action_dist: np.ndarray,
         **kwargs,
     ) -> np.ndarray:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Parameters
         ----------
@@ -168,16 +168,16 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         Returns
         ----------
@@ -195,7 +195,7 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
         action_dist: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        """Estimate policy value of an evaluation policy and return PyTorch Tensor.
+        """Estimate the policy value of evaluation policy and return PyTorch Tensor.
         This is intended for being used with NNPolicyLearner.
 
         Parameters
@@ -204,16 +204,16 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: Tensor, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: Tensor, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         pscore: Tensor, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: Tensor, shape (n_rounds, n_actions, len_list)
-            Action choice probabilities by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
+            Action choice probabilities of evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         Returns
         ----------
@@ -242,20 +242,20 @@ class InverseProbabilityWeightingMock(BaseOffPolicyEstimator):
             Reward observed in each round of the logged bandit feedback, i.e., :math:`r_t`.
 
         action: array-like, shape (n_rounds,)
-            Action sampled by a behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
+            Action sampled by behavior policy in each round of the logged bandit feedback, i.e., :math:`a_t`.
 
         position: array-like, shape (n_rounds,)
-            Positions of each round in the given logged bandit feedback.
+            Position of recommendation interface where action was presented in each round of the given logged bandit feedback.
 
         pscore: array-like, shape (n_rounds,)
-            Action choice probabilities by a behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
+            Action choice probabilities of behavior policy (propensity scores), i.e., :math:`\\pi_b(a_t|x_t)`.
 
         action_dist: array-like, shape (n_rounds, n_actions, len_list)
             Action choice probabilities
             by the evaluation policy (can be deterministic), i.e., :math:`\\pi_e(a_t|x_t)`.
 
         alpha: float, default=0.05
-            Significant level of confidence intervals.
+            Significance level.
 
         n_bootstrap_samples: int, default=10000
             Number of resampling performed in the bootstrap procedure.

--- a/tests/ope/test_meta_slate.py
+++ b/tests/ope/test_meta_slate.py
@@ -43,7 +43,7 @@ class SlateStandardIPSMock(SlateStandardIPS):
         evaluation_policy_pscore: np.ndarray,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Returns
         ----------
@@ -95,7 +95,7 @@ class SlateIndependentIPSMock(SlateIndependentIPS):
         evaluation_policy_pscore_item_position: np.ndarray,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Returns
         ----------
@@ -147,7 +147,7 @@ class SlateRewardInteractionIPSMock(SlateRewardInteractionIPS):
         evaluation_policy_pscore_cascade: np.ndarray,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy.
+        """Estimate the policy value of evaluation policy.
 
         Returns
         ----------

--- a/tests/ope/test_offline_estimation_performance.py
+++ b/tests/ope/test_offline_estimation_performance.py
@@ -135,17 +135,23 @@ ope_estimators = [
     RandomOffPolicyEstimator(),
     DirectMethod(),
     InverseProbabilityWeighting(),
-    InverseProbabilityWeightingTuning(lambdas=[1, 100], estimator_name="ipw (tuning)"),
+    InverseProbabilityWeightingTuning(
+        lambdas=[100, 1000, np.inf], estimator_name="ipw (tuning)"
+    ),
     SelfNormalizedInverseProbabilityWeighting(),
     DoublyRobust(),
-    DoublyRobustTuning(lambdas=[1, 100], estimator_name="dr (tuning)"),
+    DoublyRobustTuning(lambdas=[100, 1000, np.inf], estimator_name="dr (tuning)"),
     SelfNormalizedDoublyRobust(),
     SwitchDoublyRobust(tau=1.0, estimator_name="switch-dr (tau=1)"),
     SwitchDoublyRobust(tau=100.0, estimator_name="switch-dr (tau=100)"),
-    SwitchDoublyRobustTuning(taus=[1, 100], estimator_name="switch-dr (tuning)"),
+    SwitchDoublyRobustTuning(
+        taus=[100, 1000, np.inf], estimator_name="switch-dr (tuning)"
+    ),
     DoublyRobustWithShrinkage(lambda_=1.0, estimator_name="dr-os (lambda=1)"),
     DoublyRobustWithShrinkage(lambda_=100.0, estimator_name="dr-os (lambda=100)"),
-    DoublyRobustWithShrinkageTuning(lambdas=[1, 100], estimator_name="dr-os (tuning)"),
+    DoublyRobustWithShrinkageTuning(
+        lambdas=[100, 1000, np.inf], estimator_name="dr-os (tuning)"
+    ),
 ]
 
 
@@ -238,10 +244,14 @@ def test_offline_estimation_performance(
 
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["dm"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["ipw"]
+    assert relative_ee_df_mean["random"] > relative_ee_df_mean["ipw (tuning)"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["snipw"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["dr"]
+    assert relative_ee_df_mean["random"] > relative_ee_df_mean["dr (tuning)"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["sndr"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["switch-dr (tau=1)"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["switch-dr (tau=100)"]
+    assert relative_ee_df_mean["random"] > relative_ee_df_mean["switch-dr (tuning)"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["dr-os (lambda=1)"]
     assert relative_ee_df_mean["random"] > relative_ee_df_mean["dr-os (lambda=100)"]
+    assert relative_ee_df_mean["random"] > relative_ee_df_mean["dr-os (tuning)"]

--- a/tests/ope/test_offline_estimation_performance.py
+++ b/tests/ope/test_offline_estimation_performance.py
@@ -34,7 +34,7 @@ from obp.ope import (
 )
 
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 hyperparams = {
     "lightgbm": {
         "max_iter": 500,
@@ -120,7 +120,7 @@ class RandomOffPolicyEstimator(BaseOffPolicyEstimator):
         action_dist: np.ndarray,
         **kwargs,
     ) -> float:
-        """Estimate policy value of an evaluation policy."""
+        """Estimate the policy value of evaluation policy."""
         return self._estimate_round_rewards(action_dist=action_dist).mean()
 
     def estimate_policy_value_tensor(self, **kwargs) -> torch.Tensor:

--- a/tests/ope/test_offline_estimation_performance.py
+++ b/tests/ope/test_offline_estimation_performance.py
@@ -21,12 +21,16 @@ from obp.ope import (
     RegressionModel,
     OffPolicyEvaluation,
     InverseProbabilityWeighting,
+    InverseProbabilityWeightingTuning,
     SelfNormalizedInverseProbabilityWeighting,
     DirectMethod,
     DoublyRobust,
+    DoublyRobustTuning,
     SelfNormalizedDoublyRobust,
     SwitchDoublyRobust,
+    SwitchDoublyRobustTuning,
     DoublyRobustWithShrinkage,
+    DoublyRobustWithShrinkageTuning,
 )
 
 
@@ -131,13 +135,17 @@ ope_estimators = [
     RandomOffPolicyEstimator(),
     DirectMethod(),
     InverseProbabilityWeighting(),
+    InverseProbabilityWeightingTuning(lambdas=[1, 100], estimator_name="ipw (tuning)"),
     SelfNormalizedInverseProbabilityWeighting(),
     DoublyRobust(),
+    DoublyRobustTuning(lambdas=[1, 100], estimator_name="dr (tuning)"),
     SelfNormalizedDoublyRobust(),
     SwitchDoublyRobust(tau=1.0, estimator_name="switch-dr (tau=1)"),
     SwitchDoublyRobust(tau=100.0, estimator_name="switch-dr (tau=100)"),
+    SwitchDoublyRobustTuning(taus=[1, 100], estimator_name="switch-dr (tuning)"),
     DoublyRobustWithShrinkage(lambda_=1.0, estimator_name="dr-os (lambda=1)"),
     DoublyRobustWithShrinkage(lambda_=100.0, estimator_name="dr-os (lambda=100)"),
+    DoublyRobustWithShrinkageTuning(lambdas=[1, 100], estimator_name="dr-os (tuning)"),
 ]
 
 

--- a/tests/ope/test_regression_models.py
+++ b/tests/ope/test_regression_models.py
@@ -95,7 +95,6 @@ invalid_input_of_initializing_regression_models = [
 
 
 # context, action, reward, pscore, position, action_context, n_actions, len_list, fitting_method, base_model, action_dist, description
-
 invalid_input_of_fitting_regression_models = [
     (
         None,  #

--- a/tests/policy/test_offline_learner_performance.py
+++ b/tests/policy/test_offline_learner_performance.py
@@ -20,7 +20,7 @@ from obp.policy import IPWLearner, NNPolicyLearner
 from obp.ope import DoublyRobust, RegressionModel
 
 
-# hyperparameter for the regression model used in model dependent OPE estimators
+# hyperparameters of the regression model used in model dependent OPE estimators
 hyperparams = {
     "lightgbm": {
         "max_iter": 500,


### PR DESCRIPTION
## new feature

#### [estimators_tuning.py](https://github.com/st-tech/zr-obp/blob/add-automatic-hyperparam-selection/obp/ope/estimators_tuning.py)

- implement the following four new estimator classes
    - [`InverseProbabilityWeightingTuning`](https://github.com/st-tech/zr-obp/blob/df8517000ab794f0860147b731d5b197a252d830/obp/ope/estimators_tuning.py#L24)
    - [`DoublyRobustTuning`](https://github.com/st-tech/zr-obp/blob/df8517000ab794f0860147b731d5b197a252d830/obp/ope/estimators_tuning.py#L246)
    - [`SwitchDoublyRobustTuning`](https://github.com/st-tech/zr-obp/blob/df8517000ab794f0860147b731d5b197a252d830/obp/ope/estimators_tuning.py#L484)
    - [`DoublyRobustWithShrinkageTuning`](https://github.com/st-tech/zr-obp/blob/df8517000ab794f0860147b731d5b197a252d830/obp/ope/estimators_tuning.py#L722)

These classes have automatic hyperparameter tuning method that can identify an appropriate value of hyperparameter using only log data (clipping hyperparameter for IPW and DR, shrinkage hyperparameter for DRos, switching hyperparameter for Switch-DR). They work as follows.

```python
# define an estimator class
>>> dr_os_tuning = DoublyRobustWithShrinkageTuning(
        lambdas=[1, 5, 10, 10000], # a set of candidate values of the estimator's hyperparam
    )

# estimate the policy value of \pi_e
# the estimator class automatically selects the best hyperparameter and uses it in OPE
>>> dr_os_tuning.estimate_policy_value(
        reward=bandit_feedback["reward"],
        action=bandit_feedback["action"],
        pscore=bandit_feedback["pscore"],
        action_dist=action_dist,
        estimated_rewards_by_reg_model=estimated_rewards_by_reg_model,
    )
0.5332493472941252

# the best value of the hyperparam used in OPE
>>> dr_os_tuning.best_lambda_
10000

# the scores of the hyperparameter values (lower value is better)
>>> dr_os_tuning.estimated_mse_upper_bound_dict
{1: 0.3439450731440607,
 5: 0.11020296532475063,
 10: 0.05567332432526242,
 10000: 0.0011261403289179813} # (has the lowest score and thus is chosen)
```

You can see that `dr_os_tuning` chooses `lambda_=10000` from the candidate set and uses it in the estimation. 
The best hyperparameter is determined by `estimated_mse_upper_bound`.

#### [estimators.py ](https://github.com/st-tech/zr-obp/blob/add-automatic-hyperparam-selection/obp/ope/estimators.py)

How do the estimators calculate the score of candidate hyperparameter values? 
They estimate the upper bound of MSE in the policy value estimation for the hyperparameter tuning. 
Specifically, they estimate the upper bound of MSE as follows.

![texclip20210710005945](https://user-images.githubusercontent.com/32621707/125106045-21f47400-e11a-11eb-931b-bfd6df7c6ea4.png)

where BiasUB stands for Bias Upper Bound. `\theta` is a candidate hyperparameter value. 
In the above MSE upper bound, variance can be estimated from the log bandit data. 
Then, the current implementation uses the following bias upper bound.

![texclip20210710155150](https://user-images.githubusercontent.com/32621707/125154774-c1efe300-e196-11eb-98a6-603c1214c064.png)

where `\hat{q}(x,a)` is a reward estimator and `w(x,a)` is the true importance weight.

Note that `\hat{w}(x,a)` depends on the estimator as follows.
    - IPW and DR: `\hat{w}(x,a) = \min { \lambda_, w(x,a) }` (clipping)
    - DRos: `\hat{w}(x,a)= \lambda w(x,a) / (\lambda + w^2(x,a))` (optimistic shrinkage)
    - Switch-DR: `\hat{w}(x,a)= w(x,a) \mathbb{I} {w(x,a) < \tau }` (switching)
   
Moreover, the current implementation uses `\delta=0.05` to calculate the bias upper bound.

The following new functions calculate the MSE upper bound.
    - [`_estimate_mse_upper_bound` (in IPW)](https://github.com/st-tech/zr-obp/blob/df8517000ab794f0860147b731d5b197a252d830/obp/ope/estimators.py#L543)
    - [`_estimate_mse_upper_bound` (in DR)](https://github.com/st-tech/zr-obp/blob/df8517000ab794f0860147b731d5b197a252d830/obp/ope/estimators.py#L1279)
    - [`_estimate_mse_upper_bound` (in Switch-DR)](https://github.com/st-tech/zr-obp/blob/df8517000ab794f0860147b731d5b197a252d830/obp/ope/estimators.py#L1577)
    - [`_estimate_mse_upper_bound` (in DRos)](https://github.com/st-tech/zr-obp/blob/df8517000ab794f0860147b731d5b197a252d830/obp/ope/estimators.py#L1777)


The above automatic hyperparameter tuning procedure is based on Section 5 of Su et al.(2020). 
Su et al.(2020) describes several ways to derive bias upper bound.
The above bias upper bound corresponds to the direct bias estimation stated in page 17 of the paper.

**reference**
Yi Su, Maria Dimakopoulou, Akshay Krishnamurthy, and Miroslav Dudik.
"[Doubly Robust Off-Policy Evaluation with Shrinkage](https://arxiv.org/pdf/1907.09623.pdf).", 2020.
