### PR TITLE
fix a slate example notebook

### DIFF
--- a/examples/quickstart/synthetic_slate.ipynb
+++ b/examples/quickstart/synthetic_slate.ipynb
@@ -33,7 +33,6 @@
     "from obp.ope import SlateStandardIPS, SlateIndependentIPS, SlateRewardInteractionIPS, SlateOffPolicyEvaluation\n",
     "from obp.dataset import (\n",
     "    logistic_reward_function,\n",
-    "    linear_behavior_policy_logit,\n",
     "    SyntheticSlateBanditDataset,\n",
     ")"
    ]
@@ -77,6 +76,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -91,64 +107,18 @@
     "- reward structure (`reward_structure`)\n",
     "- click model (`click_model`)\n",
     "- base reward function (`base_reward_function`)\n",
-    "- behavior policy (`behavior_policy_function`) "
+    "- behavior policy (`behavior_policy_function`)\n",
+    "\n",
+    "We use a uniform random policy as a behavior policy here."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:16<00:00, 61.69it/s]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'n_rounds': 1000,\n",
-       " 'n_unique_action': 10,\n",
-       " 'slate_id': array([  0,   0,   0, ..., 999, 999, 999]),\n",
-       " 'context': array([[-0.20470766,  0.47894334],\n",
-       "        [-0.51943872, -0.5557303 ],\n",
-       "        [ 1.96578057,  1.39340583],\n",
-       "        ...,\n",
-       "        [ 1.26953635, -1.3414933 ],\n",
-       "        [-0.29333288, -0.2424589 ],\n",
-       "        [-3.05698974,  1.91840302]]),\n",
-       " 'action_context': array([[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "        [0, 1, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       "        [0, 0, 1, 0, 0, 0, 0, 0, 0, 0],\n",
-       "        [0, 0, 0, 1, 0, 0, 0, 0, 0, 0],\n",
-       "        [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],\n",
-       "        [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],\n",
-       "        [0, 0, 0, 0, 0, 0, 1, 0, 0, 0],\n",
-       "        [0, 0, 0, 0, 0, 0, 0, 1, 0, 0],\n",
-       "        [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],\n",
-       "        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1]]),\n",
-       " 'action': array([7, 4, 2, ..., 1, 9, 2]),\n",
-       " 'position': array([0, 1, 2, ..., 0, 1, 2]),\n",
-       " 'reward': array([1, 0, 0, ..., 1, 0, 0]),\n",
-       " 'expected_reward_factual': array([9.99929232e-01, 8.15725154e-04, 6.53987540e-01, ...,\n",
-       "        9.99998964e-01, 1.22999808e-01, 4.68682096e-01]),\n",
-       " 'pscore_cascade': array([0.09951976, 0.01501018, 0.00179284, ..., 0.06351948, 0.00918261,\n",
-       "        0.0010469 ]),\n",
-       " 'pscore': array([0.00179284, 0.00179284, 0.00179284, ..., 0.0010469 , 0.0010469 ,\n",
-       "        0.0010469 ]),\n",
-       " 'pscore_item_position': array([0.09951976, 0.13060096, 0.09483066, ..., 0.06351948, 0.1302615 ,\n",
-       "        0.09483066])}"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# generate a synthetic bandit dataset with 10 actions\n",
     "# we use `logistic_reward_function` as the reward function and `linear_behavior_policy_logit` as the behavior policy.\n",
@@ -161,46 +131,36 @@
     "reward_structure=\"cascade_additive\"\n",
     "click_model=None\n",
     "random_state=12345\n",
-    "behavior_policy_function=linear_behavior_policy_logit\n",
     "base_reward_function=logistic_reward_function\n",
     "\n",
-    "dataset = SyntheticSlateBanditDataset(\n",
-    "    n_unique_action=n_unique_action,\n",
-    "    len_list=len_list,\n",
-    "    dim_context=dim_context,\n",
-    "    reward_type=reward_type, # 'binary' or 'continuous'\n",
-    "    reward_structure=reward_structure, # 'cascade_additive', 'cascade_exponential', 'independent', 'standard_additive', or 'standard_exponential'\n",
-    "    click_model=click_model, # None, 'pbm', or 'cascade'\n",
-    "    random_state=random_state,\n",
-    "    behavior_policy_function=behavior_policy_function,\n",
-    "    base_reward_function=base_reward_function,\n",
-    ")\n",
-    "# obtain training and test sets of synthetic logged bandit feedback\n",
-    "n_rounds_test = 1000\n",
-    "bandit_feedback_test = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds_test, return_pscore_item_position=True)\n",
-    "\n",
-    "# `bandit_feedback` is a dictionary storing synthetic logged bandit feedback\n",
-    "bandit_feedback_test"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## (2) Evaluation Policy Definition (Off-Policy Learning)\n",
-    " After generating synthetic data, we now define the evaluation policy."
+    "# obtain  test sets of synthetic logged bandit feedback\n",
+    "n_rounds_test = 10000"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 2953.13it/s]\n"
+      "[sample_action_and_obtain_pscore]: 100%|██████████| 10000/10000 [00:01<00:00, 6317.55it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.8366\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -222,6 +182,125 @@
     "random_behavior_feedback = random_behavior_dataset.obtain_batch_bandit_feedback(\n",
     "    n_rounds=n_rounds_test,\n",
     "    return_pscore_item_position=True,\n",
+    ")\n",
+    "\n",
+    "# print policy value\n",
+    "random_policy_value = random_behavior_dataset.calc_on_policy_policy_value(\n",
+    "    reward=random_behavior_feedback[\"reward\"],\n",
+    "    slate_id=random_behavior_feedback[\"slate_id\"],\n",
+    ")\n",
+    "print(random_policy_value)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (2) Evaluation Policy Definition (Off-Policy Learning)\n",
+    " After generating synthetic data, we now define the evaluation policy as follows:\n",
+    " \n",
+    "1. Generate logit values of three valuation policies (`random`, `optimal`, and `anti-optimal`).\n",
+    "  - A `optimal` policy is defined by a policy that samples actions using`3 * base_expected_reward`.\n",
+    "  - An `anti-optimal` policy is defined by a policy that samples actions using the sign inversion of `-3 * base_expected_reward`.\n",
+    "2. Obtain pscores of the evaluation policies by `obtain_pscore_given_evaluation_policy_logit` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "random_policy_logit_ = np.zeros((n_rounds_test, n_unique_action))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_expected_reward = random_behavior_dataset.base_reward_function(\n",
+    "    context=random_behavior_feedback[\"context\"],\n",
+    "    action_context=random_behavior_dataset.action_context,\n",
+    "    random_state=random_behavior_dataset.random_state,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimal_policy_logit_ = base_expected_reward * 3\n",
+    "anti_optimal_policy_logit_ = -3 * base_expected_reward"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[obtain_pscore_given_evaluation_policy_logit]: 100%|██████████| 10000/10000 [00:09<00:00, 1054.20it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "random_policy_pscores = random_behavior_dataset.obtain_pscore_given_evaluation_policy_logit(\n",
+    "    action=random_behavior_feedback[\"action\"],\n",
+    "    evaluation_policy_logit_=random_policy_logit_\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[obtain_pscore_given_evaluation_policy_logit]: 100%|██████████| 10000/10000 [00:09<00:00, 1019.17it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "optimal_policy_pscores = random_behavior_dataset.obtain_pscore_given_evaluation_policy_logit(\n",
+    "    action=random_behavior_feedback[\"action\"],\n",
+    "    evaluation_policy_logit_=optimal_policy_logit_\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[obtain_pscore_given_evaluation_policy_logit]: 100%|██████████| 10000/10000 [00:09<00:00, 1003.37it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "anti_optimal_policy_pscores = random_behavior_dataset.obtain_pscore_given_evaluation_policy_logit(\n",
+    "    action=random_behavior_feedback[\"action\"],\n",
+    "    evaluation_policy_logit_=anti_optimal_policy_logit_\n",
     ")"
    ]
   },
@@ -237,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 14,
    "metadata": {
     "tags": []
    },
@@ -251,69 +330,105 @@
     "rips = SlateRewardInteractionIPS(len_list=len_list)\n",
     "\n",
     "ope = SlateOffPolicyEvaluation(\n",
-    "    bandit_feedback=bandit_feedback_test,\n",
+    "    bandit_feedback=random_behavior_feedback,\n",
     "    ope_estimators=[sips, iips, rips]\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "          mean  95.0% CI (lower)  95.0% CI (upper)\n",
-      "sips  1.816407          1.751910          1.881746\n",
-      "iips  1.862276          1.818792          1.899305\n",
-      "rips  1.830078          1.779988          1.886216 \n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgwAAAGSCAYAAACPApmhAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABVhklEQVR4nO3deVhTV/4/8HdYwhJkCYgLaEEWEVAWd7BqFZe6W7faqXXrTF07rVqnX7uodTrFWrXWrWOro3ZsRdDWpbUqWtwoiBpFAcUNFBAQZYcAQn5/+CNjhCQ3EgjC+/U88zzm3HPv/WTmTvLm5txzRAqFQgEiIiIiDYwMXQARERE1fgwMREREpBUDAxEREWnFwEBERERaMTAQERGRVgwMREREpBUDAxEREWnFwEBERERaMTAQERGRViZCO2ZkZODKlStISkpCTk4OCgsLIRaLYW1tDRcXF/j4+MDX1xdisbg+6yUiIiIDEGmbGvrs2bM4evQorl27pvVgEokE/fv3x9ChQ+Ho6Ki3IomIiMiw1AaGq1evYufOnUhNTYWlpSW6d+8OLy8vuLm5wdbWFlZWVigvL0dhYSEyMjKQnJyM+Ph43LhxAyYmJnj11Vfx2muvwdLSsqHfExEREemZ2sAwadIkuLq6YvTo0ejWrRtMTU0FHfD+/fs4duwYjh07htGjR2P8+PF6LZiIiIgantrAcO7cOfTo0eO5D5yXl4fs7Gx4eno+9zGIiIiocdA6hoGIiIhI8FMS9eHPP//EqVOncPv2bZSUlKBt27YYOXIk+vTpo3G/iooK/PTTTzh16hTKysrg7e2NmTNn1hhoee3aNeU4DFtbWwwfPhzDhg3TqcaMjAyd3xcREdGLqG3btmq3GTQwHDp0CI6Ojpg6dSqsra1x8eJFfPPNNygsLMSrr76qdr///Oc/iImJUe4XHh6Of/7zn/jqq6+Uj3VmZmbi888/R9euXfHGG2/g5s2b2LlzJ8zMzDBw4MCGeotERERNgsbAMG/ePJ0PKBKJsH79ekF9//GPf8Da2lr52tfXF7m5uTh06JDawPDw4UOcOHECs2fPRr9+/QAAL730EubOnYvTp08rw8CBAwcglUoxf/58GBsbw9fXFzk5OYiIiMCAAQMgEol0fm9ERETNlcbA8ODBg3o9+dNhoZqrqytiY2PV7nP58mUAQM+ePZVtUqkUXl5ekMlkysAgk8nQp08fGBsbK/sFBQXh6NGjuHfvHtq3b6+vt0FERNTkaQwMGzZsaKg6lJKTk9GmTRu12zMyMmBvbw9zc3OVdicnJyQmJgIA5HI5Hj58CCcnJ5U+zs7OAID09HQGBiIiIh1oDAwtW7ZsqDoAAFeuXEFcXBxmz56ttk9RUVGtk0FZWVmhuLgYAFBSUgIANfpJJBIAUPYjIiIiYQw66PFp2dnZ+Oabb9CtWzf079/fYHVERkYiMjISABAaGgoHBweD1UJERNRYaAwMVVVV+PrrryESiTB//nyYmNTe/fHjx1i/fj1EIhHee+89nYsoKirCF198AQcHB7z77rsa+1pZWSnvIDx7jOo7CNV3Fp7tV31nobpfbUJCQhASEqJ8nZOTI+xNEBERveA0PVapcXnr2NhYxMbGolu3bmrDAgCYmJige/fu+PPPPxETE6NTcWVlZQgNDcXjx4/x4YcfwszMTGP/tm3b4uHDh5DL5SrtGRkZyjdqbm4Oe3v7GnMopKenA0CNsQ1ERESkmcbA8Oeff0IqlWqdSAkAgoODIZVKcebMGcEnr6ysxJo1a3D//n0sWbIENjY2Wvfx8/MD8GTq6mqPHj1CUlISAgIClG0BAQE4d+4cqqqqlG3R0dGwt7dHu3btBNdIREREWn6SuHXrFnx8fATNWSASieDr64uEhATBJ//+++8hk8kwbdo0FBYWorCwULnN1dUVpqam+OyzzwAAn376KQDA3t4eAwYMwI4dOwBAOXFTy5Yt8fLLLyv3HzVqFE6fPo3169dj4MCBuHXrFiIjI/H2229zDgYiIiIdaQwMeXl5sLe3F3wwqVSK/Px8wf3j4+MBANu3b6+xbcOGDXB0dFS5Q1Bt+vTpMDMzw44dO1BeXg5vb2/8/e9/V87yCACtW7fGRx99hB07duCLL76Ara0tpkyZwlkeiYiInoPGxaemTp2KgQMH4q233hJ0sJ07d+L48ePKv/6bAq4lQUREzcVzD3q0s7NDamqq4BOlpqbCzs5OeGVERET0QtAYGDp27IjExERkZmZqPVBmZiYSExPh5eWlt+LoxTN+/HiMHz/e0GUQEZGeaQwMgwYNQlVVFdasWaNxbEJBQQHWrl2LqqoqlTkMiIh0xdBJ1DhpHPTo7u6OkJAQREZGYsGCBRg0aBB8fX0hlUoBPHmc8erVq4iMjERhYSEGDRoEd3f3BimciIioNtWBMyIiwsCVNC1ap4aeMWMGqqqqcOLECfz888/4+eefa+03cOBAzJgxQ+8FEhERkeFpDQzGxsZ455130L9/fxw7dgzXr19HXl4eAMDW1hZeXl4ICQlBx44d67tWIiIiMhDBi0917NiRoYCIiKiZ0jjokYiIiAhgYCAiIiIBGBiIiIhIKwYGIiIi0oqBgYiIiLRiYCCiRmPfvn24cOEC/vzzT/To0QP79u0zdElE9P8xMBBRo7Bv3z4sXrwY5eXlAID09HQsXryYoYGokahTYMjOzsbFixdx8eJFZGdn66smImqGQkNDUVpaqtJWWlqK0NBQA1VERE8TPHHT00pLS/Htt98iJiZGpb13796YNWsWzM3N9VIcEamatuNPQ5dQb9LTM9S2N9X3vX1qb0OXQCTYcwWGrVu3Ij4+HhMnTkSHDh1QUVGB8+fP4+TJkzAzM8Ps2bP1XScRNXHmtvaQ5+XU2k5EhqfxJ4mysrJa2+Pi4jBjxgyMGzcOAQEB6NGjB+bMmYNevXrh3Llz9VIoETVt7oPegJGpWKXNyFQM90FvGKgiehFx4Gz90RgYFi1ahKtXr9Zor6yshIWFRY12CwsLVFVV6a86Imo22gT0hfeYWTAyfnLj09zWAd5jZqFNQF8DV0YvCg6crV8aA4OHhwdWrFiBLVu2qAxG8vX1xdatW3HmzBmkp6cjJSUFe/fuxcmTJ9G5c+d6L5oaJyZ7qqs2AX1h094Tdq7eeHnxtwwLpBMOnK1fGscwvPvuu+jTpw++++47yGQy/O1vf0NAQADefvttrFq1CuvXr1fp36FDB8yYMaNeC6bGSV2yB4DXXnvNkKUR0VOOHLhv6BLqjaaBs031fQ8Z1abBzqV10GNgYCBWr16NnTt3IjQ0FC+//DKmTZuGlStXIj4+Hunp6QAAZ2dn3l1oxjQlewYGImoI9tJWePgos9Z2qjtBT0lYWlpi1qxZCAoKwpYtW7Bw4ULMnDkTPXr0QJcuXeq7xibj/gdvG7qEepPx/4Njbe1N9X23WfW9oUsgoqe8Nnouduz6HOXlcmWbWGyO10bPNWBVTYdOEzd16dIFX331FXr06IHVq1dj7dq1KCgoqK/a6AXSyrL2uTfUtRMR6VvvHq9i6l8+gomJKQDAXtoaU//yEXr3eNXAlTUNggJDQUEBbt++jYKCApibm2PmzJlYtmwZUlJS8P777+PMmTP1XSc1cnP9PGFurHo5mRsbYa6fp4EqIqLmqHePV+Hm2hkdPQKx6vNDDAt6pPEnCblcjs2bN6vM6NizZ0/MmTMHnTp1wqpVq7B7925s3LgR0dHR+Nvf/gZbW9v6rpkaoVddnQAAn8VeRUVVFVpbmmOun6eynYiIXmwaA8OPP/6ImJgY9OvXD+7u7rh16xaioqJgY2ODmTNnQiwW46233kJQUBA2bdqE999/H2+99RZeeeWVhqqfGpFXXZ3w8600AMCWkJ4GroaIiPRJY2CIi4tT3lGoVlpaivPnz2PmzJnKNnd3d3z55ZeIiIjAd999p1NgyMzMxIEDB5CcnIx79+6hU6dOWLZsmcZ99uzZg4iIiFq3TZ48GWPHjgUAbNy4ESdPnqzRZ+3atXBy4l++RI1Rt79+ZugSiKgWGgNDWVkZ7O1V53G3t7evdfZHExMTvP766+jVq5dOBdy7dw8ymQweHh6orKwUtM/AgQPh7++v0hYXF4f9+/cjICBApd3JyanG2hYtW7bUqUYiIqLmTmNg8PDwwKlTp9CzZ0+4u7vj9u3bOH36NDw8PNTu4+LiolMBXbt2Rffu3QEAq1evRmFhodZ97O3tawSZvXv3wsnJqcb5zczM4OnJgXdERER1oTEwTJ8+HcuXL8fSpUuVbVKpFNOmTdNbAUZGOj3ZWavCwkLEx8dj3LhxeqiIiIiInqUxMLRu3Rpff/01Lly4gJycHDg4OCAwMBDm5o3r2frY2FhUVlYiODi4xra0tDRMnToVFRUVcHNzw+TJk+Ht7W2AKomIiF5cWmd6NDMzQ1BQUEPU8tzOnj0LV1dXtGmjOqe2q6srPDw84OzsjIKCAhw8eBArVqzAihUr4O7uXuuxIiMjERkZCeDJdMcODg56q7NpzmTefOnz2qDmyTDXED+JmpKGvIYETQ3dmOXm5iIxMRF/+ctfamwbNmyYyuuAgAAsWLBAuVBSbUJCQhASEqJ8nZOTo9+CqcngtUF1xWuI6krf11Dbtm3VbnvuwHD+/HkkJSWhrKwMjo6OCAoKMkha/vPPPwFA0F0QMzMzBAQE4MKFC/VdFhERUZOideKmLl26wNfXV9lWXFyML7/8EteuXVPpGxYWhnfeeQd9+zbs+vVnz56Fl5eX4LAiEokgEonquSoiIqKmReMjCvv3768RDP7973/j2rVrcHR0xNixYzF16lT07t0bjx8/xrfffou7d+/Wa8FPy87Oxo0bN2od7Fib8vJyXLx4ER06dKjnyoiIiJoWnX6SyMzMRGxsLFxdXbF06VJYWFgAeDJWIDAwEBs3bsRvv/2GWbNmCT5mWVkZZDIZAODRo0coLS1Vrl0REBAAMzMzzJ8/H97e3jUmYIqOjoaxsXGtk0WVlJQgNDQUL7/8Mlq3bo3CwkL8+uuvyM3NxYIFC3R520RE9AL5x4Ithi6hSdIpMCQlJQF4Mv1ydVio1rdvXxw5cgSJiYk6FZCfn481a9aotFW/3rBhAxwdHVFVVYWqqqoa+549exa+vr6wtrausc3ExATW1tbYt28f8vPzYWpqCk9PTyxbtgxubm461UhERNTc6RQY8vLyAEDtF66bmxtOnDihUwGOjo7Ys2ePxj4bN26stX3VqlVq9xGLxVi0aJFOtRAREVHtdJpmsfqugqmpaa3bTU1NOaCQiIioCdJ6hyEhIUH578zMTADAgwcP4OzsXKPvw4cP0aJFCz2WR0RERI2B1sCQmJhYY1zCxYsXaw0Mt2/f5rLRRERETZDGwPD0olNPq22Q4e3bt1FZWYnOnTvrpzJ6IW0J6WnoEoiIqB5oDAy6LNLUoUMHtYMTiYiI6MVW97WliYiIqMnT6bHKyspKZGVlobi4GCKRCDY2NmjZsmV91UZERESNhKDAcO7cORw5cgRJSUmorKxU2WZtbY3g4GCMGTMGtra29VEjERERGZjGwKBQKLBp0yacOnWqxjYHBweYm5sjMzMThw8fxunTp/HBBx/Ay8ur3oolIiIiw9AYGCIjI3Hq1CkEBgZi0qRJaNWqFbKysrBnzx5cv34dH330EVq2bImzZ8/ihx9+wMqVK7F69WpIpdKGqp+IiIgagMZBjydOnICzszMWLVoEFxcXWFhYwMXFBQsXLoStrS1+/PFHmJqaon///vjkk08gl8vxyy+/NFDpRERE1FA0Boa0tDR07twZxsbGKu3Gxsbo3LmzyiyQLi4uCAwMVK48SURERE2HxsAgEolQXl5e67by8nJUVFSotDk5OeHRo0f6q46IiIgaBY2BoV27djh//jyKiopU2ouKinD+/Hm0adNGpV0ul0MsFuu/SiIiIjIojYMeX3nlFXz33XdYsmQJRowYAUdHR2RnZ+PXX39Ffn4+RowYodL/3r17aN26db0WTERERA1PY2AICQlBYmIizp49i61bt6ps8/f3VwkMpaWlKC8vR1BQUP1USkRERAajdeKmd999F7169cK5c+eQn5+PFi1aIDAwEEFBQTAy+t8vGhYWFvj888/rtVgiIiIyDEEzPfbo0QM9evSo71qIiIiokeLiU0RERKQVAwMRERFpxcBAREREWjEwEBERkVYMDERERKQVAwMRERFpxcBAREREWjEwEBERkVY6B4bExERERETovI2IiIheXIJmenxaQkICIiIiMH78eJ22qZOZmYkDBw4gOTkZ9+7dQ6dOnbBs2TKN+2RnZ2PevHk12oOCgvDee++ptMXFxWH37t3IzMyEo6MjJkyYwPUuiIiIdKRzYNC3e/fuQSaTwcPDA5WVlTrtO2XKFHTs2FH52traWmX7tWvXsHr1agwePBjTp0+HTCbDunXrIJFI4Ofnp5f6iYiImgODB4auXbuie/fuAIDVq1ejsLBQ8L5t27aFp6en2u179+5Fp06dMGPGDACAr68v0tLSEBERwcBARESkA4MPenx6xUt9qqiowNWrV9G7d2+V9qCgICQnJ6OkpKRezktERNQUCbrDkJOTo/x3cXFxjTYAcHBw0GNZwmzatAlFRUWwsbFBcHAwJk+eDLFYDADIyspCZWUlnJycVPZxcnKCQqFARkYG3N3dG7xmIiKiF5GgwDB37lyNbSKRCLt379ZfVVqYmppiyJAh8PPzg4WFBRISErB//35kZWVh8eLFAICioiIAgEQiUdnXysoKwP+Cz7MiIyMRGRkJAAgNDdVrELqvtyNRY2CIkExNi2GuIX4SNSUNeQ0JCgzjxo2DSCQC8OTRycTERJ2ehNA3Ozs7zJw5U/nax8cHtra2+P7775GSkgIXF5fnPnZISAhCQkKUr5+9k0JUjdcG1RWvIaorfV9Dbdu2VbtNUGCYOHGi8t/h4eFITEzEhAkT6l6ZHvXq1Qvff/89bt++DRcXF+WdhGfHKqi780BERETqGXzQo75V3wlp1aoVjI2NkZ6errI9IyMDIpFIY4oiIiIiVU0mMMTExAAAOnToAODJOAdfX19le7Xo6Gh4enrC0tKywWskIiJ6URl8HoaysjLIZDIAwKNHj1BaWqr8kg8ICICZmRnmz58Pb29vzJ49GwCwZ88eyOVydOzYERYWFkhKSsKBAwfQo0cPvPTSS8pjjxs3DsuWLcP27dvRvXt3yGQyyGQyLFmypOHfKBER0QtM58CgUCiea5s6+fn5WLNmjUpb9esNGzbA0dERVVVVqKqqUm53cnLCwYMHcfz4cZSXl8PBwQGjRo3Ca6+9pnIcLy8vLFiwAGFhYTh69CgcHR3x7rvvctImIiIiHYkUz/Mt34xkZGTo7Vj3P3hbb8ciw2uz6vsGP+e0HX82+Dmp/myf2lt7Jz07coCPVTYlQ0a10evxNI3vazJjGIiIiKj+MDAQERGRVmoDQ3l5eZ0Pro9jEBERkeGpDQxz587Fb7/9hoqKCp0PmpKSgi+//BIHDhyoU3FERETUOKh9SsLPzw87duxAeHg4goKC0Lt3b3h6eioXd3pWVlYWLl++jJMnT+LmzZvKJxeIiIjoxac2MMybNw9Dhw7F7t27lQsyGRkZwdnZGba2tpBIJKioqEBRUREyMjJQUFAAALC2tsbkyZMxfPhwmJqaNtgbISIiovqjcR4Gd3d3fPzxx7h//z5OnDiBq1evIiUlBXfv3lXpZ21tjZ49eyr/Y2Ji8PmgiIiISI8EfbO3adMGf/nLXwA8mZnx0aNHKCwshFgsho2NDezs7Oq1SCIiIjIsnW8FmJmZoU2bNmjTRr+TRRAREVHjxXkYiIiISCsGBiIiItKKgYGIiIi0YmAgIiIirRgYiIiISCsGBiIiItKKgYGIiIi00nkehsePH+Pq1atIS0uDXC7H+PHjATxZmbK0tBQtWrSAkRFzCBERUVOiU2C4dOkSNm/ejLy8PGVbdWBISUnBJ598gvnz56NPnz56LZKIiIgMS/CtgFu3bmHVqlUQiUSYOnUqgoODVbZ7enrC0dER586d03uRREREZFiCA8PevXshFosRGhqKYcOG1To1tJubG1JTU/VaIBERERme4MBw/fp1dO/eHba2tmr7ODg4qPxcQURERE2D4MAgl8thbW2tsU9ZWRmqqqrqXBQRERE1LoIDg1Qqxb179zT2SUlJQatWrepcFBERETUuggODv78/Ll++jGvXrtW6XSaTITk5GYGBgXorjoiIiBoHwY9Vjh07FtHR0fjnP/+JoUOH4sGDBwCAixcvIjExEUeOHIGtrS1GjBhRb8USERGRYQgODFKpFB999BHWrl2LgwcPKttXrlwJAGjVqhUWLVqkdZwDERERvXh0mripQ4cOWLduHS5evIjk5GQUFhbC0tISHh4e6N69O4yNjeurTiIiIjIgnaeGNjIyQrdu3dCtWze9FJCZmYkDBw4gOTkZ9+7dQ6dOnbBs2TKN+9y8eRNHjx5FUlIScnNzYW9vjz59+mD06NEQi8XKfnv27EFERESN/ZcsWQJ/f3+91E9ERNQc6BwY9O3evXuQyWTw8PBAZWWloH2io6ORlZWF0aNHo02bNkhNTUVYWBhSU1OxaNEilb6WlpZYsmSJSpuzs7Pe6iciImoOBAeGkydPCj5ov379BPft2rUrunfvDgBYvXo1CgsLte4zZswYlbESPj4+EIvF2LJlCx48eICWLVsqtxkbG8PT01NwPURERFST4MCwadMmwQfVJTA8z8qWtQ2sdHFxAQDk5uaqBAYiIiKqO8GBYfbs2bW2l5SU4ObNm4iOjkaPHj0MNg9DcnIyRCJRjYmjiouLMXPmTJSUlKBdu3YYN24cevbsaZAaiYiIXlSCA0P//v01bn/llVeUC1M1tLy8POzbtw99+/aFjY2Nsr1169Z488034eLiArlcjmPHjmH16tVYuHCh2tAQGRmJyMhIAEBoaCgcHBz0Vud9vR2JGgN9XhvUPBnmGuInUVPSkNeQ3gY9du7cGX5+fggLC8PSpUv1dVitHj9+jLVr18Lc3BxTp05V2da3b1+V1127dsXHH3+MiIgItYEhJCQEISEhytc5OTn6L5qaBF4bVFe8hqiu9H0NtW3bVu023QcQaDnR7du39XlIjRQKBTZs2IB79+7h//7v/2BlZaWxv0gkQs+ePXH37l0ukkVERKQDvQaGtLQ0fR5Oq+3btyMuLg6LFy+Gk5NTg56biIioOanzTxJVVVV4+PAhjh8/DplMhoCAAH3UpdXPP/+M33//He+//z68vLwE7aNQKBAbGwsXF5fnejqDiIiouRIcGCZNmqS1j5WVFd58802dCigrK4NMJgMAPHr0CKWlpYiJiQEABAQEwMzMDPPnz4e3t7fySY0zZ87gp59+Qv/+/SGVSpGcnKw8XuvWrZWPXS5duhQ9e/aEk5MTysrKcPz4cdy8eRMffPCBTjUSERE1d4IDQ6dOnSASiWq0i0QiSCQSuLu745VXXtF58an8/HysWbNGpa369YYNG+Do6IiqqiqVMQeXL18GAERFRSEqKkpl3zlz5iif6GjdujV+++035ObmwsjICK6urvjwww8b7C4IERFRUyFSKBQKQxfRmGVkZOjtWPc/eFtvxyLDa7Pq+wY/57Qdfzb4Oan+bJ/au8HPeeQAH6tsSoaMaqPX4zXYUxJERETUNDEwEBERkVZqxzDosnbE00QikdpppImIiOjFpDYw6LI65bMYGIiIiJoWtYFhw4YNDVkHERERNWJqAwOXiCYiIqJqHPRIREREWj3X1NBVVVUoKCjA48ePa93OZX+JiIiaFp0Cw927d7Fr1y4kJCSgoqKi1j4ikQi7d+/WS3FERETUOAgODGlpafj4448BAF26dMGFCxfw0ksvwcbGBnfu3EFhYSF8fHx4d4GIiKgJEhwY9u3bh8rKSnzxxRdo3749Jk2ahB49emD8+PGQy+X4z3/+A5lMhjlz5tRnvURERGQAggc9JiQkIDAwEO3bt1e2VS9DYW5ujr/97W+QSCQICwvTf5VERERkUIIDQ2FhIdq0+d8iF0ZGRigrK1O+NjY2ho+PD+Lj4/VbIRERERmc4MBgZWUFuVyufG1tbY2cnByVPiYmJigpKdFfdURERNQoCA4MrVq1QnZ2tvK1q6srrly5gvz8fACAXC7H+fPn4ejoqP8qiYiIyKAED3r08/PD/v37IZfLYW5ujsGDB0Mmk2Hx4sXo2LEjbt++jQcPHuCtt96qz3qJiIjIAAQHhoEDB6Jt27YoLy+Hubk5AgMDMXXqVISHhyM2NhZisRijR4/Gq6++Wp/1EhERkQFoDAyLFy9GSEgIXn75ZdjZ2SEoKEhl+7BhwzB06FAUFBTAxsYGIpGoXoslIiIiw9A4hiE1NRVbt27FO++8g2+//RY3btyoeQAjI9ja2jIsEBERNWEa7zCsWLECkZGRiImJwR9//IE//vgD7du3x8CBA9G3b19YWlo2VJ1ERERkQBoDg6enJzw9PTF9+nScPn0aJ06cwJ07d/Cf//wHu3btQq9evTBw4EB4eXk1VL1ERERkAIIGPVpYWGDw4MEYPHgwUlJSEBkZibNnz+LUqVM4deoUnJ2dlXcdrKys6rtmIiIiamCC52Go5uLigrfffhv//ve/MWfOHHTs2BFpaWnYsWMHZs2ahfXr19dHnURERGRAOgeGamKxGP369cNnn32GtWvXwsvLCxUVFThz5ow+6yMiIqJGQPA8DLUpKirCyZMnceLECaSlpQEAB0ISERE1Qc8VGK5evYrIyEjExcXh8ePHAAAPDw+EhITUmKuBiIiIXnyCA0NeXh7++OMPnDhxQrmmhEQiQUhICEJCQtCuXbt6K5KIiIgMS2NgUCgUuHjxIo4fPw6ZTIaqqioAgJeXFwYOHIhevXpBLBbXqYDMzEwcOHAAycnJuHfvHjp16oRly5Zp3a+kpATbt29HXFwcqqqq0LVrV0yfPh0tWrRQ6RcXF4fdu3cjMzMTjo6OmDBhAu+CEBER6UhjYJgzZw4ePXoE4Mny1n379kVISAicnJz0VsC9e/cgk8ng4eGByspKwfutXbsWGRkZeOedd2BkZIRdu3Zh1apV+Oyzz5R9rl27htWrV2Pw4MGYPn06ZDIZ1q1bB4lEAj8/P729ByIioqZOY2B49OgRvL29lXcTTEzqNEayVl27dkX37t0BAKtXr0ZhYaHWfZKTk3H58mUsW7YM3t7eAACpVIolS5YgPj4eXbp0AQDs3bsXnTp1wowZMwAAvr6+SEtLQ0REBAMDERGRDjQmgK+//hpt2rSp1wKMjHR/slMmk8HGxkYZFgDA3d0djo6OuHTpErp06YKKigpcvXoV06dPV9k3KCgImzZtQklJCZ/oICIiEkjjt3V9h4XnlZ6eXuvPIk5OTkhPTwcAZGVlobKyskY/JycnKBQKZGRkNEitRERETYH+f2NoAMXFxbXeHZBIJMonOIqKipRtT6ueurq4uLjWY0dGRiIyMhIAEBoaCgcHB73VfV9vR6LGQJ/XBjVPhrmG+EnUlDTkNfRCBob6VP2YaLWcnBwDVkONGa8NqiteQ1RX+r6G2rZtq3bbc08NbUgSiQSlpaU12ouLi5V3FKrvJJSUlKj0UXfngYiIiNR7IQPD02MVnpaRkaEcs9CqVSsYGxvX6JeRkQGRSKQxRREREZGqFzIwBAQEIC8vD9euXVO23bp1C1lZWfD39wcAmJqawtfXFzExMSr7RkdHw9PTk09IEBER6UBwYIiNjVXO9KhPZWVliImJQUxMDB49eoSCggLl67KyMgDA/PnzsXnzZuU+np6e8PPzw4YNGxAbG4tz587hm2++gZeXl3IOBgAYN24cEhISsH37diQkJOC///0vZDIZxo8fr/f3QURE1JQJHvS4Zs0a2NnZ4ZVXXsHAgQP1NjIzPz8fa9asqXEuANiwYQMcHR1RVVVVI6y899572LFjBzZv3gyFQoHAwMAacy54eXlhwYIFCAsLw9GjR+Ho6Ih3332XkzYRERHpSKRQKBRCOm7btg2nT59GSUkJjIyM4Ofnh0GDBiEwMBAikai+6zQYfc7XcP+Dt/V2LDK8Nqu+b/BzTtvxZ4Ofk+rP9qm9G/ycRw7wscqmZMgo/c6XpGl8n+A7DDNmzMCbb76J6OhoHDt2DDKZDDKZDFKpFAMHDsSAAQMglUr1UjARERE1LjrNwyAWi9G/f3/0798fd+/eRWRkJE6fPo3w8HDs3bsXgYGBGDRokHLgIRERETUNzz1xU/v27VXuOoSFheH8+fM4f/48HBwcMGTIEAwePBjm5ub6rJeIiIgMoE6PVcrlcpw6dQq///67chlsFxcXFBUVYdeuXXj//feRkpKijzqJiIjIgJ7rDsOdO3dw7NgxnD17FnK5HGKxGAMGDMCQIUPg4uICuVyOI0eOYM+ePfjPf/6D5cuX67tuIiIiakCCA0NZWRnOnj2LY8eO4fbt2wCezLg4aNAg9OvXT2UiJHNzc4wePRoPHz7EiRMn9F81ERERNSjBgeGdd95BaWkpjIyM0LNnTwwZMgQ+Pj4a95FKpaioqKhzkURERGRYggODhYUFRowYgZCQENja2graZ/DgwQgODn7e2oiIiKiREBwYNm7cCCMj3cZIWlpacs0GIiKiJkBwAtA1LBAREVHTITgF7N27F5MnT1Y+PvmsR48eYfLkyfjll1/0VRsRERE1EoIDw4ULF+Dt7a12+mepVApfX1/ExcXprTgiIiJqHAQHhszMTDg7O2vs4+TkhMzMzDoXRURERI2L4MBQXl4OMzMzjX3EYjHkcnmdiyIiIqLGRXBgsLe3x40bNzT2uXHjBlesJCIiaoIEBwY/Pz8kJiYiOjq61u1nz55FYmIiV6okIiJqggTPwzBmzBicOXMG69atQ3R0NPz9/SGVSvHo0SPIZDKcP38eVlZWGDNmTD2WS0RERIYgODBIpVJ89NFHWLNmDeLi4mo8DdGyZUssWLAA9vb2ei+SiIiIDEun1Srd3Nywbt06XLhwATdu3EBxcTEkEgk8PDzQtWtXmJg81+KXRERE1Mjp/A1vYmKCnj17omfPnvVRDxERETVCnO+ZiIiItFJ7h+HkyZMAgB49esDCwkL5Woh+/frVvTIiIiJqNNQGhk2bNgEAPDw8YGFhoXwtBAMDERFR06I2MMyePRsAYGdnp/KaiIiImh+1gaF///4aXxMREVHzwUGPREREpBUDAxEREWml9ieJefPmPdcBRSIR1q9fL7h/Wloatm3bhuTkZEgkEgwYMAATJkyAkZH6LLNnzx5ERETUum3y5MkYO3YsAGDjxo21Pt2xdu1aODk5Ca6RiIiouVMbGBQKxXMdUJf9ioqKsGLFCjg7O2Px4sXIzMzEDz/8AIVCgddff13tfgMHDqyxyFVcXBz279+PgIAAlXYnJ6caAzZbtmwpuEYiIiLSEBg2btxY7yc/duwYysvLsXDhQlhaWqJLly4oLS1FeHg4Ro0aBUtLy1r3s7e3r7Fmxd69e+Hk5AQXFxeVdjMzM3h6etbXWyAiImoWDDqG4dKlS/Dz81MJBsHBwSgvL0diYqLg4xQWFiI+Ph7BwcH1USYREVGz99yrRZWWlqK4uBiWlpZq7wRok56eDh8fH5U2BwcHmJmZISMjQ/BxYmNjUVlZWWtgSEtLw9SpU1FRUQE3NzdMnjwZ3t7ez1UvERFRc6VTYKisrMTBgwdx/PhxZGdnK9sdHR0xcOBAjBw5EsbGxoKPV73a5bMkEgmKiooEH+fs2bNwdXVFmzZtVNpdXV3h4eEBZ2dnFBQU4ODBg1ixYgVWrFgBd3f3Wo8VGRmJyMhIAEBoaCgcHBwE16HNfb0diRoDfV4b1DwZ5hriJ1FT0pDXkODA8PjxY3z++edITEyESCSCg4MDbG1tkZeXhwcPHuCnn37CpUuX8PHHHzfoMte5ublITEzEX/7ylxrbhg0bpvI6ICAACxYswL59+7B48eJajxcSEoKQkBDl65ycHP0WTE0Grw2qK15DVFf6vobatm2rdpvgb/ZDhw4hMTERgYGBeOutt1T+ms/MzMTOnTtx4cIFHDp0CGPGjBF0TIlEgpKSkhrtxcXFsLKyEnSMP//8EwAQFBSkta+ZmRkCAgJw4cIFQccmIiKiJwQPejxz5gzatWuHDz74oMat/9atW2PRokVo164dTp8+LfjkTk5OSE9PV2nLyclBWVmZxpTztLNnz8LLy0vwbRmRSASRSCS4RiIiItIhMGRmZsLf31/thEpGRkbw9/dHVlaW4JP7+/vj8uXLKC0tVbZFR0dDLBYLGpiYnZ2NGzduCH46ory8HBcvXkSHDh0E10hEREQ6/CRhYmICuVyusU9ZWZlOgx4HDRqEw4cP46uvvsLo0aORnZ2N8PBwjBgxQuXJi/nz58Pb27vGBEzR0dEwNjZGr169ahy7pKQEoaGhePnll9G6dWsUFhbi119/RW5uLhYsWCC4RiIiItIhMLz00kuIjY3FxIkTYW1tXWN7QUEBYmJiakycpImVlRU+/fRTbN26FStXroREIsHw4cMxceJElX5VVVWoqqqqsf/Zs2fh6+tbaz0mJiawtrbGvn37kJ+fD1NTU3h6emLZsmVwc3MTXCMREREBIoXAuZyjo6Oxbt06ODg4YNy4cfDx8YGdnR3y8vKQkJCAffv2ITs7G3//+98FDUB8UegyH4Q29z94W2/HIsNrs+r7Bj/ntB1/Nvg5qf5sn9q7wc955AAfq2xKhoxqo72TDvTylERQUBBSUlKwf/9+/Pvf/661z6hRo5pUWCAiIqIndJow4Y033kC3bt1w4sQJpKSkoKSkBJaWlnBxccGAAQO4ZgMREVETJTgwFBYWQiQSwdPTk8GAiIiomdEaGOLi4rBz507lVNCtW7fGlClT0K1bt3ovjoiIiBoHjfMwJCcnY/Xq1SrrRmRmZmL16tVITk6u9+KIiIiocdAYGA4dOgSFQoFx48bhu+++w5YtW/Daa6+hqqoKhw4daqgaiYiIyMA0/iRx48YNeHl5qcyLMGnSJCQmJvIOAxERUTOi8Q5Dfn4+PDw8arR7eHigoKCg3ooiIiKixkVjYKisrIS5uXmNdjMzM1RWVtZbUURERNS4CF58ioiIiJovrY9VRkVFISEhQaXtwYMHAIDly5fX6C8SifDpp5/qqTwiIiJqDLQGhgcPHigDwrMSExP1XhARERE1PhoDw9KlSxuqDiIiImrENAYGb2/vhqqDiIiIGjEOeiQiIiKtGBiIiIhIKwYGIiIi0oqBgYiIiLRiYCAiIiKtGBiIiIhIKwYGIiIi0oqBgYiIiLRSO3FTRETEcx90/Pjxz70vERERNT5qA0N4ePhzH5SBgYiIqGlRGxhqW0fi0KFDkMlkePnll+Ht7Q1bW1vk5eUhISEBZ86cQWBgIIYPH16vBRMREVHDUxsYnl1H4uTJk7hy5Qo+//xzdOjQQWVb//79MXToUCxduhQ9e/asn0qJiIjIYAQPevz111/Ru3fvGmGhmpubG3r37o1ff/1Vb8URERFR46BxtcqnZWRkICAgQGMfOzs7xMTE6FRAWloatm3bhuTkZEgkEgwYMAATJkyAkZH6LJOdnY158+bVaA8KCsJ7772n0hYXF4fdu3cjMzMTjo6OmDBhAoKCgnSqkYiIqLkTHBgsLCxw/fp1jX2uX78Oc3NzwScvKirCihUr4OzsjMWLFyMzMxM//PADFAoFXn/9da37T5kyBR07dlS+tra2Vtl+7do1rF69GoMHD8b06dMhk8mwbt06SCQS+Pn5Ca6TiIiouRMcGAIDAxEVFYWdO3diwoQJsLCwUG4rLS1FeHg4rl27hldeeUXwyY8dO4by8nIsXLgQlpaW6NKli/JYo0aNgqWlpcb927ZtC09PT7Xb9+7di06dOmHGjBkAAF9fX6SlpSEiIoKBgYiISAeCA8Mbb7yBxMRE/Prrrzhx4gRcXFxgY2OD/Px8pKSkoLS0FI6Ojpg8ebLgk1+6dAl+fn4qwSA4OBi7du1CYmIiunXrptu7eUpFRQWuXr2K6dOnq7QHBQVh06ZNKCkp0RpIiIiI6AnBgcHGxgb/+te/8OOPP+LMmTNISkpSbhOLxRg4cCAmT56MFi1aCD55eno6fHx8VNocHBxgZmaGjIwMrftv2rQJRUVFsLGxQXBwMCZPngyxWAwAyMrKQmVlJZycnFT2cXJygkKhQEZGBtzd3QXXSkRE1JwJDgwA0KJFC7zzzjt4++23kZ6ervwr3cnJCcbGxjqfvLi4GBKJpEa7RCJBUVGR2v1MTU0xZMgQ+Pn5wcLCAgkJCdi/fz+ysrKwePFiAFDu/+zxrayslOeuTWRkJCIjIwEAoaGhcHBw0Pl9qXNfb0eixkCf1wY1T4a5hvhJ1JQ05DWkU2CoZmxsjPbt2+u7FsHs7Owwc+ZM5WsfHx/Y2tri+++/R0pKClxcXJ772CEhIQgJCVG+zsnJqUup1ITx2qC64jVEdaXva6ht27Zqt+m8+NTjx49x6dIlHDp0SGW9ifLycuTn56OqqkrwsSQSCUpKSmq0FxcXK+8ECNWrVy8AwO3btwH8707Cs8dXd+eBiIiI1NPpDsOlS5ewefNm5OXlKduq141ISUnBJ598gvnz56NPnz6Cjufk5IT09HSVtpycHJSVlWlMOZqIRCIAQKtWrWBsbIz09HSVWSszMjIgEome+/hERETNkeA7DLdu3cKqVasgEokwdepUBAcHq2z39PSEo6Mjzp07J/jk/v7+uHz5MkpLS5Vt0dHREIvFNaam1qZ6wqjqmShNTU3h6+tbYyKp6OhoeHp68gkJIiIiHQi+w7B3716IxWKEhobC1ta21tUs3dzccOfOHcEnHzRoEA4fPoyvvvoKo0ePRnZ2NsLDwzFixAiVL/T58+fD29sbs2fPBgDs2bMHcrkcHTt2hIWFBZKSknDgwAH06NEDL730knK/cePGYdmyZdi+fTu6d+8OmUwGmUyGJUuWCK6RiIiIdAgM169fR/fu3WFra6u2j4ODA2QymeCTW1lZ4dNPP8XWrVuxcuVKSCQSDB8+HBMnTlTpV1VVpTI2wsnJCQcPHsTx48dRXl4OBwcHjBo1Cq+99prKfl5eXliwYAHCwsJw9OhRODo64t133+WkTURERDoSHBjkcnmNqZefVVZWptOgRwBwdnaudSntp23cuFHldXBwcI2fRNTp0aMHevTooVNNREREpErwGAapVIp79+5p7JOSkoJWrVrVuSgiIiJqXAQHhuoBiteuXat1u0wmQ3JyMgIDA/VWHBERETUOgn+SGDt2LKKjo/HPf/4TQ4cOxYMHDwAAFy9eRGJiIo4cOQJbW1uMGDGi3oolIiIiwxAcGKRSKT766COsXbsWBw8eVLavXLkSwJN5DxYtWqR1nAMRERG9eHSauKlDhw5Yt24dLl68iOTkZBQWFsLS0hIeHh7o3r37c60nQURERI2fzmtJGBkZoVu3bnVaepqIiIheLIIHPS5fvhwnT57U2OfUqVNYvnx5nYsiIiKixkVwYEhMTFQOdFQnJycHiYmJdS6KiIiIGhedV6vUpLy8nOMYiIiImiCdxzDURqFQICcnBzKZDPb29vo4JBERETUiGgPDpEmTVF6Hh4fXuujU08aOHVv3qoiIiKhR0RgYOnXqBJFIBODJGAYHBwc4OjrW6GdkZAQrKyt07twZAwYMqJ9KiYiIyGA0BoZly5Yp/z1p0iS88sorGD9+fH3XRERERI2M4DEMGzZsgEQiqc9aiIiIqJESHBhatmxZn3UQERFRI6bzUxK5ubm4cuUKHj16hMePH9fahz9bEBERNS06BYY9e/bgl19+QWVlpcZ+DAxERERNi+DAcPr0aezduxe+vr4YMmQIVq9ejX79+sHPzw8JCQn4448/0KtXLwwaNKg+6yUiIiIDEBwYjh49CqlUiiVLlihnc3R0dERwcDCCg4PRo0cPhIaGIjg4uN6KJSIiIsMQPDX03bt3ERAQoDL1c1VVlfLf/v7+8PPzw8GDB/VbIRERERmc4MBQWVmJFi1aKF+LxWKUlJSo9GnXrh1SUlL0VhwRERE1DoIDg52dHXJzc5WvHRwckJqaqtInNzeXi08RERE1QYIDg4uLC+7du6d87ePjg2vXruHUqVOQy+W4ePEiYmJi4OrqWi+FEhERkeEIDgxdu3bFvXv3kJ2dDQAYM2YMLC0tsXHjRkydOhUrV64EUHPBKiIiInrxCX5Kon///ujfv7/ytYODA7744gscPHgQWVlZaNmyJYYMGYL27dvXR51ERERkQDrP9Pg0R0dHzJw5U1+1EBERUSMl+CcJIiIiar50vsNQVVWFR48eaVxLwtvbW/Dx0tLSsG3bNiQnJ0MikWDAgAGYMGECjIzUZ5mbN2/i6NGjSEpKQm5uLuzt7dGnTx+MHj0aYrFY2W/Pnj2IiIiosf+SJUvg7+8vuEYiIqLmTqfAcODAARw8eBAFBQUa+4WFhQk6XlFREVasWAFnZ2csXrwYmZmZ+OGHH6BQKPD666+r3S86OhpZWVkYPXo02rRpg9TUVISFhSE1NRWLFi1S6WtpaYklS5aotDk7Owuqj4iIiJ4QHBj27NmDvXv3wsrKCv369YNUKq3znAvHjh1DeXk5Fi5cCEtLS3Tp0gWlpaUIDw/HqFGjYGlpWet+Y8aMgbW1tfK1j48PxGIxtmzZggcPHqgsxW1sbAxPT8861UlERNTcCQ4Mf/zxBxwdHbFy5Uq1X+S6unTpEvz8/FSOFxwcjF27diExMRHdunWrdb+nw0I1FxcXAE8mj3o6MBAREVHdCQ4MhYWFGDRokN7CAgCkp6fDx8dHpc3BwQFmZmbIyMjQ6VjJyckQiURo1aqVSntxcTFmzpyJkpIStGvXDuPGjUPPnj3rXDsREVFzIjgwtG7dGsXFxXo9eXFxMSQSSY12iUSCoqIiwcfJy8vDvn370LdvX9jY2CjbW7dujTfffBMuLi6Qy+U4duwYVq9ejYULF6oNDZGRkYiMjAQAhIaGwsHBQcd3pd59vR2JGgN9XhvUPBnmGuInUVPSkNeQ4MAwePBghIWFIS8vD7a2tvVYkm4eP36MtWvXwtzcHFOnTlXZ1rdvX5XXXbt2xccff4yIiAi1gSEkJAQhISHK1zk5OfovmpoEXhtUV7yGqK70fQ21bdtW7TadAsP9+/fxySefYNy4cejQoYPanyeEJh6JRFJjxUvgyZ0HKysrrfsrFAps2LAB9+7dw4oVK7TuIxKJ0LNnT+zatQtVVVUaH90kIiKi/9HpscqXXnoJUVFR2Lx5s9o+IpEIu3fvFnQ8JycnpKenq7Tl5OSgrKxMY8qptn37dsTFxeGTTz6Bk5OToHMSERGR7gQHhuPHj2PLli0wNjaGj48P7Ozs6vxYpb+/Pw4cOIDS0lJYWFgAeDLHglgs1jr5088//4zff/8d77//Pry8vASdT6FQIDY2Fi4uLry7QEREpAPBgeHgwYOwsbHBP//5Tzg6Ourl5IMGDcLhw4fx1VdfYfTo0cjOzkZ4eDhGjBih8nPH/Pnz4e3tjdmzZwMAzpw5g59++gn9+/eHVCpFcnKysm/r1q2Vj10uXboUPXv2hJOTE8rKynD8+HHcvHkTH3zwgV7qJyIiai4EB4YHDx5g4MCBegsLAGBlZYVPP/0UW7duxcqVKyGRSDB8+HBMnDhRpV9VVRWqqqqUry9fvgwAiIqKQlRUlErfOXPmKFfVbN26NX777Tfk5ubCyMgIrq6u+PDDDxEQEKC390BERNQcCA4MUqlU7doRdeHs7IylS5dq7LNx40aV13PnzsXcuXO1Hrv6jgQRERHVjeAf8vv16weZTIbS0tL6rIeIiIgaIcGBYezYsXB3d8eKFSuQkJDA4EBERNSMCP5J4o033lD++7PPPlPbT5fHKomIiOjFIDgwdOrUCSKRqD5rISIiokZKcGBYtmxZPZZBREREjRlnLyIiIiKtGBiIiIhIK7U/SURERAAAhg4dCisrK+VrIcaPH1/3yoiIiKjRUBsYwsPDAQBBQUGwsrJSvhaCgYGIiKhpURsYqmdfrF6qWttsjERERNR0qQ0Mz64WqW31SCIiImq6BA96PHnyJFJTUzX2uXv3Lk6ePFnnooiIiKhxERwYNm3ahLi4OI19zp8/j02bNtW5KCIiImpc9PpYZVVVFWeDJCIiaoL0GhgyMjIgkUj0eUgiIiJqBDRODf3szwtxcXHIzs6u0a+qqgoPHz5EUlISAgMD9VshERERGZzGwPDsAMaUlBSkpKSo7e/h4YGpU6fqpTAiIiJqPDQGhg0bNgAAFAoF5s+fj2HDhmHYsGE1+hkZGUEikcDc3Lx+qiQiIiKD0hgYWrZsqfz3+PHj4ePjo9JGREREzYPg5a0nTJhQn3UQERFRIyY4MNy5cwfJycl4+eWXYWlpCQCQy+X4/vvvcf78eZiZmWH06NG1/mRBRERELzbBj1Xu378f+/btU4YFAPjxxx9x+vRpKBQKFBYWYseOHbh8+XK9FEpERESGIzgw3Lp1Cz4+PsrXjx8/xsmTJ+Hu7o7vvvsOGzZsgLW1NQ4fPlwvhRIREZHhCA4MBQUFsLe3V76+ffs25HI5QkJCIBaLIZVK0a1bN63rTRAREdGLR6eZHisrK5X/vnbtGgDVVSytra1RUFCgp9KIiIiosRAcGBwcHHDjxg3l67i4ONjb26NVq1bKttzcXFhZWem3QiIiIjI4wU9J9O7dG+Hh4Vi9ejVMTU2RnJyM4cOHq/RJT09XCRBERETUNAgODCNGjMDly5dx7tw5AICLiwvGjx+v3J6dnY2bN29i7NixOhWQlpaGbdu2ITk5GRKJBAMGDMCECRNgZKT55kdJSQm2b9+OuLg4VFVVoWvXrpg+fTpatGih0i8uLg67d+9GZmYmHB0dMWHCBAQFBelUIxERUXMnODCYm5tjxYoVuHv3LgDA2dm5xpf6okWL4ObmJvjkRUVFWLFiBZydnbF48WJkZmbihx9+gEKhwOuvv65x37Vr1yIjIwPvvPMOjIyMsGvXLqxatQqfffaZss+1a9ewevVqDB48GNOnT4dMJsO6desgkUjg5+cnuE4iIqLmTnBgqNa+ffta2x0dHeHo6KjTsY4dO4by8nIsXLgQlpaW6NKlC0pLSxEeHo5Ro0apzPnwtOTkZFy+fBnLli1TDrqUSqVYsmQJ4uPj0aVLFwDA3r170alTJ8yYMQMA4Ovri7S0NERERDAwEBER6UDjff/ExETk5OQIPlhqamqNFS41uXTpEvz8/FSCQXBwMMrLy5GYmKh2P5lMBhsbG5UnNNzd3eHo6IhLly4BACoqKnD16lX07t1bZd+goCAkJyejpKREcJ1ERETNncbAsHz5ckRFRam0/fLLL8q/2J917tw5bNq0SfDJ09PT0bZtW5U2BwcHmJmZISMjQ+N+Tk5ONdqdnJyQnp4OAMjKykJlZWWNfk5OTlAoFBqPT0RERKp0/kmioqICxcXFejl5cXExJBJJjXaJRIKioiKN+9X2c4VEIkF2djYAKPd/9vjVj32qew+RkZGIjIwEAISGhtYINHXRdtdvejsWNU9H/2+coUugF9z0Wfr7TKPmRaeJm5qDkJAQhIaGIjQ01NClvLA+/PBDQ5dALzheQ1RXvIb0z6CBQSKR1DqWoLi4WOMEUBKJBKWlpbXuV31HoXr/Z4+v7s4DERERqWfQwPD0mINqOTk5KCsr0/hTQG37AUBGRoZyzEKrVq1gbGxco19GRgZEIpFef2ogIiJq6gwaGPz9/XH58mWVuwXR0dEQi8UqT0A8KyAgAHl5ecr1LIAnq2lmZWXB398fAGBqagpfX1/ExMSo7BsdHQ1PT0+1j2xS3YWEhBi6BHrB8RqiuuI1pH8GDQyDBg2CqakpvvrqK8THxyMyMhLh4eEYMWKEyhf6/PnzsXnzZuVrT09P+Pn5YcOGDYiNjcW5c+fwzTffwMvLSzkHAwCMGzcOCQkJ2L59OxISEvDf//4XMplMZYZK0j/+H5XqitcQ1RWvIf0TKRQKhbqNkyZNeq6DhoWFCe6blpaGrVu3qkwNPXHiRJVZJOfOnQtvb2/MnTtX2VZcXIwdO3bg3LlzUCgUCAwMxPTp02Ftba1y/HPnziEsLAz3799XTg0dHBz8XO+LiIiouTJ4YCAiIqLGT2NgIHpWVFQUNm3ahDlz5qB///6GLocasYSEBCxfvhzjx4/HxIkTAQATJ06Et7c3li1bZtji6IXGzyHD4DwMREREpBXvMJBOSkpKkJubCzs7Oz5pQhqVlZUhJycHLVq0UI4tSk9Ph5mZGRwcHAxcHb3I+DlkGAwMREREpJXOa0lQ03b27FkcPnwY9+/fh1wuh7W1NTp06IBx48ahQ4cOtf52mJ2djXnz5qFfv34YNmwY/vvf/+LGjRswNjaGv78/pkyZAqlUqnKemzdvYt++fbh16xYKCwshkUjQtm1bDBo0CH369DHAOyd9EzqGYdmyZUhMTMQPP/yAH3/8ETExMSgqKkL79u0xfvx4dO3aVeW4RUVF2L9/P86dO4eHDx/CxMQEUqkUvr6+eOutt2Biwo+1puDp68fb2xvh4eG4c+cOWrVqheHDh/NzyAA4hoGUDh8+jHXr1iE/Px/BwcEYNmwYvL29cevWLSQnJ2vdPysrC8uWLYOJiQmGDh0KT09PnD17Fp988onKYmK3b9/GJ598gqSkJPj5+WHEiBHo2rUrSktLce7cufp8i9SIrVmzBhcvXkRwcDD69euHjIwMfPnllyqTrykUCnz++ec4cOAAWrVqhaFDh6Jfv35o2bIljh8/jsePHxvwHVB9uH79Oj7//HNYWlpi8ODB6Ny5s8b+/ByqP4zipBQVFQU7Ozt89dVXMDMzU7ZXVVXVuubHs65du4aJEyeqTIwVERGBPXv2ICIiAtOmTQMAnD59GpWVlVi6dClcXFxUjlFYWKiX90IvnocPH2LVqlUwNzcHAIwYMQKLFy/G1q1b0a1bN5iYmODu3bu4desWhg0bpryeqhUXF0MsFhugcqpPV65cwbvvvqvyF39UVJTa/vwcqj+8w0AqTE1NYWxsrNJmZGSkcTGwalZWVhg5cqRK28iRIyGRSHDmzJka/au/GJ7WokULHSumpmLs2LEq10Tbtm3Rt29f5OfnIz4+XqVvbdeORCJRmfCNmgY3Nzedfh7g51D94f+7SKl3797Izs7GwoULsWfPHiQkJKC8vFzw/q6urip3JgDAzMwMrq6uKCgoQG5urvI8IpEIS5YswbZt2xAXF6dyq5CaJy8vL7VtqampAABnZ2e0a9cOP//8M0JDQ3H06NFaF6KjpqNDhw469efnUP3hTxKkNHr0aEgkEhw9ehQRERGIiIiAmZkZXn75ZUyZMgUWFhYa91eXyqsfqSstLYWdnR08PT3x6aefYt++fTh27Bh+//13iEQi+Pn5Ydq0aVxJtJl6dlr3p9uqF6gzNjbG0qVLERYWhtjYWFy8eBHAk9Vpx48fj379+jVcwdQgbGxsdOrPz6H6w8BASiKRCIMGDcKgQYOQl5eHq1ev4vjx44iMjER5eTnmzZuncX91v/sVFBQAgErg8PHxgY+PD+RyOa5du4Y///wTUVFR+OKLL7B27VqOdG+GCgoKYG9vX6MNUL12rK2t8de//hUzZ87E3bt3cenSJfz222/YuHEjpFKp1kFx1LTxc6j+8CcJqpWtrS369OmDjz/+GFKpFBcuXNC6z507d1BWVqbSVlZWhjt37sDa2hp2dnY19jE3N4e/vz9mz56N3r17IysrC2lpaXp7H/TieHq5+mfbXnrppRrbjIyM4OLigjFjxmDOnDkAIOg6paaNn0P1h4GBlBITE2u0yeVylJWVCUraRUVFOHjwoErbwYMHUVxcrDJoKTk5GRUVFSr9FAoF8vPzATwZeEnNz88//wy5XK58nZGRgVOnTsHGxka5bH12djYePHhQY9+8vDwAvHaIn0P1ifdbSOnLL7+ERCKBh4cHHBwcUFZWhvPnz6O4uBhvvPGG1v29vLxw8OBB3LhxAy+99BJSU1Mhk8nQsmVLlUecfvnlFyQlJaFTp05wdHSEkZERkpKScOvWLQQEBMDJyak+3yY1Uvb29vjggw/QvXt3yOVyREdHo6KiAvPmzVMG1pSUFKxevRqenp5wcnKCtbU1MjMzcf78eVhYWGDAgAEGfhdkaPwcqj8MDKT0xhtv4OLFi7h+/Tri4uJgaWkJZ2dnTJ8+HT169NC6f6tWrTBt2jTs2rULv//+O4yMjBAUFIQpU6aoPJY5ePBgWFpa4saNG7hy5QqMjY3h6OiIt956C4MHD67Pt0iN2IIFC/Djjz/izJkzKC4uhrOzMyZMmIBu3bop+7i5uWHUqFG4evUq4uLiIJfLIZVK0bdvX4wZMwatW7c24DugxoCfQ/WHa0lQnT09JevcuXMNXQ69YKqnht6zZ4+hS6EXGD+H6h/HMBAREZFWDAxERESkFQMDERERacUxDERERKQV7zAQERGRVgwMREREpBUDAxEREWnFwEBEjVpCQgImTpyIiRMnGroUomaNMz0SCVReXo6TJ0/iwoULSE1NRUFBAUxMTCCVSuHl5YXg4GD4+vpqPMbcuXNrXQvB3NwcLVu2RKdOnTB06FA4OzvX6FM9wZEQ3t7eWLZsmaC+2mqrjT4mxykuLsavv/4KABg+fDgkEkmdjtcYRUVFITs7W7kqItGLjIGBSID4+Hhs3rwZDx8+VLZZWFjg8ePHSE9PR3p6Oo4fP46AgADMmzcPLVq00Hg8U1NTWFpaAniy4E1hYSHu3buHe/fu4fjx4/jrX/+qdl0EY2NjlSlua6Ntu9Da1NG2XYji4mJEREQAAPr37682MJiZmaFt27Z1Pp8hREVFKUMeAwO96BgYiLSIjo7G+vXrUVlZCalUiokTJ6JHjx7KL+X09HQcO3YMR44cgUwmw0cffYQVK1bAxsZG7TGDgoJU/kIvLy/HhQsXsG3bNuTn52PLli1wc3OrdVnnjh076nz3QBfP1mZo7u7u+Prrrw1dBlGzxzEMRBqkpaVh8+bNqKysRPv27fHll19iwIABKn/BOzk5Ydq0afjggw9gYmKCzMxMfPPNNzqdRywWo3fv3pg/fz4AoKqqCkePHtXreyEiqgveYSDSYPfu3SgrK4OpqSkWLFgAa2trtX0DAwPx2muvYc+ePbhy5QouXryIwMBAnc7XpUsX2NnZITc3F7du3apr+Q3q4cOHOHjwIOLj4/HgwQNUVlaiRYsWsLW1RadOndCnTx+4u7sDqDkeY968eSrHenoMRkJCApYvXw4ANRaoioqKwqZNm9CyZUts3LgRSUlJ2L9/P27evImysjK0adMGQ4cOVfl55+LFi/j111+RkpKCsrIytGvXDiNHjkRQUFCt7ys7OxvR0dFISEhAdnY2Hj16BABwcHCAn58fRowYAQcHh1rrqhYREaH8+aXahg0b4OjoqHxdVVWFqKgonD59Gnfv3kVpaSlatGiBjh07YsiQIWp/0qj+73L8+PF47bXXcPjwYZw9exaZmZkoKSnB0qVLlfump6fj0KFDSExMxMOHD6FQKGBtbQ2pVAofHx/069ePyzqTWgwMRGrk5uYiLi4OABAcHCzod/QRI0bg4MGDKC0txZEjR3QODAAglUqRm5uL0tJSnfc1lJSUFCxfvhzFxcUAACMjI1hYWCAvLw+5ubm4c+cOiouLlYHBysoKLVq0QGFhIQCgRYsWMDL63w3P5xmDcfz4cWzZsgXAk/ElZWVlSElJwbfffovMzEy88cYb2LNnDyIiIiASiWBhYYHy8nLcunULX3/9NYqKimpd1njTpk3KcGNiYgILCwsUFRUpx65ERUXhww8/hJeXl3IfsVgMGxsbFBUVobKyEmZmZjA3N1c57tPvt6SkBKtWrUJCQkKN//5iYmIQExODkSNHYsqUKWrff0VFBZYvX47r16/D2NgY5ubmEIlEyu3x8fFYuXIlKioqAEDZ5+HDh3j48CFu3LgBExMTPo1CajEwEKmRkJCA6pnTe/bsKWgfc3NzdOnSBbGxsUhKSkJlZSWMjY11Om/1kwp1GbjY0H744QcUFxfD1dUVM2fOhIeHB0QiER4/fowHDx7g/PnzeHoW+kWLFimXIwaAL774QuWvbV0VFBRg69atGDp0KMaNGwdra2sUFRVhx44dOHnyJPbv3w+JRIJ9+/bh9ddfx9ChQ2FpaYnc3Fxs3rwZly5dwg8//IA+ffrUGNDp4uKC3r17o0uXLmjVqhWMjIxQWVmJO3fuYM+ePbh06RLWrl2L9evXQywWA3gyDiQoKEj51//IkSM1fhFv3rwZCQkJMDExwZQpUzBgwACYmZkhLy8PP/30E/744w8cPHgQrVq1qjXUAMCRI0cAAHPmzEFQUBDEYjEKCwuVoeG7775DRUUF/Pz8MGXKFLRv3x7Ak/EzWVlZiI2NrXGnhOhpDAxEaqSlpSn/7erqKng/FxcXxMbGQi6X48GDB2jdurXgfWNiYlBQUAAA8PDwqLXP9evX8de//lXjcaZPn672Frs20dHRuHTpksY+ixYtQseOHVVqAoCZM2fC09NT2W5iYoI2bdpg5MiRz1WLUGVlZRgwYACmT5+ubLOyssLs2bORlJSE7Oxs7Nq1C6+//jpee+01ZR87Ozu89957eOedd1BWVobz58+jb9++KseeNm1ajfMZGxvD3d0dH374If7xj38gNTUVMTExNfYV4saNG4iNjQUAzJgxAyEhIcpttra2mD17NkpKShAbG4uwsDD0799fGUyeJpfLsXjxYnTr1k3ZVv20Tn5+PrKysgA8CRR2dnbKPmKxGO3atUO7du10rp2aFw56JFKj+nY5oNtf+08/UllUVKS1v0KhwIMHD3D48GFs3rwZwJMv2iFDhtTav7KyEvn5+Rr/U15eLrjeZ1VUVGg9/uPHj1X2qX4kMjc397nPW1djxoyp0WZkZKScG8PU1BTDhg2r0cfS0lIZcu7evavTOY2MjODn5wcAuHbtmo4VPxEdHQ0AsLe3V/so7aRJkwA8uSbj4+Nr7dOuXTuVsPA0CwsL5Z0GQ/5vRC823mEgMoCTJ0/i5MmTtW4zNzfH3Llz0aZNm1q3P8+kTLp4nkmZAgMDcfz4cWzcuBHXr19Ht27d4ObmBjMzs3qqUpWVlZXaOzm2trYAAGdn5xrjCKpVPwKrLuAlJSXhxIkTuHHjBh4+fIiysrIafaoHQ+rq9u3bAJ7M0/D0uIanOTs7QyqV4tGjR7h9+3atweDpOz7PEovF6Ny5M+Lj4/Gvf/0LgwYNQmBgIFxdXWFiwq8BEoZXCpEaz94pkEqlgvYTcmfi6cmRRCIRzMzM4ODggE6dOmHgwIGwt7evQ+UN780330RmZiYSEhJw6NAhHDp0CEZGRnBxcUFgYCBCQkIE//f3PCwsLNRuq/4S1tSnepxJZWVljW3//e9/ceDAAZXjSSQS5RetXC5HWVlZrSFCiPz8fADQ+t+Pvb09Hj16pOz/LE1P8ADArFmzsHLlSqSmpmLv3r3Yu3cvTExM4Obmhu7du9d4XJjoWQwMRGo8PT3z7du3BX/h3blzB8D/pnuuTWObHKmuJBIJli5dimvXruH8+fO4fv06bt++rfzPgQMHMGvWLPTp08fQpeokPj5eGRYGDx6MwYMHw9nZWeVOwO7du7Fv3z6VQZ2GoO7uRDUHBwesXLkS8fHxkMlkuH79OlJTU3H9+nVcv34dP//8MxYuXKh1enNqvhgYiNTw8fGBSCSCQqFAbGys2t+HnyaXy3HlyhUAQKdOnXR+QuJF5+XlpXy8sLy8HPHx8di9ezfu3r2LzZs3w9fXV/kTwYvg7NmzAAA/Pz+8/fbbtfbJy8ur0zlsbGyQkZGhMu14baq3a5pBVBsjIyP4+/vD398fAFBaWooLFy7gxx9/RE5ODtatW4fNmzfzZwqqFQc9EqlhZ2eH7t27A3gyMC0jI0PrPocOHVLOn6Du8bfmQiwWo1u3bli0aBGAJ4Mpnx4YqO0v4sag+kta3VMyCoVCOXdCbZ6eB0GdDh06AHjyGG9VVVWtfdLT05VjJNzc3LQeUygLCwv06dMHs2bNAvDk5xFdB35S89H4/x9LZECTJk2CWCxGRUUF1qxZo3zksTYymQz79u0D8OTuxPNM2vQiqqysVPtFB0DlEcCnQ8LTYwqqJ3xqbKrHmaSmpta6/dixY8rHFWtT/R41vb/g4GAATwZNnjhxotY+YWFhAJ6Mq+ncubP2wp/x7FMtz3r6fyMhIYeaJwYGIg3atWuHWbNmwcjICHfv3sU//vEPnDhxQuULICMjAzt27MCXX36Jx48fo1WrVvj73//ebD54Hz58iL///e/Yu3cv7ty5ozJwMDU1FevXrwfwZNVJb29v5TaJRKIcF/LHH3/UOuDQ0Kpv3ctkMkREREAulwN4EgD27duHbdu2aVyZtHpyJJlMpvYpCnd3d+XEYNu2bcPvv/+uHECZl5eHb7/9FjExMQD+F2B1df36dSxatAiHDh1CWlqaMuApFApcv34d33//PYAnAytrW/CMCOAYBiKt+vTpAysrK+Xy1t9++y2+/fZbWFpaoqKiQjnVLvDkt+758+drHbFeF0ImbgKezOz3PIRM3OTg4IAvvvhC+TorKwthYWEICwuDkZERLC0tIZfLlX/ZmpiYYO7cuTVG4Q8aNAhhYWH4/fffcfz4cVhbW8PIyAgeHh547733nqt+ferbty9OnjyJpKQk7NmzB+Hh4bC0tERJSQkUCgUCAwPh4uKivLP0rH79+uHgwYPIzMzE7NmzYW1trfzC/+yzz5RPw8yePRuFhYVITEzEtm3bsGPHDpibmyvPAwAjR46s089cd+/exc6dO7Fz504YGxsr30d1ULOwsMC77777QvxURIbBwEAkgL+/P9avX4+oqChcuHABqampKCwshImJifJxyODg4Oe6Xayr6omb6kv1xE2aPP1XrlQqxeLFi5GQkIDk5GTlo3/GxsZo3bo1fHx8MGzYsFrnlRg7diwsLCxw+vRp5e/0CoVC7dMlDc3ExAQfffQRfvnlF5w9e1Y5bbe7uzv69euHkJCQGotKPa1NmzZYunQpfvnlF9y4cUO5tgSg+ginpaUlPv30U+XiUykpKZDL5bC1tYWnpyeGDh2qdvEpIdzc3PD+++8jISEBN2/eRG5uLgoKCmBqaop27dqhS5cuGDZsWL0++kovPpHC0M8CERERUaPHe09ERESkFQMDERERacXAQERERFoxMBAREZFWDAxERESkFQMDERERacXAQERERFoxMBAREZFWDAxERESkFQMDERERafX/AO4b3cuG9lpgAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 576x432 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# estimate the policy value of uniform random evaluation policy\n",
-    "estimated_policy_value_a, estimated_interval_a = ope.summarize_off_policy_estimates(\n",
-    "    evaluation_policy_pscore=random_behavior_feedback[\"pscore\"],\n",
-    "    evaluation_policy_pscore_item_position=random_behavior_feedback[\"pscore_item_position\"],\n",
-    "    evaluation_policy_pscore_cascade=random_behavior_feedback[\"pscore_cascade\"],\n",
+    "_, estimated_interval_random = ope.summarize_off_policy_estimates(\n",
+    "    evaluation_policy_pscore=random_policy_pscores[0],\n",
+    "    evaluation_policy_pscore_item_position=random_policy_pscores[1],\n",
+    "    evaluation_policy_pscore_cascade=random_policy_pscores[2],\n",
     "    alpha=0.05,\n",
-    "    n_bootstrap_samples=100,\n",
-    "    random_state=12345\n",
+    "    n_bootstrap_samples=1000,\n",
+    "    random_state=random_behavior_dataset.random_state,\n",
     ")\n",
-    "print(estimated_interval_a, '\\n')\n",
-    "# visualize estimated policy values of random evaluation policy by the three OPE estimators\n",
+    "estimated_interval_random[\"policy_name\"] = \"random\"\n",
+    "\n",
+    "print(estimated_interval_random, '\\n')\n",
+    "# visualize estimated policy values of Uniform Random by the three OPE estimators\n",
     "# and their 95% confidence intervals (estimated by nonparametric bootstrap method)\n",
     "ope.visualize_off_policy_estimates(\n",
-    "    evaluation_policy_pscore=random_behavior_feedback[\"pscore\"],\n",
-    "    evaluation_policy_pscore_item_position=random_behavior_feedback[\"pscore_item_position\"],\n",
-    "    evaluation_policy_pscore_cascade=random_behavior_feedback[\"pscore_cascade\"],\n",
+    "    evaluation_policy_pscore=random_policy_pscores[0],\n",
+    "    evaluation_policy_pscore_item_position=random_policy_pscores[1],\n",
+    "    evaluation_policy_pscore_cascade=random_policy_pscores[2],\n",
     "    alpha=0.05,\n",
-    "    n_bootstrap_samples=100, # number of resampling performed in the bootstrap procedure\n",
-    "    random_state=12345,\n",
+    "    n_bootstrap_samples=1000, # number of resampling performed in the bootstrap procedure\n",
+    "    random_state=random_behavior_dataset.random_state,\n",
     ")"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "We can observe that the variance of the three estimators is as follows: `sips > rips > iips`."
+    "_, estimated_interval_optimal = ope.summarize_off_policy_estimates(\n",
+    "    evaluation_policy_pscore=optimal_policy_pscores[0],\n",
+    "    evaluation_policy_pscore_item_position=optimal_policy_pscores[1],\n",
+    "    evaluation_policy_pscore_cascade=optimal_policy_pscores[2],\n",
+    "    alpha=0.05,\n",
+    "    n_bootstrap_samples=1000,\n",
+    "    random_state=random_behavior_dataset.random_state,\n",
+    ")\n",
+    "\n",
+    "estimated_interval_optimal[\"policy_name\"] = \"optimal\"\n",
+    "\n",
+    "print(estimated_interval_optimal, '\\n')\n",
+    "# visualize estimated policy values of Optimal by the three OPE estimators\n",
+    "# and their 95% confidence intervals (estimated by nonparametric bootstrap method)\n",
+    "ope.visualize_off_policy_estimates(\n",
+    "    evaluation_policy_pscore=optimal_policy_pscores[0],\n",
+    "    evaluation_policy_pscore_item_position=optimal_policy_pscores[1],\n",
+    "    evaluation_policy_pscore_cascade=optimal_policy_pscores[2],\n",
+    "    alpha=0.05,\n",
+    "    n_bootstrap_samples=1000, # number of resampling performed in the bootstrap procedure\n",
+    "    random_state=random_behavior_dataset.random_state,\n",
+    ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_, estimated_interval_anti_optimal = ope.summarize_off_policy_estimates(\n",
+    "    evaluation_policy_pscore=anti_optimal_policy_pscores[0],\n",
+    "    evaluation_policy_pscore_item_position=anti_optimal_policy_pscores[1],\n",
+    "    evaluation_policy_pscore_cascade=anti_optimal_policy_pscores[2],\n",
+    "    alpha=0.05,\n",
+    "    n_bootstrap_samples=1000,\n",
+    "    random_state=random_behavior_dataset.random_state,\n",
+    ")\n",
+    "estimated_interval_anti_optimal[\"policy_name\"] = \"anti-optimal\"\n",
+    "\n",
+    "print(estimated_interval_anti_optimal, '\\n')\n",
+    "# visualize estimated policy values of Anti-optimal by the three OPE estimators\n",
+    "# and their 95% confidence intervals (estimated by nonparametric bootstrap method)\n",
+    "ope.visualize_off_policy_estimates(\n",
+    "    evaluation_policy_pscore=anti_optimal_policy_pscores[0],\n",
+    "    evaluation_policy_pscore_item_position=anti_optimal_policy_pscores[1],\n",
+    "    evaluation_policy_pscore_cascade=anti_optimal_policy_pscores[2],\n",
+    "    alpha=0.05,\n",
+    "    n_bootstrap_samples=1000, # number of resampling performed in the bootstrap procedure\n",
+    "    random_state=random_behavior_dataset.random_state,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -322,873 +437,204 @@
     "## (4) Evaluation of OPE estimators\n",
     "Our final step is **the evaluation of OPE**, which evaluates and compares the estimation accuracy of OPE estimators.\n",
     "\n",
-    "First, we can obtain the policy value of the evaluation policy as follows."
+    "With synthetic slate data, we can calculate the policy value of the evaluation policies. \n",
+    "Therefore, we can compare the policy values estimated by OPE estimators with the ground-turths to evaluate the accuracy of OPE."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "policy value of Behavior policy: 1.894\n",
-      "policy value of Evaluation policy (Uniform Random): 1.858\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# we first calculate the policy values of the three evaluation policies using the expected rewards of the test data\n",
-    "policy_names = [\"Behavior policy\", \"Evaluation policy (Uniform Random)\"]\n",
-    "bandit_feedbacks = [bandit_feedback_test, random_behavior_feedback]\n",
+    "gt_random = random_behavior_dataset.calc_ground_truth_policy_value(\n",
+    "    context=random_behavior_feedback[\"context\"],\n",
+    "    evaluation_policy_logit_=random_policy_logit_\n",
+    ")\n",
+    "gt_random"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gt_optimal = random_behavior_dataset.calc_ground_truth_policy_value(\n",
+    "    context=random_behavior_feedback[\"context\"],\n",
+    "    evaluation_policy_logit_=optimal_policy_logit_\n",
+    ")\n",
+    "gt_optimal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gt_anti_optimal = random_behavior_dataset.calc_ground_truth_policy_value(\n",
+    "    context=random_behavior_feedback[\"context\"],\n",
+    "    evaluation_policy_logit_=anti_optimal_policy_logit_\n",
+    ")\n",
+    "gt_anti_optimal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimated_interval_random[\"ground_truth\"] = gt_random\n",
+    "estimated_interval_optimal[\"ground_truth\"] = gt_optimal\n",
+    "estimated_interval_anti_optimal[\"ground_truth\"] = gt_anti_optimal\n",
     "\n",
-    "for name, feedback in zip(policy_names, bandit_feedbacks):\n",
-    "    true_policy_value = feedback[\"reward\"].sum() / np.unique(feedback[\"slate_id\"]).shape[0]\n",
-    "    print(f'policy value of {name}: {true_policy_value}')"
+    "estimated_intervals = pd.concat(\n",
+    "    [\n",
+    "        estimated_interval_random,\n",
+    "        estimated_interval_optimal,\n",
+    "        estimated_interval_anti_optimal\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimated_intervals"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the above policy values, we evaluate the estimation accuracy of the OPE estimators."
+    "We can confirm that the three OPE estimators return the same results when the behavior policy and the evaluation policy is the same, and the estimates are quite similar to the `random_policy_value` calcurated above.\n",
+    "\n",
+    "We can also observe that the performance of OPE estimators are as follows in this simulation: `IIPS > RIPS > SIPS`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>relative-ee</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.019897</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.003781</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.012113</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "      relative-ee\n",
-       "sips     0.019897\n",
-       "iips     0.003781\n",
-       "rips     0.012113"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# evaluate the estimation performances of OPE estimators \n",
-    "# by comparing the estimated policy values of random policy and its ground-truth.\n",
+    "# by comparing the estimated policy values and its ground-truth.\n",
     "# `summarize_estimators_comparison` returns a pandas dataframe containing estimation performances of given estimators \n",
-    "relative_ee_for_random = ope.summarize_estimators_comparison(\n",
-    "    ground_truth_policy_value=random_behavior_feedback[\"reward\"].sum() / np.unique(random_behavior_feedback[\"slate_id\"]).shape[0],\n",
-    "    evaluation_policy_pscore=random_behavior_feedback[\"pscore\"],\n",
-    "    evaluation_policy_pscore_item_position=random_behavior_feedback[\"pscore_item_position\"],\n",
-    "    evaluation_policy_pscore_cascade=random_behavior_feedback[\"pscore_cascade\"],    \n",
-    "    metric=\"relative-ee\", # \"relative-ee\" (relative estimation error) or \"se\" (squared error)\n",
+    "\n",
+    "relative_ee_for_random_evaluation_policy = ope.summarize_estimators_comparison(\n",
+    "    ground_truth_policy_value=gt_random,\n",
+    "    evaluation_policy_pscore=random_policy_pscores[0],\n",
+    "    evaluation_policy_pscore_item_position=random_policy_pscores[1],\n",
+    "    evaluation_policy_pscore_cascade=random_policy_pscores[2],\n",
     ")\n",
+    "relative_ee_for_random_evaluation_policy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# evaluate the estimation performances of OPE estimators \n",
+    "# by comparing the estimated policy values and its ground-truth.\n",
+    "# `summarize_estimators_comparison` returns a pandas dataframe containing estimation performances of given estimators \n",
     "\n",
-    "# estimation performances of the three estimators (lower means accurate)\n",
-    "relative_ee_for_random"
+    "relative_ee_for_optimal_evaluation_policy = ope.summarize_estimators_comparison(\n",
+    "    ground_truth_policy_value=gt_optimal,\n",
+    "    evaluation_policy_pscore=optimal_policy_pscores[0],\n",
+    "    evaluation_policy_pscore_item_position=optimal_policy_pscores[1],\n",
+    "    evaluation_policy_pscore_cascade=optimal_policy_pscores[2],\n",
+    ")\n",
+    "relative_ee_for_optimal_evaluation_policy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# evaluate the estimation performances of OPE estimators \n",
+    "# by comparing the estimated policy values and its ground-truth.\n",
+    "# `summarize_estimators_comparison` returns a pandas dataframe containing estimation performances of given estimators \n",
+    "\n",
+    "relative_ee_for_anti_optimal_evaluation_policy = ope.summarize_estimators_comparison(\n",
+    "    ground_truth_policy_value=gt_anti_optimal,\n",
+    "    evaluation_policy_pscore=anti_optimal_policy_pscores[0],\n",
+    "    evaluation_policy_pscore_item_position=anti_optimal_policy_pscores[1],\n",
+    "    evaluation_policy_pscore_cascade=anti_optimal_policy_pscores[2],\n",
+    ")\n",
+    "relative_ee_for_anti_optimal_evaluation_policy"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can observe that the performance of three estimators is as follows: `iips > rips > sips`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## (5) Advanced Evaluation of OPE Estimators using various types of reward assumptions\n",
-    "\n",
-    "The performance of the OPE estimators is expected to depend on the reward assumptions as follows.\n",
-    "\n",
-    "1. When reward structure is cascade, RIPS should be the most accurate estimator of the three.\n",
-    "2. When reward structure is independent, IIPS should be the most accurate estimator of the three.\n",
-    "\n",
-    "The first hypothesis was observed in the previous section."
+    "The variance of OPE estimators is as follows: `SIPS > RIPS > IIPS`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "reward_structures = ['cascade_additive', 'cascade_exponential', 'independent', 'standard_additive',  'standard_exponential']\n",
-    "click_models = [None, 'pbm', 'cascade']"
+    "estimated_intervals[\"errbar_length\"] = (\n",
+    "    estimated_intervals.drop([\"mean\", \"policy_name\", \"ground_truth\"], axis=1).diff(axis=1).iloc[:, -1].abs()\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cascade_additive None\n",
-      "cascade_additive pbm\n",
-      "cascade_additive cascade\n",
-      "cascade_exponential None\n",
-      "cascade_exponential pbm\n",
-      "cascade_exponential cascade\n",
-      "independent None\n",
-      "independent pbm\n",
-      "independent cascade\n",
-      "standard_additive None\n",
-      "standard_additive pbm\n",
-      "standard_additive cascade\n",
-      "standard_exponential None\n",
-      "standard_exponential pbm\n",
-      "standard_exponential cascade\n"
-     ]
-    }
-   ],
-   "source": [
-    "for i, j in product(reward_structures, click_models[:]):\n",
-    "    print(i, j)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:16<00:00, 59.47it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [01:06<00:00, 14.97it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:16<00:00, 59.94it/s]\n",
-      "[sample_reward_of_cascade_model]: 100%|██████████| 1000/1000 [00:00<00:00, 239155.21it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:17<00:00, 56.71it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:16<00:00, 59.21it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:16<00:00, 60.19it/s]\n",
-      "[sample_reward_of_cascade_model]: 100%|██████████| 1000/1000 [00:00<00:00, 433340.63it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:16<00:00, 59.77it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:15<00:00, 63.50it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:16<00:00, 61.00it/s]\n",
-      "[sample_reward_of_cascade_model]: 100%|██████████| 1000/1000 [00:00<00:00, 263163.76it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:18<00:00, 53.19it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:17<00:00, 55.67it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:18<00:00, 53.81it/s]\n",
-      "[sample_reward_of_cascade_model]: 100%|██████████| 1000/1000 [00:00<00:00, 370325.27it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:16<00:00, 62.19it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:15<00:00, 63.14it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:16<00:00, 60.59it/s]\n",
-      "[sample_reward_of_cascade_model]: 100%|██████████| 1000/1000 [00:00<00:00, 466241.00it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# generate a synthetic bandit dataset with 10 actions\n",
-    "# we use `logistic_reward_function` as the base reward function and `linear_behavior_policy_logit` as the behavior policy.\n",
-    "# we generate dataset with various types of reward structures and click models.\n",
-    "\n",
-    "bandit_feedbacks = []\n",
-    "\n",
-    "for reward_structure, click_model in product(reward_structures, click_models):\n",
-    "    dataset_ = SyntheticSlateBanditDataset(\n",
-    "        n_unique_action=n_unique_action,\n",
-    "        len_list=len_list,\n",
-    "        dim_context=dim_context,\n",
-    "        reward_type=reward_type, # 'binary' or 'continuous'\n",
-    "        reward_structure=reward_structure, # 'cascade_additive', 'cascade_exponential', 'independent', 'standard_additive', or 'standard_exponential'\n",
-    "        click_model=click_model, # None, 'pbm', or 'cascade'\n",
-    "        random_state=random_state,\n",
-    "        behavior_policy_function=behavior_policy_function,\n",
-    "        base_reward_function=base_reward_function,\n",
-    "    )\n",
-    "    # obtain training and test sets of synthetic logged bandit feedback\n",
-    "    n_rounds_test = 1000\n",
-    "    bandit_feedback_test_ = dataset_.obtain_batch_bandit_feedback(n_rounds=n_rounds_test, return_pscore_item_position=True)\n",
-    "    bandit_feedback_test_[\"reward_structure\"] = reward_structure\n",
-    "    bandit_feedback_test_[\"click_model\"] = click_model\n",
-    "\n",
-    "    # `bandit_feedback` is a dictionary storing synthetic logged bandit feedback\n",
-    "    bandit_feedbacks.append(deepcopy(bandit_feedback_test_))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "15"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(bandit_feedbacks)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 2946.23it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 3424.42it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 3248.63it/s]\n",
-      "[sample_reward_of_cascade_model]: 100%|██████████| 1000/1000 [00:00<00:00, 188847.55it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 3294.79it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 3400.24it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 2594.03it/s]\n",
-      "[sample_reward_of_cascade_model]: 100%|██████████| 1000/1000 [00:00<00:00, 237180.73it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 2608.62it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 3245.02it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 3280.31it/s]\n",
-      "[sample_reward_of_cascade_model]: 100%|██████████| 1000/1000 [00:00<00:00, 234961.85it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 2607.40it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 3245.91it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 3348.12it/s]\n",
-      "[sample_reward_of_cascade_model]: 100%|██████████| 1000/1000 [00:00<00:00, 353740.74it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 2394.11it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 2071.67it/s]\n",
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 1000/1000 [00:00<00:00, 2647.27it/s]\n",
-      "[sample_reward_of_cascade_model]: 100%|██████████| 1000/1000 [00:00<00:00, 337868.86it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# evaluate the estimation performances of OPE estimators with various types of reward assumptions\n",
-    "# by comparing the estimated policy values of random policy and its ground-truth.\n",
-    "# `summarize_estimators_comparison` returns a pandas dataframe containing estimation performances of given estimators.\n",
-    "\n",
-    "estimated_policy_value_df = pd.DataFrame()\n",
-    "\n",
-    "for feedback in bandit_feedbacks:\n",
-    "    ope_ = SlateOffPolicyEvaluation(\n",
-    "        bandit_feedback=feedback,\n",
-    "        ope_estimators=[sips, iips, rips]\n",
-    "    )\n",
-    "    # define Uniform Random Policy as a baseline evaluation policy\n",
-    "    random_behavior_dataset_ = SyntheticSlateBanditDataset(\n",
-    "        n_unique_action=n_unique_action,\n",
-    "        len_list=len_list,\n",
-    "        dim_context=dim_context,\n",
-    "        reward_type=reward_type,\n",
-    "        reward_structure=feedback[\"reward_structure\"],\n",
-    "        click_model=feedback[\"click_model\"],\n",
-    "        random_state=random_state,\n",
-    "        behavior_policy_function=None,\n",
-    "        base_reward_function=base_reward_function,\n",
-    "    )\n",
-    "\n",
-    "    # compute the factual action choice probabililties for the test set of the synthetic logged bandit feedback\n",
-    "    random_behavior_feedback_ = random_behavior_dataset_.obtain_batch_bandit_feedback(\n",
-    "        n_rounds=n_rounds_test,\n",
-    "        return_pscore_item_position=True,\n",
-    "    )\n",
-    "    relative_ee_for_random = ope_.summarize_estimators_comparison(\n",
-    "        ground_truth_policy_value=random_behavior_feedback_[\"reward\"].sum() / np.unique(random_behavior_feedback_[\"slate_id\"]).shape[0],\n",
-    "        evaluation_policy_pscore=random_behavior_feedback_[\"pscore\"],\n",
-    "        evaluation_policy_pscore_item_position=random_behavior_feedback_[\"pscore_item_position\"],\n",
-    "        evaluation_policy_pscore_cascade=random_behavior_feedback_[\"pscore_cascade\"],    \n",
-    "        metric=\"relative-ee\", # \"relative-ee\" (relative estimation error) or \"se\" (squared error)\n",
-    "    )\n",
-    "\n",
-    "    # estimation performances of the three estimators (lower means accurate)\n",
-    "    relative_ee_for_random\n",
-    "    relative_ee_for_random[\"reward_structure\"] = feedback[\"reward_structure\"]\n",
-    "    relative_ee_for_random[\"click_model\"] = feedback[\"click_model\"]\n",
-    "    estimated_policy_value_df = pd.concat([estimated_policy_value_df, relative_ee_for_random])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "estimated_policy_value_df[\"reward_assumption\"] =\\\n",
-    "    estimated_policy_value_df[\"reward_structure\"] + \"_\" + estimated_policy_value_df[\"click_model\"].fillna(\"None\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>relative-ee</th>\n",
-       "      <th>reward_structure</th>\n",
-       "      <th>click_model</th>\n",
-       "      <th>reward_assumption</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.019897</td>\n",
-       "      <td>cascade_additive</td>\n",
-       "      <td>None</td>\n",
-       "      <td>cascade_additive_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.003781</td>\n",
-       "      <td>cascade_additive</td>\n",
-       "      <td>None</td>\n",
-       "      <td>cascade_additive_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.012113</td>\n",
-       "      <td>cascade_additive</td>\n",
-       "      <td>None</td>\n",
-       "      <td>cascade_additive_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.009804</td>\n",
-       "      <td>cascade_additive</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>cascade_additive_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.006740</td>\n",
-       "      <td>cascade_additive</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>cascade_additive_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.003346</td>\n",
-       "      <td>cascade_additive</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>cascade_additive_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.024432</td>\n",
-       "      <td>cascade_additive</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>cascade_additive_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.031846</td>\n",
-       "      <td>cascade_additive</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>cascade_additive_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.021359</td>\n",
-       "      <td>cascade_additive</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>cascade_additive_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.026002</td>\n",
-       "      <td>cascade_exponential</td>\n",
-       "      <td>None</td>\n",
-       "      <td>cascade_exponential_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.015134</td>\n",
-       "      <td>cascade_exponential</td>\n",
-       "      <td>None</td>\n",
-       "      <td>cascade_exponential_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.032554</td>\n",
-       "      <td>cascade_exponential</td>\n",
-       "      <td>None</td>\n",
-       "      <td>cascade_exponential_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.019743</td>\n",
-       "      <td>cascade_exponential</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>cascade_exponential_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.014953</td>\n",
-       "      <td>cascade_exponential</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>cascade_exponential_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.016810</td>\n",
-       "      <td>cascade_exponential</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>cascade_exponential_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.012319</td>\n",
-       "      <td>cascade_exponential</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>cascade_exponential_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.004510</td>\n",
-       "      <td>cascade_exponential</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>cascade_exponential_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.017700</td>\n",
-       "      <td>cascade_exponential</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>cascade_exponential_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.014014</td>\n",
-       "      <td>independent</td>\n",
-       "      <td>None</td>\n",
-       "      <td>independent_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.005931</td>\n",
-       "      <td>independent</td>\n",
-       "      <td>None</td>\n",
-       "      <td>independent_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.020076</td>\n",
-       "      <td>independent</td>\n",
-       "      <td>None</td>\n",
-       "      <td>independent_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.020100</td>\n",
-       "      <td>independent</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>independent_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.017146</td>\n",
-       "      <td>independent</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>independent_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.019755</td>\n",
-       "      <td>independent</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>independent_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.017512</td>\n",
-       "      <td>independent</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>independent_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.010501</td>\n",
-       "      <td>independent</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>independent_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.021702</td>\n",
-       "      <td>independent</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>independent_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.012963</td>\n",
-       "      <td>standard_additive</td>\n",
-       "      <td>None</td>\n",
-       "      <td>standard_additive_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.015505</td>\n",
-       "      <td>standard_additive</td>\n",
-       "      <td>None</td>\n",
-       "      <td>standard_additive_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.009082</td>\n",
-       "      <td>standard_additive</td>\n",
-       "      <td>None</td>\n",
-       "      <td>standard_additive_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.003356</td>\n",
-       "      <td>standard_additive</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>standard_additive_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.014512</td>\n",
-       "      <td>standard_additive</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>standard_additive_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.004365</td>\n",
-       "      <td>standard_additive</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>standard_additive_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.023264</td>\n",
-       "      <td>standard_additive</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>standard_additive_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.030946</td>\n",
-       "      <td>standard_additive</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>standard_additive_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.022853</td>\n",
-       "      <td>standard_additive</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>standard_additive_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.020141</td>\n",
-       "      <td>standard_exponential</td>\n",
-       "      <td>None</td>\n",
-       "      <td>standard_exponential_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.006611</td>\n",
-       "      <td>standard_exponential</td>\n",
-       "      <td>None</td>\n",
-       "      <td>standard_exponential_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.021864</td>\n",
-       "      <td>standard_exponential</td>\n",
-       "      <td>None</td>\n",
-       "      <td>standard_exponential_None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.018715</td>\n",
-       "      <td>standard_exponential</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>standard_exponential_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.002871</td>\n",
-       "      <td>standard_exponential</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>standard_exponential_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.006106</td>\n",
-       "      <td>standard_exponential</td>\n",
-       "      <td>pbm</td>\n",
-       "      <td>standard_exponential_pbm</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sips</th>\n",
-       "      <td>0.013323</td>\n",
-       "      <td>standard_exponential</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>standard_exponential_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>iips</th>\n",
-       "      <td>0.000629</td>\n",
-       "      <td>standard_exponential</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>standard_exponential_cascade</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rips</th>\n",
-       "      <td>0.012978</td>\n",
-       "      <td>standard_exponential</td>\n",
-       "      <td>cascade</td>\n",
-       "      <td>standard_exponential_cascade</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "      relative-ee      reward_structure click_model  \\\n",
-       "sips     0.019897      cascade_additive        None   \n",
-       "iips     0.003781      cascade_additive        None   \n",
-       "rips     0.012113      cascade_additive        None   \n",
-       "sips     0.009804      cascade_additive         pbm   \n",
-       "iips     0.006740      cascade_additive         pbm   \n",
-       "rips     0.003346      cascade_additive         pbm   \n",
-       "sips     0.024432      cascade_additive     cascade   \n",
-       "iips     0.031846      cascade_additive     cascade   \n",
-       "rips     0.021359      cascade_additive     cascade   \n",
-       "sips     0.026002   cascade_exponential        None   \n",
-       "iips     0.015134   cascade_exponential        None   \n",
-       "rips     0.032554   cascade_exponential        None   \n",
-       "sips     0.019743   cascade_exponential         pbm   \n",
-       "iips     0.014953   cascade_exponential         pbm   \n",
-       "rips     0.016810   cascade_exponential         pbm   \n",
-       "sips     0.012319   cascade_exponential     cascade   \n",
-       "iips     0.004510   cascade_exponential     cascade   \n",
-       "rips     0.017700   cascade_exponential     cascade   \n",
-       "sips     0.014014           independent        None   \n",
-       "iips     0.005931           independent        None   \n",
-       "rips     0.020076           independent        None   \n",
-       "sips     0.020100           independent         pbm   \n",
-       "iips     0.017146           independent         pbm   \n",
-       "rips     0.019755           independent         pbm   \n",
-       "sips     0.017512           independent     cascade   \n",
-       "iips     0.010501           independent     cascade   \n",
-       "rips     0.021702           independent     cascade   \n",
-       "sips     0.012963     standard_additive        None   \n",
-       "iips     0.015505     standard_additive        None   \n",
-       "rips     0.009082     standard_additive        None   \n",
-       "sips     0.003356     standard_additive         pbm   \n",
-       "iips     0.014512     standard_additive         pbm   \n",
-       "rips     0.004365     standard_additive         pbm   \n",
-       "sips     0.023264     standard_additive     cascade   \n",
-       "iips     0.030946     standard_additive     cascade   \n",
-       "rips     0.022853     standard_additive     cascade   \n",
-       "sips     0.020141  standard_exponential        None   \n",
-       "iips     0.006611  standard_exponential        None   \n",
-       "rips     0.021864  standard_exponential        None   \n",
-       "sips     0.018715  standard_exponential         pbm   \n",
-       "iips     0.002871  standard_exponential         pbm   \n",
-       "rips     0.006106  standard_exponential         pbm   \n",
-       "sips     0.013323  standard_exponential     cascade   \n",
-       "iips     0.000629  standard_exponential     cascade   \n",
-       "rips     0.012978  standard_exponential     cascade   \n",
-       "\n",
-       "                 reward_assumption  \n",
-       "sips         cascade_additive_None  \n",
-       "iips         cascade_additive_None  \n",
-       "rips         cascade_additive_None  \n",
-       "sips          cascade_additive_pbm  \n",
-       "iips          cascade_additive_pbm  \n",
-       "rips          cascade_additive_pbm  \n",
-       "sips      cascade_additive_cascade  \n",
-       "iips      cascade_additive_cascade  \n",
-       "rips      cascade_additive_cascade  \n",
-       "sips      cascade_exponential_None  \n",
-       "iips      cascade_exponential_None  \n",
-       "rips      cascade_exponential_None  \n",
-       "sips       cascade_exponential_pbm  \n",
-       "iips       cascade_exponential_pbm  \n",
-       "rips       cascade_exponential_pbm  \n",
-       "sips   cascade_exponential_cascade  \n",
-       "iips   cascade_exponential_cascade  \n",
-       "rips   cascade_exponential_cascade  \n",
-       "sips              independent_None  \n",
-       "iips              independent_None  \n",
-       "rips              independent_None  \n",
-       "sips               independent_pbm  \n",
-       "iips               independent_pbm  \n",
-       "rips               independent_pbm  \n",
-       "sips           independent_cascade  \n",
-       "iips           independent_cascade  \n",
-       "rips           independent_cascade  \n",
-       "sips        standard_additive_None  \n",
-       "iips        standard_additive_None  \n",
-       "rips        standard_additive_None  \n",
-       "sips         standard_additive_pbm  \n",
-       "iips         standard_additive_pbm  \n",
-       "rips         standard_additive_pbm  \n",
-       "sips     standard_additive_cascade  \n",
-       "iips     standard_additive_cascade  \n",
-       "rips     standard_additive_cascade  \n",
-       "sips     standard_exponential_None  \n",
-       "iips     standard_exponential_None  \n",
-       "rips     standard_exponential_None  \n",
-       "sips      standard_exponential_pbm  \n",
-       "iips      standard_exponential_pbm  \n",
-       "rips      standard_exponential_pbm  \n",
-       "sips  standard_exponential_cascade  \n",
-       "iips  standard_exponential_cascade  \n",
-       "rips  standard_exponential_cascade  "
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "estimated_policy_value_df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14]),\n",
-       " [Text(0, 0, 'cascade_additive_None'),\n",
-       "  Text(1, 0, 'cascade_additive_pbm'),\n",
-       "  Text(2, 0, 'cascade_additive_cascade'),\n",
-       "  Text(3, 0, 'cascade_exponential_None'),\n",
-       "  Text(4, 0, 'cascade_exponential_pbm'),\n",
-       "  Text(5, 0, 'cascade_exponential_cascade'),\n",
-       "  Text(6, 0, 'independent_None'),\n",
-       "  Text(7, 0, 'independent_pbm'),\n",
-       "  Text(8, 0, 'independent_cascade'),\n",
-       "  Text(9, 0, 'standard_additive_None'),\n",
-       "  Text(10, 0, 'standard_additive_pbm'),\n",
-       "  Text(11, 0, 'standard_additive_cascade'),\n",
-       "  Text(12, 0, 'standard_exponential_None'),\n",
-       "  Text(13, 0, 'standard_exponential_pbm'),\n",
-       "  Text(14, 0, 'standard_exponential_cascade')])"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhUAAAJgCAYAAAA9C5EMAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAADZ+0lEQVR4nOzdd1gU1/c/8PcunUWKIEqxAUGkW4NgJaiJGns32BMLMfoRNTGJYo0lMcbYorGholEQC5YYsWAMUgxgQ4KADVZUmnQW2P39wY/5srI0mdmhnNfz5IlMu7MLO3P2zrnnCmQymQyEEEIIIfUk5PsECCGEENI0UFBBCCGEEFZQUEEIIYQQVlBQQQghhBBWUFBBCCGEEFZQUEEIIYQQVlBQQQghhBBWqPJ9Ak2BWCzm+xQIIYQQpTA1Na1yHfVUEEIIIYQVFFQQQgghhBUUVBBCCCGEFZRTQQghhNSDTCZDYWEhpFIpBAIB36fDCplMBqFQCE1NzTq9JgoqCCGEkHooLCyEmpoaVFWb1i21pKQEhYWF0NLSqvU+9PiDEEIIqQepVNrkAgoAUFVVhVQqrdM+FFQQQggh9dBUHnkoUtfXRkEFIYQQwpPhw4fXafvQ0FBMnTqVo7OpPwoqCCGEEJ6cO3eO71NgFQUVhBBCCE8++OADAGU9EGPHjsXnn3+Ovn374ssvv4RMJgMAXL9+HX379sXgwYNx6dIlZt/8/HwsXrwYQ4cOxaBBg3D58mUAwMqVK7F161YAwI0bNzB69Og650a8r6aXWUIIIYQ0Qg8ePMC1a9fQpk0bjBgxApGRkXB0dMTSpUtx8uRJdOzYEXPnzmW237ZtG9zc3PDzzz/j7du3GDp0KPr06YPly5djyJAh6NmzJ1asWIEjR45AKFROHwL1VBBCCCENgLOzM0xNTSEUCmFnZ4cXL14gISEB7dq1g4WFBQQCAcaMGcNsf/PmTezcuRMDBw7E2LFjUVRUhJSUFGhpaWHz5s2YNGkSZsyYgQ4dOijtNVBPBSGEENIAqKurM/9WUVFBSUlJtdvLZDLs3bsXVlZWldbFxcXBwMAAr169Yv08q0NBBWlWLp97We36wcNNlHQmhBBSMysrK7x48QJPnz5Fhw4dcObMGWZdv379cPDgQaxbtw4CgQAPHjyAvb09kpOTsWfPHly+fBmenp4YPHgwunbtqpTzpccfhBBCSAOlqamJzZs3Y+rUqRg8eDCMjIyYdYsWLUJxcTE8PDwwYMAAbN68GTKZDN7e3li5ciXatGmDLVu2YOnSpSgsLFTK+Qpk5eml5L2JxWK+T4HUEvVUEELYlp+fD21tbb5PgxOKXpupqWmV21NPBSGEEEJYQUEFIYQQQlhBQQUhhBBCWEFBBSGEEEJYQUNKCWem+96uct2hab2UeCaEEEKUgXoqCCGEEMIKCioIIYSQJmbJkiWIj49Xerv0+IMQQghh0culs1k9nsmP++q8z08//cTqOdQW9VQQQgghjVh+fj48PT3h4eEBd3d3nD17FmPHjsXdu3cBlE2v7uPjgwEDBmD8+PFIT08HAOzfvx/9+/eHh4cH5s2bx8q5UFBBCCGENGLXr19HmzZtEBwcjGvXrmHAgAFy6/Pz8+Hk5ITr16+jV69e+PnnnwEAO3fuxOXLlxEcHIyNGzeyci4UVBBCCCGNmI2NDW7evIn169cjPDwcurq6cuuFQiGGDx8OABg9ejQiIiIAAJ07d8aXX36JU6dOQVWVnWwICioIIYSQRszS0hJ//vknbGxssHnzZmzdurXa7QUCAQDg8OHDmD59Ou7fv48hQ4bUONV6bVBQQQghhDRiqamp0NLSwpgxYzB37lzcv39fbr1UKsWFCxcAAKdPn0bPnj0hlUohFovh5uaG7777Djk5OcjLy6v3udDoD0IIIbyqrlAeQMXyahIXF4d169ZBIBBATU0NGzZswNq1a5n12traiI6OxrZt22BoaIjffvsNpaWlWLBgAXJyciCTyTBz5kzo6enV+1woqCCEEEJY9D5DQOujf//+6N+/v9yygIAAuZ9XrVpVab8zZ86wfi70+IMQQgghrOC9pyI5ORkHDhxAfHw8RCIR3N3dMW7cOAiF1cc7+fn5OHToECIjIyGVStGtWzfMmDEDLVq0YLY5efIkwsPDkZaWBplMBlNTUwwfPhyurq51PhYhhBDSGD1+/FhpbfEaVOTm5mLt2rUwNzfHsmXLkJqaiiNHjkAmk2HixInV7rt161aIxWLMmTMHQqEQfn5++PHHH7FmzRpmm/z8fPTv3x/m5uYQCoUICwvDL7/8AqFQCBcXlzodixBCCCHV4zWouHLlCiQSCby9vaGtrQ1HR0cUFBTA398fw4cPh7a2tsL94uPjcffuXaxatQq2trYAgJYtW+Lbb7/FvXv34OjoCACYPn263H5OTk5ITk5GSEgIE1TU9liEEEIIqR6vORUxMTFwcnKSCx7c3NwgkUgQGxtb5X7R0dHQ09NjggAAsLKygrGxMWJiYqptU0dHR24sbn2ORQghhJD/w2tQkZKSAlNTU7llRkZG0NDQgFgsrnY/MzOzSsvNzMyQkpJSaXlpaSny8vLw999/4969exg4cOB7H4sQQgghivEaVOTl5UEkElVaLhKJkJubW+1+ih6NiESiSsU74uPjMWnSJMyYMQO7du3C9OnT0bNnz/c6FiGEENIQlZfhTk1Nxeeff87befA++oNr7dq1w4YNG5CXl4eoqCgcOHAAWlpa6N2793sfMzg4GMHBwQCAjRs3wsjIiK3TbTb4e89eVruWfpeENDwN/XP56tUrubkzPtv/N6vHPzqrT43bXLx4EQBgbm6OgwcPsta2hoZGnd5/XoMKkUiE/Pz8Ssvz8vKgo6NT7X45OTkK93u350NTUxOWlpYAAEdHR+Tn58PPz48JKupyrHIeHh7w8PBgfk5LS6vyXIliDfU9a6jnRUhz1tA/l0VFRVBRUeHs+LWZk+ODDz7A48eP8eLFC0ybNg3Xrl3DiRMn8OeffyInJwcvX77EmDFjsHjxYuTn52POnDl4+fIlpFIpFi5ciBEjRig8blFRUaX3/920hYp4DSoU5S2kpaWhqKio2pM2MzPD1atXKy0Xi8Xo0aNHtW1aWFjgxo0bKC0thYqKSr2ORQghhDRkMTExuHr1KrS0tDB06FB89NFHSE5ORps2bXDkyBEAQHZ2Nmvt8ZpT4ezsjLt376KgoIBZFhoaCnV1dbnRGO/q0qULsrKyEBcXxyxLTEzEq1ev4OzsXG2bcXFxMDQ0ZKLK+hyLEEIIacj69OmDli1bQktLC5988gkiIiJqnCq9PnjtqRg4cCAuXbqEn376CSNGjMDr16/h7++PYcOGySVPLliwALa2tpg3bx4AwNraGk5OTtixYwc8PT0hEAjg5+cHGxsbpq7EmzdvsHv3bri6uqJNmzYoLCxEREQEQkNDMXv2bObYtTkWIYQQ0hiVT3Ne8efyqdKvXbuGzZs3o3fv3vjf//7HSnu8BhU6OjpYuXIl9u/fj02bNkEkEmHo0KEYP3683HZSqRRSqVRu2aJFi+Dr64vdu3dDJpOha9eumDFjBrNeJBLBwMAAp0+fRlZWFrS1tWFubo5vvvkGXbt2rdOxCCGEkMbo77//RmZmJjQ1NXH58mVs2bIFqamp0NfXx5gxY6Crq4vjx4+z1h7voz/Mzc3h4+NT7TY7d+6stEwkEmH+/PmYP3++wn20tbWxYMGCWp1DTccihBBCGiNnZ2d8/vnnTKKmk5MTbty4UWmqdLbwHlQQQgghTcmhab2U3mb5pGFt27bFtWvXmOUmJiY4cOCA3LaKpkpnC019TgghhBBWUE8FIYQQ0gRNmDABEyZMUGqb1FNBCCGEEFZQUEEIIYQQVlBQQQghhBBWUFBBCCGEEFZQUEEIIYQ0MZ6ennj79q3S26XRH4QQQgiLLp97yerxBg83qdP2MpkMvr6+EAqV329AQQUhhBDSyL148QKTJ09Gly5dcP/+fcTHx+P+/fvIy8vDlClT4OjoiPv378Pa2hq//vortLS08MMPP+Cvv/6Cqqoq+vbti5UrV9b7POjxByGEENIEPHnyBNOmTcP169dhbm7OLE9MTMS0adMQEhKCFi1awNfXFxkZGbh06RKuX7+O4OBgLFy4kJVzoKCCEEIIaQLMzc3RrVu3SstNTU3Ro0cPAMDo0aMREREBXV1daGhowNvbGxcvXoSWlhYr50BBBSGEENIEaGtrK1yuaPpzVVVVXLhwAUOHDkVwcDCmTJnCyjlQTgUhhBDShKWkpODOnTvo3r07zpw5gx49eiAvLw8FBQX46KOP0KNHD/Tqxc4kaBRUEEIIIU2YpaUlfH194e3tDWtra0ybNg3Z2dmYOXMmioqKIJPJ4OPjw0pbFFQQQgghLKrrEFA2vDvleXh4OAAgLy8Pqqqq2L59u9z2WlpauHDhAuvnQTkVhBBCCGEFBRWEEEJIE/VuDwbXKKgghBBCCCsoqCCEEELqQSaT8X0KnKnra6OgghBCCKkHoVCIkpISvk+DdSUlJXWeP4RGfxBCCCH1oKmpicLCQhQVFVUqNNVYyWQyCIVCaGpq1mk/CioIIYSQehAIBKyVuW7s6PEHIYQQQlhBQQUhhBBCWEFBBSGEEEJYQUEFIYQQQlhBQQUhhBBCWEFBBSGEEEJYQUEFIYQQQlhBQQUhhBBCWEHFr0ij8nLp7GrXm/y4T0lnQggh5F3UU0EIIYQQVlBQQQghhBBWUFBBCCGEEFbwnlORnJyMAwcOID4+HiKRCO7u7hg3blyN063m5+fj0KFDiIyMhFQqRbdu3TBjxgy0aNECACCVSnHu3DlERUUhOTkZAGBhYYGJEyfCyspK7ljjx4+vdPwPPvgA69evZ+lVEkIIIU0fr0FFbm4u1q5dC3Nzcyxbtgypqak4cuQIZDIZJk6cWO2+W7duhVgsxpw5cyAUCuHn54cff/wRa9asAQBIJBKcPXsW/fv3x8iRIyEQCPDnn39i5cqVWLduHSwsLOSON2zYMLi4uDA/04xzhBBCSN3wGlRcuXIFEokE3t7e0NbWhqOjIwoKCuDv74/hw4dDW1tb4X7x8fG4e/cuVq1aBVtbWwBAy5Yt8e233+LevXtwdHSEuro6tm/fDh0dHWY/BwcHLFy4EH/++Sfmz58vd0xjY2NYW1tz92IJIYSQJo7XnIqYmBg4OTnJBQ9ubm6QSCSIjY2tcr/o6Gjo6ekxAQUAWFlZwdjYGDExMQAAoVAoF1AAgKqqKszNzZGZmcnuCyGEEEIIv0FFSkoKTE1N5ZYZGRlBQ0MDYrG42v3MzMwqLTczM0NKSkqV+xUXF+PJkycwMTGptM7f3x8TJ07ErFmzsGvXLuTm5tbhlRBCCCGE18cfeXl5EIlElZaLRKJqb+p5eXkKH42IRCK8fv26yv0CAwORm5uLjz/+WG55v3790K1bN+jq6iIpKQmnTp3Cs2fPsGHDhhoTRgkhhBBShvfRH8oSFRWFwMBATJ06tVLviJeXF/NvW1tbmJmZYcOGDbhz5w569uxZ6VjBwcEIDg4GAGzcuBFGRkbcnnwT9L7v2ct6H7f6I9DvkpCGhz6XjQevQYVIJEJ+fn6l5Xl5eZXyId7dLycnR+F+ino+EhISsHXrVgwcOBBDhw6t8bycnZ2hqamJJ0+eKAwqPDw84OHhwfyclpZW4zGJPK7es/oel36XhDQ89LlsWN79Yl4Rr337inIg0tLSUFRUVO1JV5U7IRaLK+VaiMVibNy4EQ4ODpg5c2atzksgEMj9nxBCCCE14zWocHZ2xt27d1FQUMAsCw0Nhbq6utzIjnd16dIFWVlZiIuLY5YlJibi1atXcHZ2ZpZlZmZi/fr1aN26NRYuXFjr/IiYmBgUFhZWqmVBCCGEkKrx+vhj4MCBuHTpEn766SeMGDECr1+/hr+/P4YNGyaXiLlgwQLY2tpi3rx5AABra2s4OTlhx44d8PT0hEAggJ+fH2xsbODo6AigrPjVDz/8gLy8PMyaNQvPnj1jjqempoaOHTsCKMuPSExMhIODA5OoGRgYCCsrK3Tt2lWJ7wYhhBDSuPEaVOjo6GDlypXYv38/Nm3aBJFIhKFDh1Yqmy2VSiGVSuWWLVq0CL6+vti9ezdkMhm6du2KGTNmMOuzsrKYQGLjxo1y+7Zq1Qo7d+4EALRu3RohISEIDw9HQUEB9PX10bdvX0ycOJFGftSgpmnIYT9LOSdCCCGkQeB99Ie5uTl8fHyq3aY8AKhIJBJh/vz5lSpjljM2NsbJkydrbN/BwQEODg61O1lCCCGEVIm+ihNCCCGEFRRUEEIIIYQVFFQQQgghhBUUVBBCCCGEFRRUEEIIIYQVFFQQQgghhBUUVBBCCCGEFRRUEEIIIYQVFFQQQgghhBW8V9QkhBDStFFJ/+aDeioIIYQQwgoKKgghhBDCCgoqCCGEEMIKyqkghBDSoF0+97La9YOHmyjpTEhNqKeCEEIIIaygoIIQQgghrHjvxx/Pnj3DrVu3kJKSgqKiIqxYsQIA8Pr1ayQkJMDR0RE6OjqsnSghhBBCGrb3CipOnDiB06dPQyaTVVonk8mwbds2TJ8+HZ988km9T5AQQgghjUOdH3/8888/CAwMhKOjIzZv3oyRI0fKrW/dujUsLS1x584dts6REEIIIY1AnYOKS5cuoU2bNli2bBnat28PVdXKnR1mZmZITU1l5QQJIYQQ0jjUOah4/vw5nJycFAYT5QwMDJCVlVWf8yKEEEJII1PnoEImk0EgEFS7zdu3b6Gurv7eJ0UIIYSQxqfOiZomJiaIj4+vcr1UKkVcXBzMzc3rdWKEEEIIn6joVt3VuaeiV69eSEpKQlBQkML1p0+fRmpqKnr37l3vkyOEEEJI41HnnoqhQ4ciLCwMR48exe3bt5lHIYcPH0ZcXBwSExNhbW0NDw8P1k+WEEIaGvo2S8j/qXNQoa6uDh8fHxw8eBC3bt2CVCoFAFy4cAECgQB9+vTBrFmzoKKiwvrJEkIIIaTheq/iV9ra2vDy8sK0adOQkJCA3NxcaGtrw8rKCrq6umyfIyGEEEIagXrNUqqjowNnZ2eWToU0J9RlTAghTU+9goqUlBSkpKSgsLAQffv2ZeucCCGEENIIvVdQ8fTpU/z222948uQJs6w8qIiNjcUPP/yARYsWoXv37uycJSGEEEIavDoPKRWLxVi1ahXEYjGGDBmCLl26yK3v3LkzdHR0EBYWxtpJEkIIIaThq3NQERAQgJKSEvzwww+YNm0aLC0t5dYLBAJYW1sjMTGRtZMkhBBCSMNX56Di/v376NmzZ7UVMw0NDZGZmVmvEyOEEEJI41LnoCIvLw+GhobVbiOTyVBSUvLeJ0UIIYSQxqfOQYWenl6N05onJyfXGHgQQgghpGmp8+gPe3t7/PPPPxCLxTA1Na20PiEhAffv38fgwYNrdbzk5GQcOHAA8fHxEIlEcHd3x7hx4yAUVh/v5Ofn49ChQ4iMjIRUKkW3bt0wY8YMtGjRAkDZxGbnzp1DVFQUkpOTAQAWFhaYOHEirKys5I5VXFyM48eP4+bNmygqKoKtrS1mzZoFY2PjWr0GQgghhLxHT8WoUaOgoqICHx8f/PXXX0zuxIsXL/DXX39h06ZN0NLSwvDhw2s8Vm5uLtauXQuBQIBly5ZhzJgxOH/+PE6ePFnjvlu3bsXDhw8xZ84ceHl5ITExET/++COzXiKR4OzZs7C0tMSXX36JBQsWQEVFBStXrkRSUpLcsQ4ePIgbN27A09MTixcvRk5ODtatWweJRFLHd4cQQghpvurcU2Fqagpvb29s27YN+/fvZ5YvWbIEQFkJ7yVLlsDIyKjGY125cgUSiQTe3t7Q1taGo6MjCgoK4O/vj+HDh0NbW1vhfvHx8bh79y5WrVoFW1tbAEDLli3x7bff4t69e3B0dIS6ujq2b98OHR0dZj8HBwcsXLgQf/75J+bPnw8ASE9Px7Vr1zBv3jz069cPANC+fXt4eXnh77//xkcffVTXt4gQQghplt6r+JWzszN27NiBkJAQxMfHM3N/fPDBBxgwYIDcjbw6MTExcHJykgse3Nzc4Ofnh9jY2CqLZ0VHR0NPT48JKADAysoKxsbGiImJgaOjI4RCYaXzUFVVhbm5udzIlLt37wIAPvzwQ2ZZy5YtYWNjg+joaAoqCCGEkFp67zLdIpEIQ4YMwZAhQ9678ZSUFNjZ2cktMzIygoaGBsRicbX7mZmZVVpuZmaGlJSUKvcrLi7GkydP4OLiwiwTi8UwNDSEpqZmpWPFxsbW9qUQQv6/953X5eXS2dXuZ/Ljvvc+J9I80d+U8tVr7g+gLGEyPz+/Vo873pWXlweRSFRpuUgkQm5ubrX7KXo0IhKJ8Pr16yr3CwwMRG5uLj7++GNmWXkvy7t0dHSQl5en8DjBwcEIDg4GAGzcuPG9XntTUP2to36qek9rarPm30X1R2iuv0t2vd97XP/fLV/ob6omXF4rALpeNCT1DiouXLiAgIAAnDhxgo3z4UxUVBQCAwMxdepUhaNW6sLDwwMeHh7Mz2lpaQAoKmZT+XuqrP3Y2p/UjK/fLV8a63k3JnS9UK7q7qF1Hv3BJpFIhPz8/ErL8/Lyqs3LEIlEKCgoULifop6PhIQEbN26FQMHDsTQoUPl1uno6Cg8h9zcXIXHIoQQQohi9e6pqA9FORBpaWkoKiqqNhIyMzPD1atXKy0Xi8Xo0aNHpWUbN26Eg4MDZs6cWWkfU1NTpKeno7CwUC6voqo6HKR5ol6ohu99czkIIezhtafC2dkZd+/elet1CA0Nhbq6utzIjnd16dIFWVlZiIuLY5YlJibi1atXcHZ2ZpZlZmZi/fr1aN26NRYuXKiwoJaTkxMAICIiglmWkZGBR48eVZqBlRBCCCFVq3dPhUwme+99Bw4ciEuXLuGnn37CiBEj8Pr1a/j7+2PYsGFyyZMLFiyAra0t5s2bBwCwtraGk5MTduzYAU9PTwgEAvj5+cHGxgaOjo4Ayopf/fDDD8jLy8OsWbPw7Nkz5nhqamro2LEjgLLJz9zd3eHr6wsA0NXVhb+/P1q1aoU+ffq892sjhBBCmpt6BxXDhg3DgAED3mtfHR0drFy5Evv378emTZsgEokwdOhQjB8/Xm47qVQKqVQqt2zRokXw9fXF7t27IZPJ0LVrV8yYMYNZn5WVxQQSGzdulNu3VatW2LlzJ/PzjBkzoKGhAV9fX0gkEtja2mLhwoVQV1d/r9dFCCGENEf1Diq0tbWrrHxZG+bm5vDx8al2m4oBQDmRSIT58+czlTHfZWxsXKty30BZz8W0adMwbdq0Wm1PCCGEkMreO6h49uwZbt26hZSUFBQVFWHFihUAgNevXyMhIQGOjo61rqxJCCGEkMbvvYKKEydO4PTp0wrzKWQyGbZt24bp06fjk08+qfcJEkIIIaRxqPPoj3/++QeBgYFwdHTE5s2bMXLkSLn1rVu3hqWlJe7cucPWORJCCCGkEahzUHHp0iW0adMGy5YtQ/v27aGqWrmzw8zMDKmpqaycICGEEEIahzo//nj+/Dn69++vMJgoZ2BggKysrPqcFyGEENIoNedieXXuqZDJZBAIBNVu8/btWxqOSQghhDQzdQ4qTExMEB8fX+V6qVSKuLg4mJub1+vECCGEENK41Dmo6NWrF5KSkhAUFKRw/enTp5GamorevXvX++QIIYQQ0njUOadi6NChCAsLw9GjR3H79m3mUcjhw4cRFxeHxMREWFtby00NTgghhJCmr85Bhbq6Onx8fHDw4EHcunWLKZ994cIFCAQC9OnTB7NmzYKKigrrJ0sIIYSQhuu9il9pa2vDy8sL06ZNQ0JCAnJzc6GtrQ0rKyvo6uqyfY6EEEIIaQTqNfeHjo6O3FTjhBBCCGm+6pyo+fPPPyM6OrrSrKGEEEIIad7q3FMRHh6O8PBw6OnpoU+fPujXrx/atWvHxbkRQgghpBGpc1Cxfv163LhxA6GhoTh//jzOnz+Pjh07ol+/fnBzc6OcCkIakMvnXla7fvBwEyWdCSGkOahzUGFlZQUrKytMnz4dd+7cwY0bN3D37l0cOnQIR44cQdeuXdG3b19069aNRoAQQgghzch7J2qqqqrCxcUFLi4uyM7Oxs2bNxESEoLIyEhERkaiRYsW2Lev6dY3J4Q0Dc15ngZC2FbnRE1FdHV1MWzYMGzevBmenp5QUVFBTk4OG4cmhBBCSCNRryGl5cRiMW7cuIG///4bGRkZAIA2bdqwcWhCCCGENBLvHVTk5eXhn3/+QUhICBISEgAAWlpacHd3R79+/WBjY8PaSRJCyHTf29Wun2TQQTknQgipUp2Dijt37uDmzZv4999/UVJSAoFAAEdHR/Tr1w89e/akKc8JIYSQZqrOQcWPP/4IoGwK9H79+qFfv35o2bIl6ydGCCGEkMalzkGFh4cH+vXrB2tray7OhxBCCCGNVJ2Dis8//5yL8yCkSaMiVISQ5oCVIaWEEEIIITX2VKxevRoCgQBeXl4wNDTE6tWra3VggUCAlStX1vsECSGEENI41BhUxMbGAgCKiorkfiaEEEIIqajGoOLEiRPV/kwIIYQQAlBOBSGEEEJYUuegYteuXbhz50612/z777/YtWvXe58UIYQQQhqfOgcVISEhePr0abXbPHv2DCEhIe97ToQQQghphDh5/FFcXAyhkJ6sEEIIIc0J63f+4uJiPHr0CPr6+mwfmhBCCCENWK0qan755ZdyP1+4cAE3btyotJ1UKkV2djaKi4sxcOBAVk6QEEIIIY1DrYIKmUxWq2UqKipo164d7O3tMWbMmFqdQHJyMg4cOID4+HiIRCK4u7tj3LhxNT4+yc/Px6FDhxAZGQmpVIpu3bphxowZaNGiBbPNvXv3cO3aNTx+/Bhv3rzB2LFjMX78eLnjvH79ulLQBACurq5YtGhRrV4DIYQQQmoZVOzcuZP594QJEzB06FCMHTu23o3n5uZi7dq1MDc3x7Jly5CamoojR45AJpNh4sSJ1e67detWiMVizJkzB0KhEH5+fvjxxx+xZs0aZpuYmBg8f/4c9vb2CA0NrfZ4np6e6NSpE/Ozrq5u/V4cIYTUw3Tf29WuPzStl5LOhJDaq/OEYj4+PmjVqhUrjV+5cgUSiQTe3t7Q1taGo6MjCgoK4O/vj+HDh0NbW1vhfvHx8bh79y5WrVoFW1tbAEDLli3x7bff4t69e3B0dAQAfPbZZ5g6dSoA1DgM1tTUlGZeJYQQQuqhzomatra2rAUVMTExcHJykgse3NzcIJFIqi0HHh0dDT09PSagAAArKysYGxsjJiaGWUYjUAghhBDlqXNPRbni4mIkJiYiIyMDxcXFCrfp169ftcdISUmBnZ2d3DIjIyNoaGhALBZXu5+ZmVml5WZmZkhJSanF2Ve2a9cu5ObmQk9PD25ubpg0aRLU1dXf61iEEEJIc/ReQcW1a9fg5+eH3NzcarerKajIy8uDSCSqtFwkElV77Ly8PIWPRkQiEV6/fl1tm+9SU1PD4MGD4eTkBC0tLTx8+BBnz57Fq1evsGzZsjodi/CvpufQkww6KOdECCGkGapzUBETE4M9e/bA3Nwco0aNwpEjR9CjRw9YWVnh4cOHuHfvHlxcXNClSxcuzpd1BgYGmDVrFvOznZ0d9PX1sW/fPjx9+hQdOnSotE9wcDCCg4MBABs3boSRkREA4GUNbZVv11TU9Hrro6r3iss269NufYMZ7v42qj9zbtp9vzYb6u+25veIj/e4cV1PmtvvtrndCyqqc1ARFBQEHR0drFu3DlpaWjhy5Ag6dOiAkSNHYuTIkbh27Rp+//13fPLJJzUeSyQSIT8/v9LyvLw86OjoVLtfTk6Owv0U9XzUlYuLC/bt24ekpCSFQYWHhwc8PDyYn9PS0mp13NpuR/h7r6jdptlmfdqt7/ly9XrpevJ/GtvvtrH/7kxNTatcV+dMxidPnqBbt27Q0tJilkmlUubf7u7u6NSpEwIDA2s8lqIciLS0NBQVFVV70lXlTojFYoW5Fu9LIBCwdixCCCGkqatzUFFUVAQDAwPmZzU1NRQUFMhtY2FhgcePH9d4LGdnZ9y9e1du/9DQUKirq8uN7HhXly5dkJWVhbi4OGZZYmIiXr16BWdn5zq8GsXCwsIAlL0OQgghhNROnR9/6OvrIzs7m/nZwMCg0kiN/Px8ud6LqgwcOBCXLl3CTz/9hBEjRuD169fw9/fHsGHD5BIxFyxYAFtbW8ybNw8AYG1tDScnJ+zYsQOenp4QCATw8/ODjY0NU6MCAN68eYPExEQAQElJCZKTkxEWFgYNDQ0m5+PkyZMoLCxEp06doKWlhUePHuHcuXPo2bMn2rdvX9e3hxBCCGm26hxUmJubywURNjY2CA0NxaNHj9C5c2c8f/4ct2/fRtu2bWs8lo6ODlauXIn9+/dj06ZNEIlEGDp0aKVS2lKptFKQsmjRIvj6+mL37t2QyWTo2rUrZsyYIbfNw4cPsWvXLubnsLAwhIWFoVWrVkyVUDMzMwQFBeHq1auQSCQwMjLC8OHDMXr06Lq+NYQQ0uhRJU9SH3UOKrp06YJDhw4hIyMDLVu2xIgRIxAWFoZVq1ZBR0eHGQpa25uyubk5fHx8qt2mYpnwciKRCPPnz8f8+fOr3K9///7o379/tcd2c3ODm5tbrc6VEEIIIVWrc1Dh4eEBFxcXZnSGubk5VqxYgcDAQLx69QqWlpYYMmQIK7kNhBBCCGk86hxUqKqqQl9fX26ZtbU1vvnmG7bOiRBCCCGN0HuX6SaENF0vl86udr3Jj/uUdCaEkMaEZtwihBBCCCtq7KmYMGHCex1YIBDgjz/+eK99CSGEENL41BhUdO7cmSpLEkIIIaRGNQYVq1atUsJpEEIIIaSxo5wKQgghhLCiXkFFYWEhnjx5gkePHrF1PoQQQghppN5rSGl6ejoOHjyIf//9F1KpVC4pMy4uDnv27MHs2bNhZ2fH6skSQgghRLGGMBS8zj0VmZmZ+Pbbb3Hnzh1069YN1tbWkMlkzHorKytkZ2cjNDSU1RMlhBBCSMNW56DC398f2dnZ+P7777FkyRK5WUGBsoqbNjY2+O+//1g7SUIIIYQ0fHV+/BEdHY1u3brB3t6+ym2MjIwQFxdXrxMjhJCmrKauatjPUs6JEPL/XT73ssp1g4eb1OoYde6pePv2LUxMqj+4iooKCgsL63poQgghhDRidQ4qdHR0kJ6eXu02L1++rDTpGCGEEEKatjoHFZ06dcKdO3eQlZWlcP3Lly8RExNDIz8IIYSQZqbOQcXw4cNRXFwMHx8fREdHo6ioCEBZzYro6Ghs2rQJQqEQn376KesnSwghhJCGq86Jmh988AE+//xz7Nu3Dxs3bmSWT5s2DUBZPsW8efPQtm1b9s6SEEIIIQ3eexW/cnd3R+fOnXH58mU8fvwYubm50NbWxgcffICPP/4YpqambJ8nIYQQQhq49woqAMDExATTp0+vcn12djZ0dXXf9/CEEDSMCnmEEFJb7x1UVCU/Px9nzpzB5cuX4evry/bhm7TqxggDtR8nTAghhPChTkHFmzdvkJSUBBUVFVhZWckNG5VIJLhw4QKCgoKQl5cHdXV1ts+VEEIIIQ1YrYOKAwcO4K+//mLm+VBVVcXUqVMxePBgPHz4EDt37kR6ejpUVVXxySefYNSoUZydNCGEEEIanloFFTdu3MDly5chEAhgbm4OAEhJScHBgwehoaGB33//HVKpFAMHDsTo0aPRsmVLTk+aEEIIIQ1PrYKKkJAQqKqqwsfHB9bW1gCA2NhYrFu3Dr/99hsMDQ3x9ddfo127dpyeLCGEEEIarloVv3r27Bl69OjBBBQAYGtrix49ekAmk2HevHkUUBBCCCHNXK2Civz8fLRp06bS8vKJxSoGG4QQQghpnmoVVMhkMqiqVn5SoqKiAgA00oMQQgghdZ/7gxBCCCFEkVoPKfX394e/v7/CdRMmTKi0TCAQ4I8//nj/MyOEEEJIo8JZT0V5PQtCCCGENA+16qk4ceIE1+dBCCGEkEaOcioIIYQQwgoKKgghhBDCCgoqCCGEEMIK1qc+r6vk5GQcOHAA8fHxEIlEcHd3x7hx4yAUVh/v5Ofn49ChQ4iMjIRUKkW3bt0wY8YMtGjRgtnm3r17uHbtGh4/fow3b95g7NixGD9+/HsdixBCCCHV4zWoyM3Nxdq1a2Fubo5ly5YhNTUVR44cgUwmw8SJE6vdd+vWrRCLxZgzZw6EQiH8/Pzw448/Ys2aNcw2MTExeP78Oezt7REaGlqvYxFCmqfpvrerXT/JoINyToSQRoDXoOLKlSuQSCTw9vaGtrY2HB0dUVBQAH9/fwwfPhza2toK94uPj8fdu3exatUq2NraAgBatmyJb7/9Fvfu3YOjoyMA4LPPPsPUqVMBAHfu3KnXsQghhBBSPV5zKmJiYuDk5CQXPLi5uUEikSA2NrbK/aKjo6Gnp8cEAQBgZWUFY2NjxMTEMMtqeoRSl2MRQgghpHq8BhUpKSkwNTWVW2ZkZAQNDQ2IxeJq9zMzM6u03MzMDCkpKXU+B7aORQghhDRnvAYVeXl5EIlElZaLRCLk5uZWu5+iRyMikQh5eXl1Pge2jkUIIYQ0Z7yP/miMgoODERwcDADYuHEjjIyMAAAva9ivfLuqVX+EmvdXrppeb31U9Vq5bLMxtsvV31T92uWmzfpqau3ydT14n3Yb6nvcMD8/74/L11vbc+Y1qBCJRMjPz6+0PC8vDzo6OtXul5OTo3A/RT0fNZ1DXY/l4eEBDw8P5ue0tLRatVXb7bjavzHh67U2tnb5+puqT7uN7T1uqO02tddTH83p81MfbH1u301bqIjXoEJR3kJaWhqKioqqPWkzMzNcvXq10nKxWIwePXrU+RzYOhZfXi6dXe16kx/3KelMCCGENGe85lQ4Ozvj7t27KCgoYJaFhoZCXV1dbjTGu7p06YKsrCzExcUxyxITE/Hq1Ss4OzvX6RzYPBYhhBDSnPHaUzFw4EBcunQJP/30E0aMGIHXr1/D398fw4YNk0ueXLBgAWxtbTFv3jwAgLW1NZycnLBjxw54enpCIBDAz88PNjY2cnUl3rx5g8TERABASUkJkpOTERYWBg0NDXTp0qVOxyKEEEJI9XgNKnR0dLBy5Urs378fmzZtgkgkwtChQyuV0pZKpZBKpXLLFi1aBF9fX+zevRsymQxdu3bFjBkz5LZ5+PAhdu3axfwcFhaGsLAwtGrVCjt37qzTsQghhBBSPd5Hf5ibm8PHx6fabSoGAOVEIhHmz5+P+fPnV7lf//790b9//xrPoTbHIoQQQkj1aJZSQgghhLCC954KQgghdXf5XPVVCQYPN1HSmRDyf6inghBCCCGsoKCCEEIIIaygoIIQQgghrKCgghBCCCGsoKCCEEIIIaygoIIQQgghrKCgghBCCCGsoKCCEEIIIaygoIIQQgghrKCgghBCCCGsoKCCEEIIIaygoIIQQgghrKCgghBCCCGsoKCCEEIIIaygoIIQQgghrKCgghBCCCGsoKCCEEIIIaygoIIQQgghrKCgghBCCCGsoKCCEEIIIaygoIIQQgghrKCgghBCCCGsUOX7BAj3pvvernb9oWm9lHQmhBBCmjIKKgghhDRLNX3hmmTQQTkn0oTQ4w9CCCGEsIKCCkIIIYSwgoIKQgghhLCCggpCCCGEsIISNQkhhJAG5PK5l9WuHzzcRElnUncUVBBC6qy6rHnKmCek+aLHH4QQQghhBQUVhBBCCGEFBRWEEEIIYQXvORXJyck4cOAA4uPjIRKJ4O7ujnHjxkEorD7eyc/Px6FDhxAZGQmpVIpu3bphxowZaNGihdx2kZGR+OOPP5CamgpjY2OMGzcOrq6uzPrXr1/jyy+/rHR8V1dXLFq0iJXXSAghhDQHvAYVubm5WLt2LczNzbFs2TKkpqbiyJEjkMlkmDhxYrX7bt26FWKxGHPmzIFQKISfnx9+/PFHrFmzhtkmLi4OW7ZswaBBgzBjxgxER0dj27ZtEIlEcHJykjuep6cnOnXqxPysq6vL7oslhBBCmjheg4orV65AIpHA29sb2tracHR0REFBAfz9/TF8+HBoa2sr3C8+Ph53797FqlWrYGtrCwBo2bIlvv32W9y7dw+Ojo4AgFOnTqFz586YOXMmAMDe3h7JyckICAioFFSYmprC2tqaw1dLCCGENG285lTExMTAyclJLnhwc3ODRCJBbGxslftFR0dDT0+PCSgAwMrKCsbGxoiJiQEAFBcX48GDB+jVS34GTldXV8THxyM/P5/dF0MIIYQ0c7z2VKSkpMDOzk5umZGRETQ0NCAWi6vdz8zMrNJyMzMzpKSkAABevXqF0tLSStuZmZlBJpNBLBbDysqKWb5r1y7k5uZCT08Pbm5umDRpEtTV1evz8gghhJBmhdegIi8vDyKRqNJykUiE3NzcavdT9GhEJBLh9evXAMDs/+7xdXR0mGMAgJqaGgYPHgwnJydoaWnh4cOHOHv2LF69eoVly5YpbD84OBjBwcEAgI0bN8LIyAgAUH0NNDDbVa36I1S1f03t1qTm81Ksvu1Wh6vX2tTabah/Uw2tTWqX3+M2t/e4oX5u69NubX/vvI/+4JuBgQFmzZrF/GxnZwd9fX3s27cPT58+RYcOHSrt4+HhAQ8PD+bntLS0WrVV2+242l/Zx60Pvs6psbXbUP+mGlqb1G7DP259NLb3mK/PbX3arbivqalpldvxmlMhEokU5jbk5eUxPQpV7VdQUKBwv/KeifL93z1+VT0YFbm4uAAAkpKSangFhBBCCCnHa1BRMQeiXFpaGoqKiqqNhBTtBwBisZjJoWjdujVUVFQqbScWiyEQCKo9fjmBQFCbl0EIIYQQ8BxUODs74+7du3K9DqGhoVBXV5cb2fGuLl26ICsrC3FxccyyxMREvHr1Cs7OzgDKciXs7e0RFhYmt29oaCisra2rHK4KgNnHwsLifV4WIYQQ0izxmlMxcOBAXLp0CT/99BNGjBiB169fw9/fH8OGDZO76S9YsAC2traYN28eAMDa2hpOTk7YsWMHPD09IRAI4OfnBxsbG6ZGBQCMGTMGq1atwqFDh9CjRw9ER0cjOjoa3377LbPNyZMnUVhYiE6dOkFLSwuPHj3CuXPn0LNnT7Rv3155bwYh76G62UIBmjGUEKJcvAYVOjo6WLlyJfbv349NmzZBJBJh6NChGD9+vNx2UqkUUqlUbtmiRYvg6+uL3bt3QyaToWvXrpgxY4bcNjY2Nli8eDFOnDiBv/76C8bGxvjqq6/kCl+ZmZkhKCgIV69ehUQigZGREYYPH47Ro0dz98IJIaSRunyu6hECg4ebKPFMSEPE++gPc3Nz+Pj4VLvNzp07Ky0TiUSYP38+5s+fX+2+PXv2RM+ePatc7+bmBjc3t9qdLCGEEEKqRLOUEkIIIYQVFFQQQgghhBUUVBBCCCGEFRRUEEIIIYQVvCdqNic0/I8QQkhTRj0VhBBCCGEFBRWEEEIIYQUFFYQQQghhBeVUkGor5AFUJY+QpuTl0tnVb2A/SzknQpok6qkghBBCCCsoqCCEEEIIKyioIIQQQggrKKgghBBCCCsoUZMQQghRoqZcCJF6KgghhBDCCgoqCCGEEMIKCioIIYQQwgoKKgghhBDCCgoqCCGEEMIKCioIIYQQwgoKKgghhBDCCgoqCCGEEMIKCioIIYQQwgoKKgghhBDCCgoqCCGEEMIKCioIIYQQwgoKKgghhBDCCgoqCCGEEMIKCioIIYQQwgoKKgghhBDCCgoqCCGEEMIKCioIIYQQwgoKKgghhBDCCgoqCCGEEMIKVb5PIDk5GQcOHEB8fDxEIhHc3d0xbtw4CIXVxzv5+fk4dOgQIiMjIZVK0a1bN8yYMQMtWrSQ2y4yMhJ//PEHUlNTYWxsjHHjxsHV1fW9jkUIIYQ0VtN9b1e7fpJBh3q3wWtPRW5uLtauXQuBQIBly5ZhzJgxOH/+PE6ePFnjvlu3bsXDhw8xZ84ceHl5ITExET/++KPcNnFxcdiyZQvs7OywfPlydO3aFdu2bcPdu3frfCxCCCGEVI/XnoorV65AIpHA29sb2tracHR0REFBAfz9/TF8+HBoa2sr3C8+Ph53797FqlWrYGtrCwBo2bIlvv32W9y7dw+Ojo4AgFOnTqFz586YOXMmAMDe3h7JyckICAiAk5NTnY5FCCGEkOrx2lMRExMDJycnueDBzc0NEokEsbGxVe4XHR0NPT09JggAACsrKxgbGyMmJgYAUFxcjAcPHqBXr15y+7q6uiI+Ph75+fm1PhYhhBBCasZrUJGSkgJTU1O5ZUZGRtDQ0IBYLK52PzMzs0rLzczMkJKSAgB49eoVSktLK21nZmYGmUzGHL82xyKEEEJIzXgNKvLy8iASiSotF4lEyM3NrXY/RY9GRCIR8vLyAIDZ/93j6+joMMeo7bEIIYQQUjPeR380RsHBwQgODgYAbNy4keltMfW7WO1+f3F0Ps2p3eb0Wptbu83ptTa3dpvTa22O7VbEa0+FSCRichsqysvLY3oUqtqvoKBA4X7lPRPl+797/Hd7MGpzrHd5eHhg48aN2LhxY5XnWBvffPNNvfZvTO02p9dK7TbdNqndptsmtcsOXoMKRXkLaWlpKCoqqpRrUdN+ACAWi5n8iNatW0NFRaXSdmKxGAKBgDl+bY5FCCGEkJrxGlQ4Ozvj7t27cj0FoaGhUFdXlxuN8a4uXbogKysLcXFxzLLExES8evUKzs7OAAA1NTXY29sjLCxMbt/Q0FBYW1szeRS1ORYhhBBCasZrUDFw4ECoqanhp59+wr179xAcHAx/f38MGzZMLnlywYIF2L17N/OztbU1nJycsGPHDoSHhyMiIgK//vorbGxs5OpKjBkzBg8fPsShQ4fw8OFDHD16FNHR0Rg7dmydj8UFDw8PTo/fkNptTq+V2m26bVK7TbdNapcdAplMJmP9qHWQnJyM/fv3y5XpHj9+vFyZbi8vL9ja2sLLy4tZlpeXB19fX0REREAmk6Fr166YMWMGdHV15Y4fERGBEydO4OXLl0yZbjc3N7ltanssQgghhFSN96CCEEIIIU0DzVJKCCGEEFZQUEEIIYQQVlBQoWS5ubl49OgRbt26xdTMkEgkkEqlPJ9Z0yGTyZCWlob//vsPhYWFfJ8OIaSWZDIZMjIyUFpayvepkPdEFTWVRCqV4tixY7h8+TIkEgkAYMOGDdDR0cGWLVtgaWmJ8ePHc9a+WCxGRkYG03ZFXbt2Zb294uJiXL9+HYmJiUhPT8esWbNgYmKC0NBQtGvXDubm5qy3CQCXL19GYGAgsrKyAJS9xxYWFvjpp5/QuXNnDB06lJN2gbLgMDMzE8XFxZXWcfV6gbJJ8crf5zFjxsDIyAixsbFo06YNWrZsyVm7zZFMJkNmZib09PSgoqLCaVt8fIYSEhIQERGh8FohEAjwv//9j/U2ASAqKgoBAQF4+vQppFIpfvjhB1hYWGDPnj3o3Lkz+vbty0m7AD+fn4yMDPz777/IyMhQeL347LPPOGn32bNnCAwMRFJSEtLT07Fu3TpYWFjg+PHjsLGxQZcuXerdBgUVSnLs2DFcvXoVM2fOhJ2dHRYsWMCs69GjB65cucJJUPH8+XNs27YNycnJVW5z4sQJVtsUi8VYt24d8vPzYWFhgYcPHzK1SB49eoSoqCh8+eWXrLYJAOfOncOJEycwYsQI2NnZYc2aNcw6W1tb/PPPP5wEFenp6di7d2+1s9qy/R4DQFZWFjZv3oykpCS0atUKr1+/xsCBA2FkZIQbN25ATU0Nn3/+OevtAvwFjc3lpsfHZ+j8+fM4cuQI9PT00Lp1a6iqKuf2EBISgt27d6N3794YNGiQXPkAExMTXL9+nZOggq/Pzz///IOdO3dCJpNBV1e30vssEAg4CSqio6OxefNmWFtbo2/fvggICGDWqamp4c8//6SgojG5efMmJk+ejAEDBlR61NG6dWu8evWKk3Z3794NFRUVfPPNN2jTpo1SLhQHDx6EkZERvv76a2hqamLy5MnMOltbW/j5+XHS7uXLlzF+/HiMGDGi0ntsamqKly9fctLujh078OrVK8yaNUtp7zEAHDhwAIWFhfjll1/QqlUruffZwcFB7qLBJr6CxuZ00+PjM3T+/Hl88sknmDZtGgQCAevHr0pgYCCGDx+OyZMnQyqVyr2/5ubmCAoK4qRdvj4/f/zxBz788EN8/vnnCiez5MqxY8fQr18/zJ07F6WlpXKvr0OHDrhy5Qor7VBQoSR5eXlo3bq1wnUlJSWc5VQkJyfD29tbqdVB4+Li8L///Q8ikajS69LT00NmZiYn7WZlZcHCwkLhOqFQqLCbkQ2JiYn46quv0L17d06OX5W7d+/Cy8sLbdq0qfQ+GxoaIiMjg5N2+Qoam9NNj4/PUHFxMbp27arU9xYom5qhqkKD6urqCueHYgNfn5+cnBy4u7srNaAAyr4MeHp6AkCl37GWlla1M4PXBSVqKkm7du1w584dheuio6PRsWNHTtq1srJCWloaJ8euipqamsLcDaDsWWJVE7XVV5s2bRAbG6twXWxsLGdd8ubm5igqKuLk2DWpWCSuouzsbKirq3PSZlxcHEaOHAmRSFTp4sRl0Nicbnp8fIb69++PiIgI1o9bE0NDQzx58kThusTERLRp04aztvn4/PTs2RMPHz7k5NjV0dXVxevXrxWue/HiBYyMjFhph3oqlGT06NHYsmULJBIJXFxcAABPnz5FREQEgoODsWzZMk7anTNnDrZt2wYNDQ3Y2dkpvBhpaGiw2qajoyNOnz4NR0dHaGpqAiiLjIuLi1l7bqfIkCFDsG/fPqiqqjLvcXZ2Nq5du4YLFy5gzpw5nLQ7c+ZM7N27F4aGhrCxseGkDUVsbGxw6dIluUTb8hvu9evXYWdnx0m7fAWN5Tc9rsvnv6v8pmdvb19pHVc3PT4+Q1OmTMGBAwewdu1ahdcKgUCAQYMGsd6uu7s7AgICoKenh549ezLL79+/j3PnzmHMmDGstwnw9/mZNWsWdu/ejd9++w329vYKeyy4SJ53c3PDiRMnYG5uDmtrawBlr1csFuPs2bNwd3dnpR2qqKlEoaGh8PPzk+s5aNmyJTw9PeHq6spJm3l5edizZw/Cw8Or3IbtJMK0tDSsWLECEokEjo6OCA0NRffu3ZGcnIySkhKsX78e+vr6rLZZ7ty5cwgICJDrOVBXV8e4ceMwfPhwTtosKSnBgQMHcPXqVaiqqkJLS6vSNvv27WO93efPn2PlypUwMDBAjx49cPbsWQwcOBAvXrzA8+fPsX79+mpn+31fv/zyC16+fAkfHx9oampi0qRJ2LhxI8zNzbF69WqYmZlh3rx5rLcrlUpx4MABvHz5Uqk3vTNnzuD06dOYNWsWevbsiWnTpmHDhg3Iy8vDL7/8gjFjxmDIkCGstsnHZ+jevXvYsmVLtcOwuUg4lslk2L9/P65cuQKhUAipVAoVFRVIpVJ4eHhg9uzZrLcJ8Pf5efr0KbZs2VJlrwHAzftcXFyMLVu2IDo6Gvr6+sjKykLLli2RlZUFJycnLFmyhJU8JQoqeCAWi5GTkwMdHR2Ymppy2p27ceNGxMfHw93dvcokwv79+7Pebm5uLs6fP48HDx4wr9Xe3h7Dhg1DixYtWG+vooKCAvz333/Izc2Fjo6O3Ky0XNixYwdu376N7t27V/kejxs3jpO2U1NT4e/vjwcPHiA7Oxs6OjpwcHDAuHHjYGJiwkmbfAWNze2mp+zP0MKFC9GqVStMnz5dqQnH5VJTU3H//n2518rFTf3dNpX9+SnvlZ40aVKV73OrVq04aRso6wGq+D47ODiw2vtHQUUT5+npiTlz5qB37958n0qTNXXqVHz22WecfEtuqPgIGpvjTU+ZPD09sXTpUqU/XmpuPD09lZ48r0yUU6FEGRkZiIqKQnp6utIKnrRq1YqzhKOGSCKR4NGjRwrfY666x3V1dVlLcmosdHR0MHHiRKW2mZGRgVmzZnFaSKw6bdq04TRpkG8ODg549uyZUoKKqhKqq2Jra8vRmSifMpPn69oOG9cxCiqUJCIiAtu2bYNUKlVqwZPPPvsM/v7+6NChA4yNjVk/fjkvL686PcbZsWMH6+cQFxeHLVu2IDs7u8ptuAgqxo4di6CgINja2jJJdVxZvXp1nbb38fHh6EyUrznd9EpKSnDx4kVERERU+SWE7TydIUOG4Pfff4dEIoG9vb3ChFu2Arq6/h1z8VgLAMLCwhAeHl5lteENGzaw3ubUqVOxa9cuqKurV/k+s5U87+XlVaft2XifKahQkuPHj8PR0RFeXl7Q0dFRWrv+/v5IS0vDwoULYWxsrDC3gI0PzocffigXVISGhqKoqAiOjo7Q1dVFdnY27t27Bw0NDbi5udW7PUUOHjwIY2NjfPfddzA3N1da93hUVBRSU1Mxb948WFpaVnqP2az0+O6jhfj4eLx9+xYWFhbM+5yUlAR9fX188MEHrLT5Lj5ueEDzuun5+voiODgYXbt2hZ2dnVL+lteuXQsAOHnyJE6ePKlwG7Ze508//cT8OzMzE7t374azszM+/PBD5u84LCwMd+/e5STpFyh7nadOnUL79u2Ver345ptvAAA7d+6schu23uevv/6a+Xd+fj78/PxgZmaGnj17Qk9PD2/fvkV4eDjEYjFrX2opqFCStLQ0zJgxQ6kBBQC0bdsWbdu25bydqVOnMv8ODAxE69at8c0338h9cy8sLMTGjRsVjo5gg1gshre3Nzp06MDJ8auSk5PDdIuXlpYiJyeHs7YWL17M/PvatWtMdcuK3ZZpaWnYuHEjZ9/o+bjhAc3rphcWFobJkyfj008/Zf3YVVFmr1bFa9Lx48fRr1+/So/TnJ2d8ccff+DixYuc/C1fv34dI0aMkCvepgxcBUmKVByaunPnTnTt2rVS6fFBgwZh7969iIqKYuULHwUVStKpUyeIxWKlJ0HNnz9fqe0BZeWy58yZU+lRgKamJj799FPs2bOHk7Hn7dq1YyYSUya+HjEEBgZi6tSplZ6DGhkZYdy4cTh8+DA8PDxYb5ePGx7QvG56MpkM7du3Z/WYNeErb+H+/fv4+OOPFa6ztbXFhQsXOGm3oKAADg4OnBy7OlyMtquNiIgIeHt7K1zn4uKCLVu2sNIOBRVKMnXqVGzfvh2amppwdHRUShGqd8lkMuTk5KBFixacDmMtKCio8uaelZXF2XTkn3/+OXbu3AljY+MmldhVlaysLJSUlChcV1JSUm1uSX3wccMDmtdN76OPPsKtW7d4GYkhFouRkJCArKws6Ovrw9LSEmZmZpy1p6Ojg8jISIWvNSIigrPeXVdXV8TExPASWABlNYRevHiBzMxMGBgYoG3btpwVjgPK6vXExcUpfJ8fPXrEWkI/BRVKsnTpUgCQmzfgXVwlI0VFRTHT3ZaWlkJFRQUWFhYYPXo0J5XbunXrhqNHj0JbWxvdu3eHqqoqSkpKEBkZCT8/P3Tr1o31NoGy7nGJRILVq1crtQgVUFZI5/Tp03IXYysrK4wcOZKzG7CdnR38/PzQunVrWFpaMssTEhLg5+fH2U2Yzxse0Dxuenp6erh16xZWr14NBwcHpRT6ys/PZwrlyWQyaGpqorCwEAKBAD179sTcuXM5qfcycuRIHDhwAG/evEH37t2Zx0uRkZGIiYnBzJkzWW8TKEv89fPzQ05ODhwdHZVW2bK0tBTHjx/H5cuX5ZJD1dXVMXjwYEycOJGTR4oDBw7EqVOnkJOTg+7duzM5FZGRkQgODsbo0aNZaYfqVCjJjRs3atyGi26xK1euYN++fXBwcJBLzomIiMD9+/cxe/ZsDBw4kNU28/PzsXPnTmauEy0tLWYWy27duuHLL7/k5OJ08uTJGntguChCFRERga1bt6JNmzZyH9Y7d+4gNTUV//vf/+TKD7MlPT0dmzdvxtOnT6Gvr89cjLOystC+fXt8/fXXMDQ0ZL3dixcv4sKFCzA2NlbaDQ/g76Z3+fJlHDhwAF26dKnypjd48GBW25wwYUKN27D9JeTXX39FdHQ0UzlUXV0dEokE4eHhzOv/6quvWG2zXGRkJE6fPo0nT55AKpVCKBSiQ4cOGDVqFCefHYCf9xgAU313zJgx+PDDD+USJk+dOoWPPvqIs0Dq4sWLOHv2rFxPsr6+PoYPH46hQ4ey0gYFFU3c/Pnz0bVrV4VV//bu3Yvo6Ohqe0/qIzk5udI3d75qDHBp4cKFaN++Pf73v//JBTUymQw///wznj9/jm3btnHWflRUFBITE+W+uXPxDascXxfj5nbTU7apU6di2rRp+OijjyqtCw4OxuHDh3H48GFOz0EqlSI7Oxu6urpVTvbFljdv3tS4DReVLWfMmIExY8Zg2LBhldYFBQUhMDAQBw8eZL3dclKpFOnp6cz1wtDQkNX3mh5/KFlGRgbi4+PlSki3bNmSs/ZycnKqvOi5uLjg77//5qxtc3NzXoKIkpISPH/+nHmP27Vrx+kIhfT0dMyYMaNSL4lAIMBHH30kN5KAC127duU0iHgXV4/panLnzh1MmzZNrjqsuro6+vTpg6KiIk5veD169ECPHj2UetNTNk1NTRgYGChc17JlS85zvoCyWUO5mhfoXVyWwq6OQCCo8rqojJF6QqEQrVq14uz1U1ChJOWTIV29ehVSqZRZLhQKme4uLi5SdnZ2iI2NVfg8ODY2ltPkt/T0dLx8+VJhURmuboJnz57FmTNn5Kaj1tbWxqhRozibUMzS0hLJyckKy+6+ePGCs2nty5WWliItLU1hvYim1DPU3G56eXl5uHLlCuLi4pCXlweRSITOnTvDw8ODk4S+wYMHIygoCPb29nJJe0VFRQgKCmL9EU9Fr1+/xt9//13l9aLiUGo2lZaWIjw8HHFxccyXEBsbG3z44YdQUVHhpM2+ffvi2rVrCq8XV69eRZ8+fThpFyhLoo+MjMTLly85q+pMQYWSnDx5EtevX8ekSZPg6urKPEcLDQ3FiRMn0KJFi1p1K9dGcnIy8+8hQ4bgt99+Q05ODnr06CGXUxETE4O5c+ey0mZFBQUF2Lp1K+7evVvlNlx8271w4QKOHTuGgQMHwtXVlZmJLzQ0FMeOHYOqqiprs0lWnAV16tSp+OWXX1BSUoKePXsyz9wjIiJw9epVLFq0iJU231VSUoKDBw8iJCRE4QUC4K5XQdk3PKB53fRSU1OxevVqvH37Fp06dYKhoSHevn2LkydP4s8//4SPjw8rJcOPHj0q9/PLly8xb948ODg4MNeK+/fvQ11dHRYWFvVuT5GkpCT4+PjAyMgIYrEY7du3R35+Pt68eYOWLVtyVhr97du3WLduHZ4/f45WrVpBT08P8fHxuHz5Mtq3b4/vv/8eurq6rLR1+fJl5t+tWrVCWFgYFi9eXClHp7CwkLOh2qmpqcxEgIWFhdDV1UVubi6kUilEIhG0tbVZCSoop0JJ5s2bh08++UTht+Vz587h0qVLrOU21DU4YfvGs3//fjx8+BBz5szBypUrsWTJEohEIvz999948OABFi5cCCsrK1bbBICvvvoKvXr1wqRJkyqtO378OEJDQ7F9+3ZW2uL7PQaAP/74AyEhIZgyZQq2b9+OWbNmQUNDA3///TdevXqFGTNmcNIj9O4Nr/zmEx8fD11dXdZueEDlm96tW7dQXFys8Kbn6uoKT09PVtqtqDY3PbZraGzatAmvX7/Gd999J/d4NCMjAxs2bECrVq2Y2S7roy5lnAUCASfl9VevXg0jIyPMmzcPkyZNwoYNG2BhYYH//vsP27ZtwxdffMHJ5Fu//vorHj16BG9vb7nrUUJCArZs2QJbW1ssWLCAlbYawvVi06ZNkMlkWLx4MTw9PbFhwwZ06NCB+dK1ePFiVq7L1FOhJNnZ2VUOLWzfvj2rNQX4nu8hOjoaEydOZMpEGxgYwMrKCra2tjh8+DDOnTvHSXdmeno67OzsFK6zs7PD+fPnWWtLmVXxqnL79m2MGzcOrq6u2L59O6ysrGBhYYF+/fphx44duHPnDidBha+vL7S1tbF+/XqFN7zDhw+zcsMDyl5jRSoqKlBRUcHjx4+ZZeVF1sLDwzkJKo4cOQIXFxfmpjd37ly5m96IESNYbzM2NhZeXl6V8q1atmyJMWPGsPYFpLpS0cry9OlTjBgxgslJKu9169SpE8aOHQs/Pz9OgorypN93b6RWVlaYPHkyDhw4wFpbfOUhVZSQkIC5c+cy+WUlJSUQCoXo3bs3srOzcejQIaxbt67e7VBQoSQmJib4559/4OTkVGndP//8w+oUynwXfnr79i2TUayhoYHc3FxmXZcuXVir3PYuIyMj3Lt3T2H+yL1791idSZSvqngVpaenw8TEBEKhEGpqanLvc58+ffDrr7/iiy++YL1dZd3wgOZ906uYe1VRU+tcFggEUFVVhUAggK6uLt68eYNOnToBKPtMp6amctJuSUlJlRMAamlpVVlYrrEqLi6GlpYWhEIhdHR0kJmZyaxr164djh8/zko7FFQoyejRo7Ft2zakp6fjww8/hL6+Pt6+fYuwsDA8ePCAs+fu5ZRZMMjQ0JCZ/8LExARRUVHMRffx48dQU1PjpN1PPvkEBw8eRG5uLlxcXJju8bCwMNy4cQPTp0/npN1yyq6QZ2BggLy8PACAsbExHj16xARUr1694qxdoPnc8AB+bnp2dnY4ceIELC0t5bL037x5g5MnT3JWBfLt27e4cOECEhMTmb9jKysrfPLJJ5wlqJqbm+PVq1ewt7eHtbU1Lly4AEtLS6iqquLs2bNo3bo1J+1+8MEHOHv2LOzt7SvNUXT27FlYW1tz0i5QFtDcuHEDCQkJcu9z//79ORupZmJiwkyF3qFDB1y5cgVdunSBUCjEtWvXqkyCrisKKpTE1dUVIpEIJ0+exKFDh+QqW3733XecVSfko2CQo6Mj7t27h549e2Lo0KHYuXMnkpKSoKamhtjYWM4SkT7++GOoqqoiICAA169fZ5YbGBjg888/Vzj+ng18VciztbVFXFwcunfvjo8++ghHjx5Famoq1NTUEBoaytlssHzd8IDmc9ObPn061qxZg6+++goWFhZMgJyUlAQjIyO5CfzYEhcXhw0bNkBFRQWOjo4wMzNDdnY2rly5gj///BPLly+HjY0N6+16eHgwNSMmTZqE9evXM1+yNDU1ORv5MXXqVKxevRrz5s2Dk5MT8x6XJ5hz9Rg5OTkZP/zwAzIzM5nZhV+8eIGQkBCcOnWKmWWZbW5ubnj69Cn69u2LCRMmYP369Zg2bRqEQiGkUilr80RRoiYPpFIpMwcH12Pd+SgYVFRUhKKiIiZzOiIiAmFhYZBIJHB0dISHhwenr1smk1Uq7sLlXCd8VcjLyspCdnY22rVrBwA4f/48wsPDIZFI4ODggLFjx1bZvVsfr1+/xpo1a5Cenq7whrdixQoYGxuz3u67N73yrPl79+6htLSUs5vezZs38ebNG4wZMwbJyclYv349MjIyAPzfTU/RY836KikpwbVr1+QKm33wwQecfZtdtmwZRCIRvv76a4WzCxcUFGDTpk2st/uuwsJCxMfHQyKR4IMPPoCenh5nbWVnZyMoKKhSkDps2DDWRn68a+XKlcjPz8c333yjcHZhkUiE1atXc9J2RWlpaYiJiYFEIoG9vT1zHakvCiqauIZQJa+p47tCHh+UfcMDmudNT5mmTJkCb29vhcm9//77L37++Wf4+fnxcGZNy5QpU7Bw4UKFRQkjIiKwbdu2Rv0+0+MPDgUEBNRp+7Fjx7J+DnwUDLp//z7S09MVJjPeuHEDRkZGsLe3Z6WtkJCQOm3fr18/VtqtiK8KeU+fPkVGRobCm0BUVBQMDQ05m8xMVVWVk/k9qpOSkgJvb+9KvS+ampr49NNP8fPPPyvlPMpnGm5qzM3Nq5xdODMzk7McrOPHjyMnJ0dhUvHevXuhq6tbadr5xszY2LjKujISiYTVhPKKLl68iMzMTEyZMqXSumPHjqFly5ZVzsZbFxRUcOjSpUu12q48a5+LoIKPgkF//PEHevTooXBd+TPa9evXs9LWrl276rQ9F0EFXxXyfH190blzZ4VBRWJiIs6fP4+VK1dy0jYfmvpNz8vLq9aP6QQCAWs1V8rNnDkTO3bsgKamJnr06AE1NTUUFxcjIiICZ8+erVNNi7r4559/MH78eIXrOnfujJMnT7IWVNTlsYJAIODk8zN58mQcPnwYxsbGzLB7AIiPj8eJEyc4GRYNAH/99VeV+WwmJiY4d+4cBRUN3f79+6tcJ5PJEBYWhtOnTyM3N5fTRM2aquRVLDDERkW1Fy9eVHkR6NixI06dOlXvNsr5+vpWuz4hIQGBgYF4+PAhq8N2KzIyMkJ4eHiVFfKGDRvGVNRjcwbPJ0+eYOTIkQrXWVtb4+LFi6y0A/B/wwOa/k3vww8/rPE9fvLkCR4+fFjvthTZvHkzJBIJM/ldeVI3UJZ0/O4cNvv27WOl3czMzCrnPzIwMGDyV9jQokWLWp1PfHw8a22+KzAwEAUFBfj++++hp6fHXJPfvn2LFi1a4PTp0zh9+jSz/YYNG1hp982bN1UWpTM2Nq7VBGu1QUGFkkmlUty6dQtnzpyBWCxGt27d8MUXX3BSYRIAwsLCqi0YFBYWxiwTCASsBBUqKipyNRMqKh9qypaqEhEfPXqEwMBA3Lt3Dx06dMCiRYvg4uLCatvljhw5wvw7JSWl0vp3c1bYCiqkUqlcufCKioqKWB1nz/cND2j6N73qRnTEx8fj1KlTePjwIczNzTFq1ChW2qxo8ODBnCY0V0VfXx9PnjxR+Ej0yZMnrCZMVjeSJC0tDWfOnMG///6LFi1asDYV+Lvatm2rlInD3qWjowOxWKywQKBYLIaWlhYr7VBQoSTl45LPnj2LN2/ewMXFBYsWLWIt47YqfBQP6tSpE86dO4cePXrIJe2VlJTg/Pnz6Ny5M2dt3717F4GBgYiLi4OVlRWWLVuGbt26cdYewF+1PEtLSwQHBytM+AoODoalpSVrbfF9wwOax03vXQ8ePGB62iwsLODt7c3ZVOtV9cZUJTY2FhYWFvUeYdSrVy8EBATAzMxM7lFeVFQUTp06BQ8Pj3odvyapqak4ffo0/v77b+jp6WHy5MkYOHCg3ONiNtV16GZaWhoMDAzqPcFZt27d4O/vj06dOsndd54/f46AgIAqH1nXFY3+4JhEIkFwcDCCgoKQlZWFPn36YOTIkZx1xdeHVCrFV199ha+//rpekfSzZ8+wcuVKaGtrw9XVFQYGBsjMzMTt27eRn5+PNWvWsB5M3blzB4GBgUhMTIStrS1Gjx7Nab2E9yWVSrF27Vp88cUXMDExqdexYmNjsXbtWnTs2BH9+vWDvr4+MjMzcfPmTTx79gzff/89pwHcuze8UaNGcXbDex9s3fSOHj2KK1euYOHChZVuer/++is8PDxY6eGrKCoqCqdPn0Z8fDw6deqE0aNHc1K1831JpVK5eTrqQyKRYPPmzbh//z50dHSY60Vubi6cnJywdOlSTgrmvXjxAoGBgQgLC4OhoSGGDx8Od3d3zkYvvQ823+fc3Fz4+PggJSUFHTt2ZCZcfPLkCdq2bQsfHx/o6OjU+5wbzrvXBJ05cwYXLlxAQUEB+vfvj5EjR3KW2cuWN2/eVJmZXFvt27fHhg0bcPLkSdy8eZOZUri8dgKbAVVoaChOnz6N58+fw9nZGWvWrGGqHTZUsbGxKCgoqPdxbG1t8f333+PYsWPMPAUCgQAffPABpwHFuze85cuXN6gbHlB2MV69ejUrF+Px48fj6dOn2LRpk8KbHluzCwNg8qyePn0KBwcH+Pj48F52n2vq6ur4/vvvERMTg4cPHzI1fBwcHDjJNUtKSkJgYCAiIyNhYmKCOXPmoG/fvpzXDOKbjo4ONmzYgJCQEOZ9bt26NT766CP069ePtcCNggoOlddSt7a2RnZ2drX1IAQCAf73v/8p69Q4Z2pqynnpcQDM83U7Ozu0bdsWkZGRiIyMrHJ7tr9R8s3Ozg7r169HUVERMwU5F8OEgeZ5wwOUd9NbvHgxUlJSYGdnhxUrVjAjA6rKm+Hq98wXZ2dnzoPTH374AXfv3kW7du2waNEi9OrVi9P2Ghp1dXUMHDgQAwcO5KwNCio41LlzZ+YZMNsJio1NSkoKUlJSYGVlVWXS2/so7/l59epVjfNdsJWI2hBpaGgwk7e9fPkSZmZmrHYZN/cbHsD9Ta88yffhw4e1SnhtCDNfsiE5ORn5+fnMXBsSiQQBAQFITk6Gg4MDPvnkE9baKi/BnZGRgf3791c7Qg9gL9m3IXj79i2KioqYarcymQxXr15FcnIy7O3t0b17d1baoaCCQ6tWreL7FHixd+9eAGDG9YeGhuLXX39l5h759ttvWXtE0RBmseTLyZMnUVxczBSzefDgATZv3oyioiLo6+vj+++/Zy3LvLne8ADl3fTmzZvHynEam/3798Pa2pp5f48cOYIbN27AxsYGfn5+KC4uxvDhw1lpi4taQI3Frl270Lp1a2bKgBMnTuDMmTNo06YN/vzzT8ydO5eV2ZcpqGiA2EqY5EtMTAwmT57M/HzixAn07t0bn332GQ4cOIATJ07wXpSJzYRJvvz9998YM2YM8/Phw4dhY2ODsWPH4o8//sCxY8fw9ddfs9JWc73hAcq76dXngs5WUiofnj9/zpS4Lykpwc2bNzFt2jR4eHjgwoULCA4OZi2oGDdu3Hvvy9YoDL4kJSUx0zVIpVJcuXIFkyZNwogRI3Dy5ElcuHCBgoqmjI2ESb68ffsWhoaGAICXL18iNTUV3t7e0NfXh4eHB7Zu3crzGZZhK2GSL5mZmUxXZlpaGp49e8bUPBk2bFidq41Wp7ne8ADl3vTeB5tJqXwoKipiaiQ8fvwYRUVF+PDDDwGUFctjqyhTfUilUnh5eTXa9xgoK4RYXvwrKSkJubm5TLVfe3t7BAUFsdJO0053JXVmZGRU72fxOjo6ePv2LYCyeUD09fWZIaQymQxSqbTe50kALS0t5OfnAyh79CESiZgiampqalXmOyhT+Q1PLBbzfSrvrTHc9JRNIBBg7NixrORHGRsbM4X5IiIi0LFjR+bml5OTw1pRpsZIIBCgX79+rNRCMTQ0RHJyMoCyEVxmZmbM7y8/P5+1uhzUU9FMJCcnIykpCWlpaXB3d4e+vj5SU1Ohp6fHfGiFQiErOQpdunTBiRMnkJWVhXPnzsllWL948YKTabEbC6FQyFq+QefOnXH27FkIhUIEBQXJJVq9fPmywQ9frqvqejwKCwuRlJTEjEbh4qZna2vb5G96b9++RVBQEJKSkpCeno4lS5agbdu2uHjxIqysrJhHQAKBoF6PEioaNmwYfv/9d4SFheHJkydyxaEePnzIeYFAZahrgF+e6CwQCOpcLKsqAwYMwNGjR3H//n1ERUXJPaKOj49nbe4cCiqauMLCQuzatQvh4eFQUVFBaWkpnJ2doa+vj2PHjsHIyKjaaonvY+rUqTh06BCuXLmCzp07y1Xqi4iIgJOTE6vt8aEuM2JyNVx4+vTp2L59O3755Rd06NABkyZNYtaFhIRwWviKD6tXr8b69esVlrQXi8VYvXo1E7DRTa/uEhISsHbtWujq6sLW1hYPHz5kHsFmZmYiKCgI3t7erLfr7u6ONm3aIDExEZMnT5YrWqejo8NZuWxlqus1lotE51GjRqFly5ZITEzEzJkzMWDAAGZdbm4u3N3dWWmHgoomztfXF/Hx8VixYgVsbGzkpr3t2rUra8/RKtLW1q4yul6zZg3r7fGhIQwRbtmyJXx8fBSu++677zgrM9wQFRYWcjaMtTnc9ICya4WdnR2WLFkCmUyGGzduMOusrKxw69Ytztq2tbVVWPOkrqXDG6qGkujcr18/hTM1K5qB931RUNHERUREYPr06bC3t6+Uy2BkZNQsnwezoaqbeUOhra3N9ymwIjY2FrGxsczPV69eRUxMjNw2EokE0dHRnPYYNPWbHlCWvLds2TIIhcJK14oWLVogOzub0/bT09Px8uVLSCSSSusqlkdvjNgYVcGW0tJSpKWlKRwIYG5uXu/jU1DRQLGRMAmUXXCrmu63sLCQs9K0oaGhuHr1KsRiscI/3qZUVIZP8fHxuHbtWpUXY7amTeZLQkICLl26xPwcFhZW6W9WVVUVZmZmnBc2a8o3PaAsEK0qcHj16hX09PQ4abegoABbt25lClMp0pTqnvClpKQEBw8eREhISJUjC9l4nymoUDJlJkwCZTNZhoSEKKwEGBYWxsk8Gbdu3cLu3bvRr18/PHjwAAMGDIBUKsW///4LbW1thd1vysZmwiRQdmGMjIzEy5cvFX5gubjh3bt3Dxs2bIC9vT3i4uLg7OwMiUSC//77D4aGhk0ip2L48OHMcE0vLy8sXboUHTp0UOo5NPSbHltJqd27d8fJkydhbW2NVq1aMcfOzs5GUFAQZ5PFHTt2DGlpaVizZg1WrlyJJUuWQCQS4e+//8aDBw+wcOFCTtqtCzZHYQD8fOkKCAhAVFQU5s6di+3bt2PWrFnQ0NDA33//jVevXmHGjBmstENBhZLwkTAJABMmTMC6deuwdu1auLi4AACio6Nx4cIFhIWFYfXq1ay3ee7cOYwZMwYjR47E1atXMWjQIFhYWKCgoADr1q1j9Vl/Q0iYTE1NxYoVKyCRSFBYWAhdXV3k5uZCKpVCJBJBW1ubk6DixIkT+OSTT/DZZ59h0qRJmDBhAiwsLPDmzRusX78ednZ2rLcJ8DcKg6/qqXzd9JQ9EmPKlClYu3YtFi9ezNRi+P3335GamgpjY2NWJ06rKDo6GhMnTmRKvxsYGMDKygq2trY4fPgwzp07h8WLF7PSVkMYhcHXl67bt29j3LhxcHV1xfbt22FlZQULCwv069cPO3bswJ07d1jpcaOgQkn4SJgEyoYdrlixQm4my/JvIytWrFCYSV9fL1++RKdOnSAUCiEUCpkCU1paWhgxYgR8fX1ZKxbUEBImfX19YWlpicWLF8PT0xPLly9Hhw4dEBoaimPHjnE2sVpycjImTpzIzC9TfsFs1aoVxo0bh5MnT3JygeJrFAZQ9jjv0aNHSE9Pr/QNTyAQYNCgQay1VU6ZN71yfIzE0NHRwfr163Hz5k3cv38fGhoa0NHRgbu7O6uzWL6rvFieUChk5q8p16VLF2zZsoW1thrCKAxlfumqKD09HSYmJhAKhVBTU5N7n/v06YNff/2VlYRNCiqUhM+ESRsbG6xZswYSiQS5ubmczmQJlD2bLb8AtmzZkpmICigrfsVmINAQEiYTEhIwd+5cqKqWfZxKSkogFArRu3dvZGdn49ChQ1i3bh3r7aqrq0Mmk0EgEMDAwACvXr1iHnloaWkhIyOD9TZrwuUojLi4OGzZsqXahEEuggpl3vTK8TUSQ1VVFe7u7qwNL6wNQ0ND5ppgYmKCqKgo5nHt48ePWQ1mGsIoDGV+6arIwMAAeXl5AMpqrzx69IiZZbemyRjrgoIKJeErYfLatWtwcXGBtrY21NXVWZ0htCqWlpZ4/vw5nJ2d0a1bNwQEBEAoFEJVVRWnTp1ivvE1FcXFxdDS0oJQKISOjg4yMzOZde3atcPx48c5abd9+/YQi8VwdHSEvb09Tp8+jZYtW0JVVRUnT55kdTREQxiFcfDgQRgbG+O7776Dubk5E8RxTZk3vXJ8jMTw8fGBm5sbXFxcWMsdqA1HR0fcu3cPPXv2xNChQ7Fz504kJSVBTU0NsbGx+PTTT1lrqyGMwlDml66KbG1tERcXh+7du+Ojjz7C0aNHkZqaCjU1NYSGhsLNzY2VdiioUBI+EiaBsoSf/fv3w9HREW5ubujevTvnczCMHDkSaWlpAMpyOtLS0rBv3z7IZDJYWlqyOib6XXwkTJqYmDCvt0OHDrhy5Qq6dOkCoVCIa9euwcDAgPU2AWDIkCF4/fo1AGDy5MnYtGkT1q9fD6DsYrV06VLW2moIozDEYjG8vb2VnqipzJteOT5GYujp6eHIkSM4ePAgbG1t4ebmhp49e0JHR4f1tiqaMmUK8+iub9++0NTURFhYGCQSCWbNmgUPDw9O21c2vr50TZo0ifmbGjp0KGQyGcLDwyGRSPDxxx+zNoOrQCaTyVg5EqnWo0ePsG7dOtjY2MDFxQX79u3D+PHjIRaLmYRJLvIb8vLyEB4ejtu3b+PBgwdQVVWFs7Mz3Nzc0LVrV6UVSCouLkZxcTGn9RNqkzC5Y8cO1ts9f/48MjIyMHXqVMTHx2P9+vWQSCTMt8z58+czE/dwSSaTITU1FRKJBGZmZpx9k+drFMZ3332HgQMHKv3bZlFREYqKiphv7xEREcxNz9HRER4eHqz3NO7ZswcPHjzA999/j1atWmHSpEnYuHEjDA0NsWrVKjg6OmL69OmstgmU9ZreuXMHt2/fZnqiHBwc4Orqih49ejSpkuQAP6Mw4uPjkZaWBldXV+Tl5WHnzp2IiopivnQtXLgQrVu3Zr1dZaGgQoni4uJw7NgxPH78mOnStLa2xpQpU2BjY8N5+zk5OQgLC8Pt27cRGxsLDQ0NdOvWDV999RWr7RQUFKCwsFDhN/TMzExoaWlx0luyadMmyGQyJmFyw4YNcgmTixcv5iRwe1daWhpiYmIgkUhgb2/fZMo48+3p06fYuXMnZsyYobAQVVOSm5uLtWvXIjk5GRYWFoiPj4elpSUzEsPHx4fzG3xBQQEiIiJw+/Zt3L9/H0KhEEeOHGG9nfv37yM9PV1hsHjjxg0YGRnB3t6e9XYrjsK4evWqwlEYbH17r4kyvnQ9ffoUGRkZCkd4REVFwdDQEO3bt693O/T4Q4mUnTD5rhYtWmDgwIEYOHAgoqKisGfPHvzzzz+sBxW7d++GtrY25s6dW2mdv78/8vPzORkRwVfC5LuMjIyU0mW7a9cuSCQShe/lL7/8Ak1NTYW/AzbwMQpj7dq1kEgkWL16NVRVVRXeVLn4ZsnHTY+vkRgVaWlpoXXr1jA2NoaWlhZnz/r/+OMP9OjRQ+G67OxsXLlyhXmsxya+RmEooqamxvnv1NfXF507d1YYVCQmJuL8+fNYuXJlvduhoEJJ+EiYfNfz588RGhqK27dvIzU1FW3atMGoUaNYb+fRo0f4/PPPFa7r0qULZ9U0lZkwmZycjNatW0NNTY2ZTrg6bJS/fdf9+/erHCLn4uICX19f1tsE+BuFMXjwYGb4rDLxddPjYyQGUBacl18nMjIy0LZtWwwZMgSurq6ctPfixQtMnDhR4bqOHTvi1KlTnLSrzFEYR48exSeffAJDQ0McPXq0xu25yEt68uQJRo4cqXCdtbU1Ll68yEo7FFQoCR8Jk0DZze/27dsIDQ2FWCyGkZERevXqBVdXV6bADdvy8/Or7IF5d3w0m5SZMOnt7c3UaqhNvQAuxrtnZ2dXmUQnEok4m6uBr1EYfM2zwcdNj4+RGEePHkVYWBjevHkDExMTDBgwAK6urpwExBWpqKhUeU3gsg6NMkdh3L59G71794ahoSFu375d7bYCgYCToEIqlVZZ/KuoqAglJSWstENBhZL8/vvvTMLkzp07lZYw6e3tDX19ffTq1Qvz5s1jqvBxqXzYnaIpzqOjo9GmTRtO2nVzc8PTp0/Rt29fTJgwAevXr8e0adPkEibZ4uPjw1xsV65cycs3aCMjIzx69Ehu1sxyjx494qw3jK9RGOVyc3Px4sULpKenw9nZGTo6OpBIJFBVVeVkaDYfNz0+RmKEhYWhV69ecHNzU+rvtlOnTjh37hx69OghF6CWlJTg/PnznJWbV+YojIrVYPmqDGtpaYng4GCF5daDg4NhaWnJSjuUqMkDZSVMAmX1BTp37qzUm15wcDB+//13DBs2DP3794eBgQEyMzMREhKC8+fPY/bs2UrJOWjqCZOnT59GQEAAPD090b9/f2hqaqKwsBAhISE4fPgwxo0bV2V3Z33wNQqjtLQUx48fx+XLl5lJvTZs2AALCwts2LABlpaWnPRmbNy4EW/fvsXatWsr3fRWrlwJXV1dfPPNN6y321xGYjx79gwrV66EtrY2XF1dmevF7du3kZ+fjzVr1nDy2eVrFEZISAi6du2qsG5Rbm4u/v33X04q4cbGxmLt2rXo2LEj+vXrB319fWRmZuLmzZt49uwZvv/+e1YCOAoqeFaeMJmVldWkZuI7deoUzpw5Izejo7q6OpMY1ZSU94ooGlmSlJSE5cuXc/K7lUql2Lt3L65fvw4ATFABAB999BE+//xzToJJvkZhHD16FFevXsXUqVNhZ2eHBQsWMEFFcHAwrly5gk2bNrHeLl83vYq4GolRVFTEPKqszbwYXCWWi8VinDx5Eg8fPkRubi50dHTg4OCAsWPHwtTUlJM2FVHGKAy+rhcA8PDhQxw7dgwJCQkAyh61fPDBB5g8eTJrPUL0+IMHXCdM/vzzz5g8eTLatGlT44RbXE2yNWbMGHzyySeIj49HTk4OWrRoAWtra9Y/rA0hYbI6JSUlUFFR4eTYQqEQc+fOxfDhw/HgwQPmYmxvb8/phZivURg3b97E5MmTmaF/FbVu3ZrVUsMVtW/fHhs2bMDJkydx8+ZNXm56XI3EmDp1KnODq828GFzd7ExNTWs9Iqy6Ce3qSxmjMKqTk5PDaUBjZ2eH9evXo6ioCHl5edWOQExLS4OBgUGdr18UVCiJMhMmc3JyUFpaCqAsmY+P5/1AWSKUogqiFUmlUnz11Vf4+uuv0bZt2zq3wVfCZFpaGlPNEijLrK7YKwOUfesJCQmBsbExK21WxdTUtMYbm1Qqxdq1a/HFF1/AxMSkXu3xNQojLy+vyu7okpKSSoEGm/i66XE9EmPevHnMe9oQ5sWoiVQqxerVq5keqrriaxRGZGQkIiMjmZ8DAgIqJeAWFxcjLi6OtdyG6mhoaFTb6ySVSuHl5fVe7zMFFUqizITJipNsrVq1irN22PLmzRuF1exqg6+EyevXryMgIID5uapv5urq6pgzZ45SzqkmsbGxzLC5+uBrFEa7du1w584dZhKkiqKjo9GxY0cezkpefW965ZQ1EqNiXkxDmBeDa3yNwnj79i1evHjB/Pzq1Su8fftWbhtVVVU4OjpizJgxrLTJFwoqlMTHx0fpCZNAWUTs7u6ucCRAZmYmrl69qrSqcVyo+Ey/fDiYMgwePBguLi6QyWRYunQpFixYUKkanaqqKoyMjHjtTuWSskdhjB49Glu2bIFEIoGLiwuAsvyOiIgIBAcHY9myZay3yRc+RmJ8+eWXWLJkicL2nj9/js2bN3NS5l6Z+BqF4eHhwSSnr169GrNnz4aZmZnS2lcmCiqUhK+ywv7+/nB2dq4yqPD392/UQUVFykyA0tXVZbovd+zYAQMDA6XVa+BbVaMwdHR0sGXLFs5GYfTo0QNfffUV/Pz8mOTUPXv2oGXLlvjyyy9rfNTWmPBx837z5k2VtQokEgnS09OVfEbc4msURsWe5KaoeVwFedIQEiark56ezvkMhA0FlwmTrVq1AlD2TDQjI0PhoxxlJ4hy6fjx47h69SpmzpzJjMIo16NHD1y5coWzRySurq5wdXWFWCxGTk4OdHR0YGpqylveEJv4GImRn5+P/Px85uesrCymgFw5iUSCf/75h5cqwFzatWsX1q9frzCoeP36NXbt2sVJUAEAGRkZiIqKUljmHuCmoqayUFDBIb4SJm/cuIGQkBDm53379lXK0C8uLsbz588VPp9uTBpCwmRGRgb27t2L6OjoKrdpSsOF+RqFUZEyhxkqCx8jMS5cuCCXG/Tjjz9Wua2np2e922ssuByFERERgW3btkEqlUJXV7dSDydXFTWVhYIKDvGVMKmhoSEXfWtra1fqkSiv6Dl48GClnRcXGkLC5J49e5CUlIRp06YptWw1X5Q5CqPi77Y2GvOjPD5GYvTu3RuWlpaQyWTYvHkzPD09KwVsqqqqMDU1hZGRkVLOiUsNYRTG8ePH4ejoCC8vrybZU9y0r34NiDITJnv16oVevXoBKOviGzNmDCeV4dhSn2TGhpAwGRcXhzlz5nA24VJDo8xRGJcuXZL7WSKRMD1RFYt9qaurQ0NDo1EHFXyMxDAxMWGGGPv4+KBjx44NulKnQCDA2LFj3/tRTEMYhZGWloYZM2Y06IBCIBCgX79+7zfvjIwoxfjx42WPHz9WuC4xMVE2fvx4JZ8R9168eCELCQmRnTp1SpaZmSmTyWSyly9fyvLz8zlp7/Xr17Li4mJOjl2dBQsWyCIjI5XeLl8iIiJkEyZMkO3evVsWHR0tGz9+vOzq1auy48ePyyZNmiSLjo7mpN3//vtP5uXlJfv7779lRUVFMplMJisqKpLdvHlT5uXlJfvvv/84affhw4eygoIChesKCgpkDx8+ZH6WSqWykydPMn/v78vLy0v25MkTheuePXsm8/LyqtfxG5qsrCzZkSNHZKtXr5Z99dVXsufPn8tkMpnswoULnP1eV61aJUtOTubk2NVZu3at7NKlS0ppq7CwsE7/sYF6KhoAthMm+Z5mt7CwELt27UJ4eDhUVFRQWloKZ2dn6Ovr49ixYzAyMqrVM+O64ithcvz48Th79ixsbW05rYYHoMaE34q4Sv7laxTGwYMHMWrUKPTu3ZtZpq6ujj59+qCoqAj79+/npEz36tWrqxxVJBaLsXr1aia/QSAQYNy4cfVuU1kjMWbPno3vvvsOHTt2xKxZs2rM++KiUmpCQgLWrl0LXV1d2Nra4uHDh8xnNzMzE0FBQbUqbFdXfI3CmDp1KrZv3w5NTU04OjpCJBJV2oatcuh1vc6ykadDQQWH+EqY5HuaXV9fX8THx2PFihWwsbHBlClTmHVdu3ZFUFAQq+2V4ythMiIiAmlpafDy8oKlpWWlwILNmzuXU0HXBR+jMJ4/f17l9PUtW7asVZl2thUWFrJ2A+BjJMbgwYOhp6fH/JuPUTS+vr6ws7PDkiVLIJPJcOPGDWadlZUVbt26xVnbfIzCWLp0KQBg9+7dVW7D1nWKjyqpFFRwiK+ESb6n2Y2IiMD06dNhb29fKWnPyMgIb9684aRdvhImc3JymOncS0tLOb3xN7Qx7sochWFqaooLFy7AwcFBLj9GIpHg/PnzrJ5LbGwsYmNjmZ+vXr3KzBRasd3o6GjWJhPjYyRGxV4VviqlJiUlYdmyZRAKhZWuFy1atEB2djYn7fI1CkOZN3o+qqRSUMGhxpYwyRaJRKJw7DdQ9s2Oi2qLAH8Jkw3tRs+FhjAKY8aMGdiwYQPmzp0LR0dH6Onp4e3bt7h37x4kEgmWL1/OWlsJCQlySaJhYWGV/m5VVVVhZmbG2o2nuY3EKKetrV1l4PDq1SumJ4VtfI3CaOrl0CmoUJL58+crra2Kj1xqg+0CL5aWlggJCVH4bD0sLAydOnVitb1yenp6UFdX5+TYtSWTyZCZmQk9PT3Oim1VVFBQgMjISLx8+ZLT7tuGMArD1tYWv/76Ky5cuIDExEQ8ffoU+vr6GDBgAIYMGcJqcabhw4dj+PDhAAAvLy8sXbqU83LZfIzEWL16dZ225yKA7t69O06ePAlra2smL0ogECA7OxtBQUHo2bMn620C/I/CSE5ORlJSEtLS0uDu7g59fX2kpqZCT0+Ps997aGgorl69CrFYrPB6wUbODAUVHOIrYXLXrl112p7toGLChAlYt24d1q5dy8zREB0djQsXLiAsLKzOF7LaUmbC5LuioqIQEBCAp0+forS0lJlQ6rfffoOtrS369u3LepupqalYsWIFJBIJCgsLoauri9zcXEilUohEImhra7P2N7V//37m3/Hx8fj1118xceJE9OzZE+rq6pBIJAgPD8eJEyfw1VdfsdKmIgYGBkovDMTHI0RllfV/t0cxPj4eb9++hYWFBXR1dZGdnY2kpCTo6+vjgw8+4OQcpkyZgrVr12Lx4sXMJGy///47UlNTYWxsjAkTJnDSbqdOnSAWi5VeAJCvRPZbt25h9+7d6NevHx48eMAUr/v333+hra3N2n2AggoO8ZUw6evry/xbLBZj69atGDBgAD788EOmyzg8PBzXr1/nZHRA586dsWLFChw7dgwHDhwAAOabyIoVKxRm0bNBmQmTFYWEhGD37t3o3bs3Bg0aJJeAZWpqiuvXr3MSVPj6+sLS0hKLFy+Gp6cnli9fjg4dOiA0NBTHjh2r9VTddcXXKAw+SSQSPHr0SGFCn0AgwKBBg+rdBh8jMRYvXsz8+9q1axCLxVi3bp3c45W0tDRs3LiRs5uvjo4O1q9fj5s3b+L+/fvQ0NCAjo4O3N3d0a9fP87qyyhzFEZFfCWynzt3DmPGjMHIkSNx9epVDBo0CBYWFigoKMC6detY6+WloIJDfCVMampqMv8+fPgwBg0ahE8//ZRZpqOjg9GjR0NNTQ2+vr6c9BzY2NhgzZo1kEgkyM3NhUgk4uQDWpEyEyYrCgwMxPDhwzF58mRIpVK5oMLc3Jyzi0RCQgLmzp3LJJiVlJRAKBSid+/eyM7OxqFDh7Bu3TrW2+VrFEZJSQkuXryIiIiIKrP1uRjyGBcXhy1btlSbMMhGUMH3SIzAwEBMnTq1Ur6GkZERxo0bh8OHDzMzbbJNVVUV7u7ucHd35+T4iihzFEZFfCWyv3z5Ep06dYJQKIRQKERBQQEAQEtLCyNGjICvry/zyK8+KKho4hISEjBy5EiF69q2bcvJh+batWtwcXGBtrY21NXVlTYREV8Jk2lpaVV+i1NXV5cbJsim4uJiaGlpQSgUQkdHB5mZmcy6du3a4fjx45y0q8xRGBX5+voiODgYXbt2hZ2dndJG9xw8eBDGxsb47rvvOB1VxPdIjKysrCprY5SUlHA2CsPHxwdubm5wcXF5vwqO74mP4ZYAf4ns2traTCDesmVLpKSkwM7ODkBZLhhbX8IoqOAQ3wmTAGBoaIgbN24oTJq8du0aDA0NWW9z37592L9/PxwdHeHm5obu3bvL9Z4ogzITJg0NDfHkyRPY29tXWpeYmMj0nrDNxMSEqWPQoUMHXLlyBV26dIFQKMS1a9eq7E2oL2WOwqgoLCwMkydPlut1UwaxWAxvb2/OEzX5ZmdnBz8/P7Ru3Vpu3ouEhAT4+flxluehp6eHI0eO4ODBg7C1tYWbmxt69uzJeQIlX6Mw+Epkt7S0xPPnz+Hs7Ixu3bohICAAQqEQqqqqOHXqFGs5MwKZTCZj5UikkromGHHRaxAWFoZt27bB1NQU3bp1Y24A//77L1JSUrBo0SImmZIteXl5CA8Px+3bt/HgwQOmFoebmxu6du3K6QgNPhImz5w5g9OnT2PWrFno2bMnpk2bhg0bNiAvLw+//PILxowZgyFDhrDe7vnz55GRkYGpU6ciPj4e69evh0QiYcb7z58/H3369GG9XaCs0mH5KIysrCzo6+vD0tKS9VEYFc2ePRtfffWV0hPrvvvuOwwcOJDzmxDfIzHS09OxefNmZlRNeaJmVlYW2rdvj6+//pqTLyFA2Tf0O3fu4Pbt20w9EAcHB7i6uqJHjx6cjoJR9iiMR48eYd26dbCxsYGLiwv27duH8ePHQywWM4nsXOSdxcfHIy0tDa6ursjLy8POnTsRFRUFmUwGS0tLLFy4kJWSBxRUcKh8mB1Qu4TJ8sxntiUlJeHMmTOVbgAjR47krM1yOTk5CAsLw+3btxEbGwsNDQ1069aNkxECFRMm7e3tsXv3biaoOHfuHKKjozl5RCKTybB//35cuXKFuaGrqKhAKpXCw8MDs2fPZr1NRdLS0hATEwOJRAJ7e3vWijI1FMePH0dmZqZSh2cDwNOnT7Fz507MmDGD01EZ75Zgr2kkRsUkSzZFRUVVulZ07dqVk7YUKSgoQEREBG7fvo379+9DKBTiyJEjrLejaBRG+fXi559/5mwUBlCWp3Ps2DE8fvyYyauwtrbGlClTYGNjw0mbihQXF6O4uJjV0XIUVCjJqlWr0K1bN4Vdt0FBQbhz5w5nQy0biqioKOzZswdZWVmc9MosXLgQH374IZMwOWnSJOYiERUVhd27d+P3339nvd1yqampuH//PlO22t7eXqkVJ5u6ixcv4sKFCzA2NoaDg0OlbH22RmG8a9asWUxdDlVVVYXfXtlOEL127RouXryIb775RuFIjI8//pizpMmGIC4uDqGhoQgNDUVOTg4n14s9e/YgOjoaX375JTMKo/x6cePGDQQFBWHLli2st1uRMhPZlYVyKpSEj4TJhuD58+cIDQ3F7du3kZqaijZt2mDUqFGctMVXwmS5Nm3acJY/US45ORmtW7eGmpparUZZcDGBGl+jMMqHSqelpcmV0K6Ii6CiKY/EeHdukZpwWckzISGBuVZkZGSgbdu2GDJkCGcVcvkahVER14nsfNRKoqBCSZSZMMn3s9nk5GTcvn0boaGhEIvFMDIyQq9eveDq6srp4xa+EibLicViZGRkMJUmK2Kr+9jb25uZMbM2MzdyEazyNQqDr8C7KY/E8PLyqtP2XPwOjh49irCwMLx58wYmJiYYMGAAXF1dOQmIK+JrFAZQdj0KDw9XeL1gs54OH7WSKKhQkkmTJmHbtm3w9vauMmGSLXxXyfP29oa+vj569eqFefPmwdramvU2FHF3d0dAQAD09PTkSvvev3+fKfzCheTkZPzyyy948eJFlduwdTH28fFhLrYrV67kZVZJvkZh8C03NxcvXrxAeno6nJ2doaOjwzwSYfsGpKyRGF9//TXz7/z8fPj5+cHMzAw9e/aUy/sSi8WcVTINCwtDr1694ObmptQRNnyNwvjrr7+wf/9+tGjRAiYmJpwG5XzUSqKcCiXiI2GSj2ezsbGx6Ny5s9JveHwlTK5cuRJv377FZ599VmUdg/I5DZoCvkZhAMDbt28RFBSEpKQkpKenY8mSJWjbti0uXrwIKysrTgLY0tJSHD9+HJcvX2a+VZY/e9+wYQMsLS1Z783gYyTGzp07oa6ujs8//7zSur1796KoqAgLFixgtU0+8TUKY8GCBbCzs8Pnn3+ulPmByoWEhKBr164Ke2dyc3Px77//slLWgHoqlMjCwoKzjO2q8FElT1nzFrxLIBBg9uzZGDZsmFITJp88eYJFixahW7dunLWhyIQJE5hHIe9KSkrC8uXLOemu/uijj3Dr1i2lBxUJCQlYu3YtdHV1YWtri4cPHzL5HJmZmQgKCqrVI6G6On78OK5evYqZM2fCzs5O7sbao0cPXLlyhfWgwtDQEJs2bVLqSIyIiIgq3z8XFxdWkxaLioqYxMSioqIat+ciiZGv6QTevn0LNzc3pQYUQNmcUOvXr1cYVLx+/Rq7du2ioILUTFnPZn/++WdMnjwZbdq0qTQ07l1czcFRThkJk++2pyhZkU8lJSWcXbT09PRw69YtrF69WqmjMHx9fWFnZ4clS5ZAJpPhxo0bzDorKyvcunWL9TYB4ObNm5g8eTIzAVNFrVu3xqtXrzhpFyjLxVHWcE51dXXExcUpDBYfPXrEan2ZqVOnMgFxbYZtcpVPw8d0As7Oznj8+DEcHBw4bacucnJyWBtWSkEFh/hOmASU92w2JycHpaWlAIDs7GxenvWXU0bCZEWenp7w8/NDx44dWSkeU520tDS8fv2a+fnJkyeVXmdxcTFCQkJgbGzMyTnwNQojKSkJy5YtYx5tVdSiRQvOykjn5eVV+XstKSmpdC7vi++RGAMHDsSpU6eQk5OD7t27MzkVkZGRCA4OxujRo1lra968ecx7yle57IqUOZ3Axx9/jD179qC0tLTKiczYSlKNjIxEZGQk83NAQEClUujFxcWIi4uTuz/UBwUVHOI7YRIAvvjiC2zevBnffvutwmezX3zxBSvtVAyIVq1axcox60qZCZMVHT9+HBkZGVi0aBGMjY0VRvwbNmxgpa3r168jICCA+bmqoZvq6uqYM2cOK22+i69RGNra2lUGDq9evWIm42Jbu3btcOfOHYXf4KOjo9GxY0dW2uF7JMb48eOho6ODs2fP4q+//mKW6+vrw9PTE0OHDmWtrYrVSfkqlw0obxRGReVfNgMCAuQ+yxWx9bt9+/at3PXw1atXePv2rdw2qqqqcHR0ZC2RnYIKDjWEaYX5eDYbEBAAd3d3hZF/ZmYmrl69irFjx7Le7t69e1FcXIwlS5ZwOvHTu9q2bYu2bdsqpa3BgwfDxcUFMpkMS5cuxYIFC9C+fXu5bVRVVWFkZMTZlNF86d69O/PMuzzxVSAQIDs7G0FBQXIjftg0evRobNmyBRKJhClp//TpU0RERCA4OBjLli1jpZ2GMBJjyJAh+Pjjj5Gens5cKwwNDTkdXvnll19iyZIlCkd+PH/+HJs3b8aOHTtYb1eZozAqUubEhx4eHkzO3OrVqzF79myYmZlx2iaN/lCSL7/8ElOnTlV44QsPD8fhw4eVOj06l/hKIPT09OQlYZIvb968gYGBgdIuhhXxMQojNzcXa9euRXJyMiwsLBAfHw9LS0ukpqbC2NgYPj4+nM0RERoaCj8/P7lHFC1btoSnpycnxZma00iM6q4XCQkJWLFiBScz7vI1CqOpo54KJeFrWuFypaWlSEtLU5hQyHWRmYrS09M5m32wISRM5uTkIDc3Fzo6OlUW1mFL+bf14uJiZGRkKO13y9coDB0dHaxfvx43b97E/fv3oaGhAR0dHbi7u6Nfv36c9sy4urrC1dUVYrGYGVVkamrKWe6QMkdiVFRQUIDIyEi8fPlS4d8TWz0k+fn5chVus7KyKuWUSCQS/PPPP5zlOvA1CqPc48ePERcXx1wvbGxsOHsMXi4jIwNRUVFVVsKl4leNCF/TCpeUlODgwYMICQmp8obLRq/BjRs35KZ637dvX6VvjcXFxXj+/Dlnj3qUmTD5rtDQUPj7+0MsFjPLTE1NMX78ePTq1YuTNjMyMrB3715ER0dXuQ1XFTX5GIUBlD3acXd3h7u7O2dtVEdZc7kocyRGudTUVKxYsQISiQSFhYXQ1dVFbm4upFIpRCIRtLW1WQsqLly4IJdP8OOPP1a5raenJyttvouvURiFhYXYunUrYmJiIBQK0aJFC+Tk5EAqlcLZ2RmLFy/mZARKREQEtm3bBqlUCl1d3Uo9nFRRs5FRVsLkuwICAhAVFYW5c+di+/btmDVrFjQ0NPD333/j1atXmDFjBivtaGhoyH0z19bWrtQjUT4F+uDBg1lp813KTJis6NatW9i+fTucnZ0xcuRI5vl3aGgofvnlF0ilUri5ubHe7p49e5CUlIRp06YpNYeEr1EY5cRiMRISEpCVlQUDAwNYWFiw/py4qgS6qrCdI6TMkRjlfH19YWlpicWLF8PT0xPLly9Hhw4dEBoaimPHjrFa9bd3796wtLSETCbD5s2b4enpWSlgU1VVhampKWfzjShzFEZFR48eRXx8PBYtWoQPP/yQ+RyFh4dj79698PPzw8yZM1lv9/jx43B0dISXlxdnvcUABRVKw0fCJFBW+33cuHFwdXXF9u3bYWVlBQsLC/Tr1w87duzAnTt3WGm/V69ezDfyXbt2YcyYMUrvLVBmwmRFp0+fxkcffVQpMOzXrx/27t2LwMBAToKKuLg4zJkzh7MJl6rC1yiM/Px87NmzB+Hh4ZDJZNDU1ERhYSEEAgF69uyJuXPnsjbW/tKlS3I/l89SCoBpFyjrUdDQ0GA9qFDmSIxyCQkJmDt3LhOclpSUQCgUonfv3sjOzsahQ4ewbt06VtoyMTGBiYkJgLLExY4dO3KWD1MVZY7CqCg8PBxTpkyR68EUCoXo1asX8vLycOLECU6CirS0NMyYMYPTgAKgoELplFnMBijLYTAxMYFQKISamhpyc3OZdX369MGvv/7Kei/J/PnzWT1eQ283NTUV06ZNU7jOxcVF7rEQm/T09DjpBq8JX6Mw9u3bh3v37uHLL79Ez549oa6uDolEgvDwcBw4cAD79u3DV199xUpb+/fvZ/4dHx+PX3/9FRMnTqzU7okTJ1hr813KHolRXFwMLS0tCIVC6OjoIDMzk1nXrl07TpIlAf4q8CpzFEZF+fn5VZZYNzQ0REFBASftdurUCWKxmPNKuBRUKJmyEyYNDAyQl5cHADA2NsajR4+YPyo2KwHyMcVudZSZMKmnp4fExESFH9bExETOvrmPHz8eZ8+eha2tLWvf0GtjypQpWLt2LRYvXszMWfP7778zozAmTJjASbt37tzBtGnT0Lt3b2aZuro6+vTpg6KiIhw+fJiTdg8ePIhRo0ZV2e7+/fuxadMmTtoWCoVo1aqVUuaOMTExYZIlO3TogCtXrqBLly4QCoW4du0aDAwMWGtr9uzZ+O6779CxY0fMmjWrxoTXquqx1AdfwUyHDh3w119/wdnZWe51y2Qy/PXXX5WGiLNl6tSp2L59OzQ1Nat83MNGLgcFFUqirITJd9na2iIuLg7du3fHRx99hKNHjyI1NRVqamoIDQ1lrVuejyl2FeEjYbJ///7w9/eHVCqFi4sL9PT0kJ2djdu3byMwMBAjR47kpN2IiAikpaXBy8sLlpaWlQILror38DUKQ1NTs8obW8uWLTkrr/z8+fNq201OTuakXWWNxCjn5uaGp0+fom/fvswwz2nTpjHP/NnsCRw8eDATbA8ePJjXCrzKHoUxadIk/PDDD1i0aBFTgyQ7OxsRERF48+YNli9fzkm7S5cuBQDs3r27ym3YuAdRnQol+eOPPxASEoIpU6ZUmTDJxWORrKwsZGdno127dgCA8+fPIzw8HBKJBA4ODhg7diw0NTVZb5cPFRMmXV1d5RImY2Ji8NVXX3GS2yCVSnHixAlcvHhRriqfuro6hg4digkTJnBy0axNGXi+uni5cOrUKTx48ADLly+Xe+xTVFSEjRs3ws7OjpOiakuXLoWuri6++eYbuYBJIpFg48aNyMnJqXb0wvuozUgMLgpCVZSWloaYmBhIJBLY29sz15Cmgq9RGADw4sULnDp1ComJicjMzISBgQGsrKwwZswYzob4VxylVRU2qptSUKEkCxcuxIgRI9C/f39MmjSJmToZAHbs2AF1dXXORoDURUhICLp168Z5Mg8XvL290alTJ4Xv4969e/Hff/9xNr4fKCvO9Pz5c2ZUQtu2bRvl+1hbyhiFUdGRI0fwzz//oLi4GA4ODkzQeP/+fairq8PV1VUueGPrm3xsbCw2bNgAdXV1ODo6Mu3eu3cPEokEy5cvZ70rfdOmTZDJZMxIjA0bNsiNxFi8eDFns2jWhlQqxdq1a/HFF18wCZeNzb59+/DPP//giy++UDgKo0+fPpwkTDZ19PhDSfhImKwrqVSKXbt2YcOGDXW+GdY1GZGNKXbfxVfCZDkdHR3entPKZDJkZmZCT0+P82I+yhyFUVFYWBhUVFSgoqKCx48fM8vLe9rCwsKYZWw+YrO1tcWvv/6KCxcuIDExEU+fPoW+vj4GDBiAIUOGcFKcSZkjMd5XbGzseycVNoTJFvkahVFReno601NRVfIm25KTk5GUlIS0tDS4u7tDX18fqamp0NPTY2UEDgUVSqKshEm+7Nq1q07bcxFU8JUwCZRV5yu/6VTszvzkk0+gr6/PWbtRUVEICAjA06dPUVpayvSA/fbbb7C1tUXfvn1Zb1OZozAq4rOMvYGBAefJxRXxNRJDWRrCZIt8jcIAyuYdOX36NDIyMphlBgYGGDVqFGd1fAoLC7Fr1y6Eh4dDRUUFpaWlcHZ2hr6+Po4dOwYjI6NaTUNfEwoqlERZCZN8KZ8OGyjrFt+6dSsGDBiADz/8UG4ypOvXr3OSPAjwlzAZFxeHDRs2QEVFBY6OjjAzM0N2djauXLmCP//8E8uXL4eNjQ3r7YaEhGD37t3o3bs3Bg0aJJeAZWpqiuvXr3MSVPA1CqM5UeZIDD40hMkW+RqFERAQAH9/f7i7u+PDDz9kgqiwsDAcPHgQOTk5nOQG+fr6Ij4+HitWrICNjQ2mTJnCrOvatSuCgoJYaYeCCiWZNGkSUzBo6NChkMlkTMLkxx9/zMkfkTJVTPY8fPgwBg0ahE8//ZRZpqOjg9GjR0NNTQ2+vr517v6sjbFjx6K0tBRnzpzByZMnmeXq6ur49NNPOXuPDxw4AAsLC3z99ddy70NhYSE2btyIgwcPcjLkMDAwEMOHD8fkyZMhlUrlggpzc3PWLhLv4msUBgA8e/YMgYGBzERm69atg4WFBY4fPw4bGxt06dKF9TZLSkpw8eJFREREVDlnAttDHpU5EoNvgYGBmDp1aqXKmUZGRhg3bhwOHz7MzLTJJr5GYVy+fBmjRo3CxIkT5ZaX9xpcvnyZk2tVREQEpk+fDnt7+0qVcI2MjPDmzRtW2qGgQkn09fXlusGHDRuGYcOGVbl9Y06YTEhIqLJXoG3btpwMnQXKnodOmjQJn376qVITJlNSUuDt7V1pFI2mpiY+/fRT/Pzzz5y0m5aWVuW3OHV1dbkJm9g0ePBgBAUFwd7evtIojKCgIM66b6Ojo7F582ZYW1ujb9++clUQ1dTU8Oeff3ISVPj6+iI4OBhdu3aFnZ2dUsqhV7w2WFtbY8uWLU12JAZfky3a29tj06ZNOHXqFMLCwuQeWy5ZsoSzURgSiaTK3CtbW9tK1VzZbLeqmj2FhYWsFVWjoKIBqk/CZENgaGiIGzduwNnZudK6a9eucZ6QpOyESXNzc2RlZSlcl5mZydmICENDQzx58gT29vaV1iUmJqJNmzactJufn4+XL19i3rx5CkdhWFhYyBVAYysX4dixY+jXrx/mzp2L0tJSuaCi/BEBF8LCwjB58mS5njdlMzIyqvLbemMficHXZItA2ZccNuc0qY0ePXogPDxc4ReCsLAwdOvWjZN2LS0tERISovC6HBYWhk6dOrHSDgUVhHWTJk3Ctm3b4O3tjW7dujE3nX///RcpKSmcfoj5SJicOXMmduzYAU1NTfTo0QNqamooLi5GREQEzp49Cy8vL07adXd3R0BAAPT09ORKY9+/fx/nzp3DmDFjOGmXr1EYYrGYmbHy3bofWlpaciOq2CSTyTh7vs6W+ozE4Btfky1WpMxRGM7OzvDz88MPP/yAHj16MNfHiIgIJCcnY8qUKYiKimK2Z6t+0YQJE7Bu3TqsXbsWLi4uAMp6/y5cuICwsDDWHklTnYoGSCqVVqploSw3btxA9+7d691DkpSUhDNnzlSaPG3kyJGcvaZ3EybLL0737t1DaWkpZwmTs2bNqnHCqYrYev4uk8mwf/9+XLlyhXnWrqKiAqlUCg8PD8yePZuVdhqKefPmYcyYMfDw8Kj0Gfnzzz9x6dIlbNu2jfV2jx8/jszMzAabx8Dn9YJNyp5sEeBnFEZdy9iz+bg4Li4Ox44dw+PHj5m8Cmtra0yZMoW1ayP1VDQDdUluY6OiGgBYWFjIZXgrA18Jk3yVGRYIBJg9ezaGDRuG+/fvIycnBzo6OrC3t680jXRT4ObmhhMnTsDc3BzW1tYAyt4DsViMs2fPwt3dnZN29fT0cOvWLaxevRoODg6V5kwQCAQYNGgQJ21zrSHUiyin7MkW+RqFwXUl1OrY2NhgzZo1kEgkyM3NhUgkYj2xmoKKJo6v5DY+8JUwOX78eE6OW1tt2rThLH+iKnyMwpgwYQKSk5Ph4+PDPMravHkzsrKy4OTkhFGjRrHeJvB/w6XT0tIQGxurcJvGGlTwVS+ifLhsbb07MoQNfI3CUMbkcDVRV1fnpGgbQEFFk6es5LaG8I2Hr4TJ5OTkajPFo6KiOP0GJhaLkZGRITfvSDku2uUrUFVTU8M333yD+/fvy/XMODg4cDqdM1ejlRoCvupF1DXPiIvfAV+jMP744w+MGzdOYeXbnJwc/P7775z18iYmJiI8PFzh9YKtCQgpqGjilJXc1hAq5PGVMPn1119jwoQJ+PTTT+Xe44KCAmZmWi4uisnJyfjll1/w4sWLKrfhol2+RmGUc3BwgIODA6dtNEfKrBfx9ddfM//Oz8+Hn58fzMzMmHoR5cXyxGIxZ5VM+RqFcenSJURHR8PLy0tuaHBERAR+//13ziZ4/Ouvv7B//360aNECJiYmnA2NpqCiARIKhZg3bx6MjY3rfSxdXV28fv1a4boXL16w1q3YECrkbd68GRKJhEnWezdh8qeffpLbnq2EyYkTJ+LEiRO4c+cOvLy80Lp1a9y7dw+//fYbSktL5S6gbNq7dy+Ki4uZMfXKqJ8AKHcURkPoJgfKRhUFBQUxj3uWLFmCtm3b4uLFi7CysmJyPBozZdaLqNiDtnPnTnTt2hWff/653DaDBg3C3r17ERUVxUnFYb5GYfz444/YvXs3li9fjnHjxsHd3R2HDv2/9s48Kooze/9Pt+wgNIssERQBcWEJCi4RlChqGIUY92DEjNsEYnSI4jYxEscFlzGaIGKYREVtjIokuAZ34ogiBP2iKCibBpF9F+kGmt8ffbp+tDQqUlUvmPdzjudoV9G3rrZdt973ee7dj2vXrmHs2LHM/y22OXnyJEaPHo2FCxdyOh+IFhU8QkIwSULcRqpDHinBpK+vLwYNGoTw8HAsX74cTk5OSElJgbu7O+bNm8dZr5Hc3FwEBQVx9kTVFnwVqkDnWCbPysrC+vXroa+vj4EDByI9PZ3pqllRUYGTJ09i2bJlrMd9XYRCISt5k+oXcfPmzTb//oYPH87ZZOGwsDAAQHl5Of7v//6vzeMK2PpsmZqaIiQkBGfOnIFYLMbRo0chEonw1VdfcbqNV1VVBXd3d84HDtKigidI7UOTELeR6pBHUjBpaWmJTz75BKGhoUhJSYG1tTUWLFjAybROBebm5ipbRnMNn4VqZ1gmj4qKgoODA4KDg9Hc3IwrV64wx+zs7PC///2PlTikdUmk+kVoaGggIyND5Q31/v37Sl1b2YSkC6O+vh6PHz9GY2MjDAwM0NDQwKyqcoWLiwsePnzI+dYhLSp4gtQ+NAlxG6knHlKCyYaGBkRHR+Ps2bMYOnQoPDw8EBUVhWXLliEwMJCzv2d/f3+IxWL06dMHZmZmnMRQBZ+FamdYJs/JycGKFSuYXiAt6d69O2tFMmldkrGxMbZs2cJ7v4hx48bh+PHjqKmpgZubG1MsJicn48KFC5gyZQoncUm5MO7evYuIiAhma9TR0RFisRjbt2+Hu7s75s+f38q2zAbe3t744Ycf0NTUBGdnZ5Ux2GhNTosKniDVDVABn+I2Uk88pASTy5cvR01NDRYvXszc1JycnLBv3z5s2rQJXl5erW6EbHD48GGUl5cjKCgIpqamKldFQkNDWY9LyoVBaplcR0enzcKhqKgIBgYGrMQhqUuSSqXYunUrJk+ezHu/iBkzZkBPTw9xcXE4d+4c87pIJIK/vz8mTpzISVxSLoz169e32hqdO3cuhg4dij179mDZsmXYs2cP63EVK2ExMTFKD7UtYeP7kRYVPMHnPjRpcRupJx5Sgklzc3N88803Sm3AtbW18fnnn2PYsGGIjIzkpKiwsrKClZUV6+/7uvDtwiC1TO7m5oajR4/C3t6eeboVCASorq7GyZMnlVqkswXfuiQNDQ1kZ2e3WonhiwkTJsDb2xtlZWXM94WxsTFrQ65UQcqF8eWXXzJtslvi4OCAbdu24cCBA5zE5bJxWUtom26eOHToEBISErBs2TLY29vDz88PmzdvhqamJtavX48xY8Zg+vTprMQi2QaWNPn5+QgPD8eTJ094E0y+itra2i45GK4lpAtVADh69CiOHz+O8ePHt7lMzoWupra2FuvXr0d+fj5sbGzw4MED2NraorCwkBHdaWtrsxpz9uzZ+PzzzzFixIhWx65du4Y9e/bg4MGDrMbctWsXdHR0MG/ePFbft7NSXFyMiIgIPHjwoE0XBleFhYLm5mZUVFTAwMCAcwElX9CigicaGhqwfft23Lp1CyKRCJWVlTAyMmL2oYODg1mzBLa0Qb2OuI2LfWgAaGpqQmlpqUoxIVdjhQH5nmVoaCgaGxthbW2NkJAQTgWTgPzf9/Lly8jOzkZZWRnmz58PCwsLJCYmolevXpzmC8iXaxXFS1vjjTtCZylUz5w5g7i4OKUmZyKRCB9++CFny+SAXGD8+++/t2qH7unpCXV1ddbjhYaGIj8/H0uXLm2lS/r2229hZWWF1atXsxrzf//7Hw4ePAh7e3sMGjRI5QA+rlYanz9/juTkZDx9+lTl9wVXIlwAjAujubkZIpEIAQEBnG7jAfLv6JiYGOTl5UEmk2HTpk2wsbHBnj174ODggJEjR3IW++HDh8jIyGC+L/r378+qRocWFTzD9z50eHg4NDQ0VC6/R0ZGQiKRYPHixazGbGxsZDQMbbkTuLjptCWYlMlknAomFXvfdXV1sLGxQXp6OjPc6aeffsLz58/xxRdfcBI7MTERx44dQ0FBAfPaO++8gxkzZuC9995jLU5nKVQB+QAtPpfJSVBWVoatW7ciLy9PpS5p5cqVrE/TfJ3CkYv/t4WFhfj6668hlUpRX18PfX191NbWQiaTQVdXFzo6Opw5Nerr67F//35cvnwZBgYGaG5uxsKFCznZ0lKQkJCAiIgIeHh4wNHREREREcz3xYkTJ3Dr1i1Otirq6+uxY8cO3L59G0KhEN27d0dNTQ1kMhlcXFywdOlSVuaAUE0Fz/C9D01C3BYTE4PU1FQEBAQgLCwM8+fPh6amJq5evYqioiLMnTuX9ZgAOcHkvn37YGJiwgwymzVrFnNs4MCBEIvFrMcE5E+WYWFhcHFxwUcffcTc3BMTE7Fz507IZDLWbu6dwYWhQCgUokePHryr9wsKCpCVlYXKykoYGhrCxsaGs9bvJHRJpCyWUVFRsLW1xdKlS+Hv74/Vq1fD2toaiYmJiI6ORlBQECdxSbkwYmNj8eGHH2LWrFmQyWSIiIhgjllaWuLkyZOsxwTkW/APHjxAUFAQhg0bxriZkpKSEBkZCbFYzMrWFy0qOKQz7EOTELddv34d06dPx4gRIxAWFgY7OzvY2NjA09MTu3btQkpKCidfjKQEkxkZGfjyyy+hq6vbSuhmYGCAiooK1mMCwC+//AIvL69WbhpPT09ERkYiNjaWk5s7KRcGIG9UlJqairKyMt6Wyevq6vDDDz8gKSkJzc3NTKdWgUCAoUOHIiAggNXtNVJODFIWy6ysLAQEBDDbv42NjRAKhfDw8EB1dTX279+PDRs2sB6XlAujtLS0zVVTDQ0N1NXVsR4TAJKSkvDJJ58orWAKhUK89957ePbsGY4cOUKLis5OZ+gGSMIDXlZWBgsLCwiFQqirqyvZZUeOHInvv/+eE1vpqlWr2jzm6urK2c1OXV1d5TAvQH4T5OJpB5AvG3/66acqjw0fPhwJCQmcxCXlwrh58ya+++47yGQy6Ovrt9IgCQQCToqKH3/8EWlpafjiiy8wdOhQaGhoQCqVIikpCXv37sWPP/6IJUuWsBaPtBODby1UQ0MDtLW1IRQKoaenp1SE9+rVC4cPH2Y9JkDOhWFsbIzc3Fw4Ojq2Opadnc3ZxOG6uro2t8yMjY3x/PlzVuLQooJDOkM3QBIecENDQzx79gyAvCXt/fv3mRtQUVER6/Fa8irBJBcuDGdnZ/zyyy9wdnZm1OICgQANDQ2cjpY3MDBAdna2ypt7dnY2a/0TXoRUs6LDhw/D2dkZixYt4tVNk5KSgk8//RQeHh7MaxoaGhg5ciQkEgknNx9XV1ckJyfzulVKSgtlYWHBrOoqGgEOGjQIQqEQly5dgqGhIesxASgVFC+6MLS0tDjrpzNmzBjExMTAwMBASbtx584dnDhxAlOnTuUkrrW1Nc6dOwcXFxelPj7Nzc04d+4cevfuzUocWlRwSGfZh+bbAz5w4EBkZGTAzc0NXl5eOHToEAoLC6Guro7ExETO8lQlmFRU3/fv30dqaiongsnZs2fj66+/xuLFi5kbfExMDPLz89HY2Ijg4GDWYwLy+TDHjh2DTCbD8OHDYWBggOrqaly/fh2xsbH46KOPOIlLqllRaWkp5s6dy7s9V0tLq80bm5GRESvithdxcXHBwYMHUVFRwZsTg5QWyt3dHXl5eRg1ahRmzpyJjRs34tNPP2X2/D///HNO4gJkXBiTJk1CaWkpwsPDGT3FmjVrIJPJMHbsWEyYMIH1mADg5+eHTZs2ISgoiHmwra6uxs2bN1FSUsKam4i6P3ji008/xbJly1Q+VaalpWH79u2IiooicGXsU1lZierqaqahzKlTp5CUlASpVAonJydMmzaNE//3xo0bIZFIlASTClX19evXIRaLOROj1dbW4tSpU7h7966S5dDHx4cTiycgd0EcOXIEZ86cUdp+0dDQwMSJEzFz5kxOB6zx7cLYsGED3Nzc4O3tzVkMVRw/fhx3797F6tWrlbZ2JBIJNm/eDAcHB0ybNo3VmCScGP/85z8xadIkvP/++/Dz82P+7wByEaeGhgZnT+8tKS0txe3btyGVSuHo6KjUmIpNSLkwFBQWFuLu3buorq5mvi/eeecdzuIB8kaLx48fR3Z2NioqKmBoaAg7OztMnTqVta0tulLBE6T2oQH+PeAikUjpycrHxwc+Pj5tnp+QkABXV9cOP4GSEkwCgJ6eHj7++OPXOpetfIVCIfz8/ODr64vHjx8zrgQrKytenub5dmHMmTMHYWFh0NLSanN2ARerBnV1dXj69CkCAwPh5OTEbPfcuXMHGhoasLGxwaFDh5jz2fj/RMKJQUoL9SImJiZtdguVyWRYv349/vGPf8DCwqJDcUi5MBSYm5u/Uj/BZr6AvAsvV24aBbSo4AlS+9Cv4wHnsrHMq5DJZNi9ezdCQ0M7fCMkJZhsD2zmq0BPT4+zIW1tQcKFsXz5cgBQ+vJ/ES72/G/cuIFu3bqhW7duePjwIfO6YrXtxo0bzGtsiUVJODFIaqHaw71791gRFZJyYbQXtvJtSVlZGbNSwXa/E1pU8ASpfWhSHnASkBJMkqSqqgqnT59utZz5t7/9TeU+PBuQcmEEBgay/p6vQ3h4OJG4AL9ODFJaKFKQcmGQ5Ny5c/jll19QXl7OvGZoaIjJkyfjgw8+YCUGLSp4hMTQHFIecBKQEkySIiMjA6GhoejWrRucnZ3Rs2dPVFdX4/z58/jtt9+wevVq9O/fn/W4pFwY77//Pm+xSEPCieHn58dMY504cSKam5sZLZS3tzfruhHSkHJhkCImJgbHjh3DmDFjMGzYMKZL640bN7Bv3z7U1NSw8m9Miwqe4XsfmpQHnAQmJibYtm0bI5g0NzdHZWUlhg8fzqlgkhR79+6FjY0NI0xVUF9fj82bN2Pfvn3YsmUL63H5dGGsXr0aixYtgqWl5SvV6QKBAJs2beLkOh49eoTY2Fjk5OSgrKwMGzZsgI2NDQ4fPoz+/fuzvgpGwonRXi1UV4eUC4MU8fHxmDx5civtl4uLC0QiEeLj42lR0dUgMTSHlAecFCQEk6R48uQJli1b1spJo6WlBV9fX3z77becxO3Xrx8KCgo4H7oEyIVlChGzpaUlp26Wtrh16xa2bt0Ke3t7jBo1CjExMcwxdXV1TrbWSHWl/SshEAiwYMEC+Pj48O7CIIFUKm1TezVw4ECcPXuWlTi0qOAJUoJJkh7wzgwXgkm+sbS0VJrW2ZKKigrO5lLw6cJo+flsb4datoiOjoanpycCAgLQ1NSkVFQoCnW24cuJsWjRonYVaqTmg3AJCRcGCYYMGYKkpCSVDwM3btyAq6srK3FoUcETpASTLZcv7e3tsX37dl484BTumTdvHnbt2gUtLS0MGTIE6urqaGhowM2bNxEXF8fZTZiUC4MUBQUF8Pf3B4BWN2BtbW2lGz5b8OXEGDZsmFJOiYmJkEgkcHZ2Zvbc09LSoKmp+dYJNdsLFy4MPnFxcYFYLMamTZswZMgQxoF48+ZN5Ofn45NPPlGaRvymK2G0qOCJziKYfJkHnARCoRCBgYEwNTUlfSm8wGa+W7duhVQqxXfffQcAzKArQG6J+89//qN0/o8//tjhmAA5FwYp9PX1UVxcrPLYn3/+yckgQL6cGHPmzGF+HxsbCzMzM6xatUqlRkdbW5uVmB1BKBS+VQXrq2Az37CwMAByO/j//d//tXlcwZvGpUUFT5ASTJ45cwYVFRX45JNPWh2Ljo6GkZERJx0K2yNsextU/STy/eCDD4hoDN6Gf6/24O7ujiNHjsDS0hL29vYA5CsWBQUFiIuLw5gxY1iPScKJER8fj88++6xNjc4PP/zAmiNi3bp17Tqfy86WfNAZ8uVr64oWFTxBSjB57tw5+Pr6tnlNJ06cYL2oICFsIwmpfGfMmMH6e7ZFZ3FhkGDmzJnIz89HSEgI447YunUrKisr8e6772Ly5MmsxyThxHj+/HmbGp3KykpmFYwNXnRiPXjwAFVVVbCxsWG2XXJyciASidC3b1/W4pKiM+TLl+OQFhU8QUowWVJS0qYIydTUFCUlJazHJCFsIwmpfPPz81/aACk1NZU1h0BncGGQQl1dHatWrcKdO3dw584dZraLk5MTLw4YvnB1dcWhQ4ego6MDNzc3qKmpobGxEcnJyRCLxawJ+QBg6dKlzO8vXbrEDANsuZVUWlqKzZs3vxV/x50h359//hnTp09Ht27dWh2rqanBf//7X6XrfFNoUcETpASTenp6KCgogIODQ6tjBQUFnOyTkhC2kYRUvitXrsTMmTPh6+urFPf58+dM4yS29mM7gwuDNE5OTpyOIiftxFi4cCHCw8OxY8cOAPLPrkKY6Orq2mrCMlvExsZizpw5rbQpJiYmmD59Og4cONCpdGAdhVS+Z8+exa1bt7Bo0SKl+83Nmzfx3//+l7Uhj7SoIARfgklXV1ccO3YM/fr1U/ogPX78GDExMRgyZAjrMUkI29oLm4JJUvl+/PHHOHLkCFJSUrBo0SKYmZkhLS0Ne/bsQVNTE1auXMlJ3L8Ciq3K14WNf2PSTgwdHR0sX74c+fn5yMrKYrr+2tnZsd4SvCWVlZVobGxUeayxsZHRlrwtkMp327ZtiIiIwOrVqzF9+nSMGTMG+/fvx7Vr1zB27Fjmwaij0KKCJ0gJJmfNmoXMzEysWLECffr0gUgkQmVlJXJzc2FlZYVZs2axHpOEsE0BCcEkqXx9fX0xaNAghIeHY/ny5XByckJKSgrc3d0xb968Ltt/ozPQ3tUYNlaEOosTw9LSktMi4kUcHBwgFothZmYGW1tb5vWsrCyIxWLeh+Wpgk0XBql8TU1NERISgjNnzkAsFuPo0aMQiUT46quvWN1yETQ3Nzez9m6UNgkKCoKvry+8vLxaHbt8+TJOnDjBLDuyjVQqRUJCAtLT01FTU4Pu3bvD0dERnp6eUFdXZz1eQ0MDtm/fjlu3bjFFjJGRESNsCw4ObjWEig1aCiYdHR0RExOD0NBQ2NjYICYmBg8fPnylyPBNIJWvgrt37yI0NBSNjY2wtrZGSEgIdHR0OIv3V6ClX7+urg5isRg9e/bE0KFDGX9/UlISCgoKMHv2bNZXDj777DN89tlnKjUxf/zxB3744QdERkayGlNBQUEBysvLVU785aKLZ1lZGbZu3Yq8vDyIRCJmVaayshK9e/fGypUrWZuk2RlcGHzm+yL19fXYv38/Ll++DAMDAzQ3N2PhwoVKs086Cl2p4AkSgkkFGhoaGDduHMaNG8dZjJaQEraREkySyrehoQHR0dE4e/Yshg4dCg8PD0RFRWHZsmUIDAx8KwRupGh58wwPD8fgwYNbaQrGjx+PyMhIpKamsl5U8OnEUJCfn4+dO3fizz//bPMcLnpEGBsbY8uWLUhNTUV2djaz7WJra8t6EdMZXBh85tuSu3fvIiIigtkadXR0hFgsxvbt2+Hu7o758+er7I7bXmhRwRMkBJOAfDS2RCJhtAPNzc24ePEi8vPz4ejoCDc3N07iAtwL216EtECU73yXL1+OmpoaLF68mLmpOTk5Yd++fdi0aRO8vLw4E9f9lbh58yaWLVum8tjw4cOxfft21mPy6cRQEBkZiYaGBgQHB8PS0pLT1TUFUqkUW7duxeTJkzF48GDO55mQdmHwnW9L1q9f32prdO7cuRg6dCj27NmDZcuWYc+ePR2OQ4sKniAhmASA3bt3w8zMDPPmzQMgf9L49ddfYW5ujt9++w0BAQGsaAtICNtehE/BZGfI19zcHN98841SPwNtbW18/vnnGDZsGCIjI2lRwQIaGhrIyMhQeZO5f/8+Y7VlExJOjNzcXAQFBXFSsLSFhoYGsrOzIZPJeIupgIQLg2S+X375JYYPH97qdQcHB2zbtg0HDhxgJQ4tKniChGASAHJychgdh0wmw/nz5+Hn54dJkybh6NGjOH36NCtFBQlh24vwKZjsDPmuWrWqzWOurq6cPEH/FRk3bhyOHz+OmpoauLm5MZqK5ORkXLhwAVOmTGE9Jgknhrm5ucrpyVzj6uqK5ORkXlf5AHIuDFL5tiwompubUVFRAQMDA3Tr1g1aWlqsDKgDaFHBG3p6eggNDVUSTJqZmcHLy4szwSQgF5kp9hFzcnJQW1uLkSNHAgAcHR1x8uRJVuK0tC++jrCNC/jsfNgZ8gXkuorLly8jOzsbZWVlmD9/PiwsLJCYmIhevXpRBwgLzJgxA3p6eoiLi8O5c+eY10UiEfz9/TFx4kTOYvPpxPD394dYLEafPn1gZmbGS0xAPujq4MGDqKiowKBBg5RW3hRwsU1AyoVBKl9ALkCOiYlBXl4eZDIZNm3aBBsbG+zZswcODg7MvaEjUPfHW86SJUvg6+uLcePG4ejRo7hx4wa+/fZbAEBKSgoiIiLw008/sRozPDwcGhoaKpdoIyMjIZFIsHjxYlZjtoRvwSSpfBX7wXV1dbCxsUF6ejrjdvnpp5/w/PlzfPHFF6zH/asik8lQVlbGrBoYGxtDKBRyGpNPJ8bq1atRWlqK2tpamJqaqnQQhYaGshoTkD8MvAouVvpIuTBI5ZuQkICIiAh4eHjA0dERERERzPfFiRMncOvWLVbcLnSlgidICSZHjx6NQ4cO4c6dO0hNTVXaZnnw4AF69uzJekwSwraW8C2YJJXvvn37YGJigpUrV0JLS0vp33bgwIEQi8WcxP2rIhQK0aNHD15mKJBwYlhZWcHKyorV93wd+Bp09SKkXBik8o2NjcWHH36IWbNmQSaTISIigjlmaWnJ2qo1LSp4gi/B5ItMnjwZRkZGyM7Oxrx58zB69GjmWG1tLSeNmfgUtnUGwSQJIR8AZGRk4Msvv4Surm4r4ZeBgYHSJFxKxygvL0dqairKyspU6g7Y3uIi4cTgav7Qq+Br0FVLSLowSOQLyL8r21qx1dDQQF1dHStxaFHBE3wJJlXh6ekJT0/PVq+zJcx5ET6FbZ1BMElCyAfI+2OoWhYH5DdBNjznFPlK1HfffQeZTAZ9ff1WN3iBQMB6UUHCiUGapqYmlJaWqiza2NaVkHRhKOAzX0C+MpObmwtHR8dWx7Kzs9vso9ReaFHBE3wJJtuCzw8wn8K2ziCYJCXkc3Z2xi+//AJnZ2emlbNAIEBDQ8NbN16eJIcPH4azszMWLVrEm/CVlBOjuLgYV69exdOnT1UWrGxMsXyRxsZGZgBeWzlz8TBAyoVBKt8xY8YgJiYGBgYGSh0079y5gxMnTmDq1KmsxKFFBU8YGxsjPz8fAwYMQGpqKnr27AkjIyMA8pshV0vkpD7AEyZMgLe3N+fCNtKdDxXwlW9LZs+eja+//hqLFy9mljVjYmKQn5+PxsZGBAcHcxb7r0RpaSnmzp3Lq5OGhBMjJycHISEhMDExQUFBAXr37o26ujqUlJTAyMiItSfZF4mJiUFqaioCAgIQFhaG+fPnQ1NTE1evXkVRURHmzp3LSVxSLgxS+U6aNAmlpaUIDw9n9BRr1qyBTCbD2LFjMWHCBFbi0KKCJ0gIJgFyH2CAX2EbQF4gyne+JiYm2LZtG06dOoW7d+/C3NwclZWVGD58OHx8fFq1JKa8Gf369UNBQQGvbc8PHz6M8vJyBAUF8ebEOHjwIIYPH47AwED4+fkhICAANjY2yMzMxHfffYdJkyaxGk/B9evXMX36dIwYMQJhYWGws7ODjY0NPD09sWvXLqSkpHBycw8LCwMg/964efOmynO4eOAila9AIMCCBQvg4+ODu3fvorq6Gnp6enB0dMQ777zDWhxaVPAECcEkQO4D/Pz5cyQnJ+Pp06e8CNsAcoJJgEy+gLz/yccff/xa5yYkJMDV1ZX2rmgnc+bMQVhYGLS0tODs7KxSq6KpqclqTBJOjLy8PEyaNIlpca/4HPfr1w/Tpk2DWCyGi4sL63HLyspgYWEBoVAIdXV1pXb6I0eOxPfff8+J/ouUC4NUvgrMzc1fueokk8mwfv16/OMf/4CFhUW73p8WFTzCt2ASIPMBLiwsxNdffw2pVIr6+nro6+ujtrYWMpkMurq60NHR4eQmS0owSSrf9iCTybB7926EhobSoqKdLF++HACULHgvwvYTLQknhkAggJqaGgQCAfT19VFSUoJ+/foBkK+KFRYWchLX0NAQz549AyAfrnj//n3mwaCoqIiTmAA5FwapfNvLvXv3mNbw7YEWFTzDt+KXxAc4KioKtra2WLp0Kfz9/bF69WpYW1sjMTER0dHRCAoK4iQuKcEkqXwp/BAYGEj6EnjB0tISRUVFcHR0hL29PU6fPg1bW1uoqakhLi6OM23HwIEDkZGRATc3N3h5eeHQoUMoLCyEuro6EhMTOdNBKeD7O5l0vlxDiwqeICWYfNkH+Nq1a/Dw8GA9ZlZWFgICAhjrXWNjI4RCITw8PFBdXY39+/djw4YNrMcFyAgmSeZL4R6urN6vgm8nxtixY1FSUgIA8PPzw8aNG5mCWEtLixPnhyKWYs7GxIkT0dzcjKSkJEilUnh7e2PatGmcxCX1nUwqX76gRQVPkBJMvuwD/Le//Y2TD3BDQwO0tbUhFAqhp6en1ISpV69eOHz4MOsxW8K3YJJ0vhT2Wb16NRYtWgRLS0usXr36pecKBAJs2rSJ1fgknBijRo1ifm9paYkdO3bgwYMHkEql6Nu3LwwMDFiPCchXEls6L3x8fODj48NJrJaQ+k4mlS9f0KKCJ0gJJisrK1FeXs6MW2/5AU5NTUVRURF69+7NakwLCwum06W1tTXOnz+PQYMGQSgU4tKlSzA0NGQ1XktICCZJ5kvhBisrK0bYa2lpyYgX+YKEEyMhIQGDBw9mXEMKYSogF5MnJCSo1IR1VUh9J7/t0KKCJ0gpfqOiojBgwACV/zmys7Nx6tQprF27ltWY7u7uyMvLw6hRozBz5kxs3LgRn376KYRCIWQyGWciNFKCSVL5Urij5b9Ze7u2sgEJJ8bu3buxceNGlVbk4uJi7N69m7WiYtGiRe0q1LhwavD5ndwZ8uULWlTwBCnFb25uLj766COVx+zt7XHmzBnWY7ZcyrO3t8f27dtx+/ZtSKVSODo6MqsmbENKMEkqX8rbCyknRlvU1NSo7JXxpgwbNkzpJpuYmAiJRAJnZ2dmWmhaWho0NTU5Ey7y+Z3cGfLlC1pU8AQJwSQgtxJKJBKVxyQSCRobGzmJ2xITExOMHTuW8zidRTDJV77tQSgUIjAwkJmSS+nc8OXESE5ORnJyMvPnmJgY6OvrK53T0NCAjIwM2NrashITkPf+UBAbGwszMzOsWrWKaTcPAPX19di8eTO0tbVZi9sSPl0YnSHf9iAUCt9YpEqLCp4gIZgEAFtbW1y4cEGp17uCCxcusPpFoeDMmTOoqKjAJ5980upYdHQ0jIyM4O3tzXpcUoJJUvkCwKNHjxAbG4ucnByUlZVhw4YNsLGxweHDh9G/f3+l+R+kXAyU9sOXE6OqqkppvHpRURGqqqqUzlFTU4OzszNrsyFeJD4+Hp999pnSDRaQ5+nr64sffviBk9ikXBh85rtu3bp2nR8SEtLhmLSo4AkSgkkAmD59OtavX49//etf8PT0hEgkQkVFBX7//Xc8evQIa9asYT3muXPn4Ovrq/KYhYUFTpw4wclNlpRgklS+t27dwtatW2Fvb49Ro0YhJiaGOaaurk6HinVh+HJijB07lllVW7duHRYsWKA0MqC5uRl1dXWcTrx9/vw5KisrVR6rrKxEfX09J3FJuTD4zPdFfcyDBw9QVVUFGxsbZtslJycHIpEIffv2ZSUmLSp4goRgEpAv8a1ZswbR0dHYu3cvAPl+bd++fbFmzRoMGDCA9ZglJSVtWt5MTU2ZJzC2ISWYJJVvdHQ0PD09ERAQgKamJqWiQlFUUbomJJwYw4cPR0pKClNU5OXlYfPmzaioqIC1tTVWrFgBY2NjVmMC8mmhhw4dgo6ODtzc3KCmpobGxkYkJydDLBa/dePf+cy35YrWpUuXUFBQgA0bNsDExIR5vbS0FJs3b2Zttg0tKniChGBSgYODAzZu3AiJRIJnz55BV1eX9VkFLdHT00NBQQEcHBxaHSsoKOBsz5CUYJJUvgUFBfD39weAVspybW1tJTU7pWvBpxNDQXx8vNKK2r59+2BoaAh/f3/ExcVBLBZjyZIlrMYEgIULFyI8PBw7duwAIP/sKtpDu7q6tpo63BE6gwuDz3xbEhsbizlz5igVFIBcAzZ9+nQcOHCAFS0YLSp4ojMIJjU1NTktJhS4urri2LFj6Nevn9KN/PHjx4iJicGQIUM4vwaAP8EkqXz19fVRXFys8tiff/7Z6suD8nbAthNDQUlJCTOtsrq6GhkZGVi7di0cHBygpqbGrHSyjY6ODpYvX478/HxkZWUxnXDt7OxYb5PdGVwYfObbksrKyjbvM42NjYy+pKPQooInSAgmSTFr1ixkZmZixYoV6NOnD0QiESorK5GbmwsrKyulse9sQkowSSpfd3d3HDlyBJaWlrC3twcgX7EoKChAXFwcZ5NvKdxAyomhQF1dnbnp3L17F5qamsz2qJ6eHmO/5ApLS0tOb6pA53Jh8JFvSxwcHCAWi2FmZqb0+cnKyoJYLMbAgQNZiUOLCp4gIZgkhZ6eHkJDQ5GQkID09HTU1NTAzMwMXl5e8PT0hLq6OidxSQkmSeU7c+ZM5OfnIyQkhBGcbd26FZWVlXj33XcxefJkTuJSuIG0E8POzg7x8fEwNjbG2bNn4eLiwszMKSoq4rwzbEFBAcrLy1XOOeGisyUp14kCvvP9xz/+ga1bt+Jf//oXRCIRszJTWVmJ3r17s9boixYVPEFCMEkSDQ0NjBs3DuPGjeMtJinBJEAmX3V1daxatQp37tzBnTt3UFNTAz09PTg5ObEmuqLwB2knxpw5c7BlyxYEBwfD2NhYaTrr9evXmeZbbJOfn4+dO3cqFVQvwsVgL1KuE1L5GhsbY8uWLUhNTUV2djaz7WJra8tqEUOLCh7hWzBJiqqqKkgkEqbRUnNzMy5evIj8/Hw4OjrCzc2Nk7ikBJOk8lXg5OQEJycnTmNQ+IWEE8PS0hJhYWFMcdpSe+Dv769kv2STyMhINDQ0IDg4GJaWlkzzOq4h5Tohka9UKsXWrVsxefJkDB48mNOZJrSoIABfgklS7N69G2ZmZpg3bx4AedX966+/wtzcHL/99hsCAgI4acRESjDJZ76KPhyvCxVrdk1IOTGA1r0NAHDaaj43NxdBQUG8W0dJuTBI5KuhoYHs7GzIZDLOY9GigsI6OTk58PLyAiB3vZw/fx5+fn6YNGkSjh49itOnT3NSVJASTPKZb3uHW3GxjErhHlJODBKYm5urnCjMNaRcGKTydXV1RXJyMuermrSooLBOXV0d87STk5OD2tpajBw5EgDg6OiIkydPchKXlGCSz3xXrlypFFcsFqNnz54YOnQoDAwMUFVVhaSkJBQUFHAykZXCD6SdGHzi7+8PsViMPn36sDbTpD3w7cIgla+LiwsOHjyIiooKDBo0SOV2FhvbIrSooLCOsbEx8vPzMWDAAKSmpqJnz54wMjICIL8RamhocBabhGCSz3xb/qcPDw/H4MGDWy3Tjh8/HpGRkUhNTe3yEw//qpB2YvDJ4cOHUV5ejqCgIJiamqrswREaGspZfL5dGKTyDQsLAwDcvHkTN2/eVHkOGyubtKigsM7o0aNx6NAh3LlzB6mpqUrbDg8ePFBStLMJKcEkqXxv3ryJZcuWqTw2fPhwbN++nZO4FO4h5cQggZWVFaysrHiPS8qFQSpfLrqDqoIWFRTWmTx5MoyMjJCdnY158+Zh9OjRzLHa2lrOmjKREoiSyldDQwMZGRkq7aP379/ndEWIwi2knBgk4Gomz6sg5TohlW+PHj14iSNobm5u5iUShcIxCxcuxMKFCzF06FDIZDIsXLgQH374ISOYTE5OxrZt20hfJmscPXoUx48fx/jx4+Hm5sZoKpKTk3HhwgVMmTIFM2bMIH2ZFEqnxN/fn4jrhDRNTU0oLS1VKRZlQ1tCVyoonMH1h/dFSAlEFfCd74wZM6Cnp4e4uDicO3eOeV0kEsHf3x8TJ05kPSaFwgXFxcW4evUqnj59qlLb0HLaJluQcmEAZPJtbGzEvn37kJCQ0GbeVFNB6ZTw9eF9EVICUVL5AsCECRPg7e2NsrIyxhJnbGzMiPoolM5OTk4OQkJCYGJigoKCAvTu3Rt1dXUoKSmBkZFRm11yOwopFwapfGNiYpCamoqAgACEhYVh/vz50NTUxNWrV1FUVIS5c+eyEocWFRTW4evD+yKkBJOk8lUgFArRo0cP3vZMKRQ2OXjwIIYPH47AwED4+fkhICAANjY2yMzMxHfffYdJkyZxEpeUC4NUvtevX8f06dMxYsQIhIWFwc7ODjY2NvD09MSuXbuQkpJCLaWUzglfH94XISWYJJUvIJ9fkJycjKdPn6pcJaG9Kiidnby8PEyaNIkRoyo+x/369cO0adMgFovh4uLCelxSLgxS+ZaVlcHCwgJCoRDq6uqora1ljo0cORLff/89K0PFaFFBYR2+Pryq8PT0hKenZ6vXuYoHkMu3sLAQX3/9NaRSKerr66Gvr4/a2lrIZDLo6upCR0eHFhWUTo9AIICamhoEAgH09fVRUlLCWGZNTExQWFjISVxSLgxS+RoaGjJN00xNTXH//n3GOVZUVMRaHFpUUFiHrw9vW/AtmCSVb1RUFGxtbbF06VL4+/tj9erVsLa2RmJiIqKjoxEUFMRZbAqFLSwtLVFUVARHR0fY29vj9OnTsLW1hZqaGuLi4oh02eQSUvkOHDgQGRkZcHNzg5eXFw4dOoTCwkKoq6sjMTGRtUZ5tKigsM7LPrzXrl2Dh4cHJ3FJCSZJ5ZuVlYWAgADGX9/Y2AihUAgPDw9UV1dj//792LBhAyexKRS2GDt2LEpKSgAAfn5+2LhxI1MQa2lpceKEUEDChUEqXz8/P1RXVwMAJk6ciObmZiQlJUEqlcLb2xvTpk1jJQ4tKiis87IP79/+9jfWPrwvQkowSSrfhoYGaGtrQygUQk9PDxUVFcyxXr164fDhw5zEpVDYZNSoUczvLS0tsWPHDjx48ABSqRR9+/aFgYEBJ3FJuTBI5SsSiZSapvn4+MDHx4f1ONR3RmGdyspKpRHdPj4+WL9+PbZs2YKBAwdytiXQUjAJyOcneHp6Ys2aNejXrx9SUlI4iUsqXwsLCyautbU1zp8/D6lUisbGRly6dOmtmg9BeXtJSEhATU0N82ctLS04OzvDzc0N3bp1Q0JCAidxFS4MRTv7gIAA7Nq1C//+978hEAg4c2GQypcv6EoFhXWioqIwYMAAlY6H7OxsnDp1CmvXrmU9LinBJKl83d3dkZeXh1GjRmHmzJnYuHEjPv30UwiFQshkMmJCNAqlPezevRsbN25kGte1pLi4GLt371Ypvu4opFwYfOa7aNEipRbvr4KN+SC0qKCwTm5uLj766COVx+zt7XHmzBlO4pISTJLKt+XSpb29PbZv347bt29DKpXC0dERvXr14iQuhcIXNTU1KvtHsAEpF8bLYDvfYcOGKRUViYmJkEgkcHZ2hr6+Pqqrq5GWlgZNTU0q1KR0XmQyGSQSicpjEokEjY2NnMQlJZgkle+LmJiYYOzYsbzEolA6QnJyMpKTk5k/x8TEQF9fX+mchoYGZGRkwNbWlpNr4NOFQSrfOXPmML+PjY2FmZkZVq1aBS0tLeb1+vp6bN68Gdra2qzEpEUFhXVsbW1x4cIFDB06tNWxCxcucPYlQUowSSrfM2fOoKKiAp988kmrY9HR0TAyMoK3tzcnsSmUjlBVVaU0cryoqAhVVVVK56ipqcHZ2RlTp07l5Br4dGF0hnzj4+Px2WefKRUUgDxXX19f/PDDD6zEplNKKaxz7949rF+/Hn369IGnpydEIhEqKirw+++/49GjR1izZg0GDBjAety8vDyUl5er1DakpqbC2NgYvXv3Zj0uqXyDgoLg6+sLLy+vVscuX76MEydOYMeOHazHpVDYZN26dViwYIFSG/3m5mbU1dVBV1eXt+uor6/nxYVBKt85c+bg73//u8rOwhcvXkRUVBQOHDjQ4TjU/UFhnYEDB2LNmjUQCATYu3cvvv32W+zfvx/dunXj7AYLyAWTWVlZKo9lZ2cjKiqKk7ik8i0pKWnT9mZqaso8hVEonZnhw4crObPy8vIQGBiIefPmYeXKlSgrK+MkLikXBql8XV1dcejQIdy4cYPZkm1sbMT169chFotZGwFPtz8onODg4ICNGzdCIpHg2bNn0NXVhaamJqcxSQkmATL56unpoaCgAA4ODq2OFRQUsLZHSqFwSXx8vNI23b59+2BoaAh/f3/ExcVBLBZjyZIlrMcl5Tohle/ChQsRHh7OrF5qa2vj+fPnAOQFx8KFC1mJQ4sKCqdoampyfnNV0BkEk3zm6+rqimPHjqFfv35KTo/Hjx8jJiYGQ4YM4eU6KJSOUFJSgnfeeQcAUF1djYyMDKxduxYODg5QU1PD3r17eb8mLl0npPLV0dHB8uXLkZ+fj6ysLFRWVkIkEsHOzo7V8QW0qKC8NZASTJJi1qxZyMzMxIoVK9CnTx+IRCJUVlYiNzcXVlZWSqPfKZTOirq6OlPw3717F5qamsyWoZ6eHmMTZ4PO4DrhM19VWFpacjIDSQEtKihvDdOnT8f69evxr3/9q03B5NuEnp4eQkNDkZCQgPT0dNTU1MDMzAxeXl7w9PSEuro66UukUF6JnZ0d4uPjYWxsjLNnz8LFxQVCoVzuV1RUxGpn2M7gwuAzX1UUFBSgvLxc5awTVSL39kLdH5S3ivT0dERHRzOCTYFAgL59+2LWrFmcCSYpFMqbk5+fjy1btqC4uBjGxsZYs2YNsz2wceNGGBgY4IsvvmA9LikXBql88/PzsXPnTqWi6kXYGLhIiwrKWwmfgklSVFVVQSKRwNTUFID8C/HixYvIz8+Ho6Mj3NzcCF8hhfL61NTUQE9PT6kD5OPHjyESiVptUbBBfHw86uvrmRkfeXl52Lx5MyoqKmBtbY0VK1bA2NiY9bgK+M537dq1qKqqwuzZs2FpaclMN25Jjx49OhyHWkopbyWampowMjJ6awsKQK5eP3XqFPPnI0eO4Mcff8Tt27fxn//8B1euXCF3cRRKO+nevXurORW9evXi5AYLyIuKlg4phQtjyZIlaG5uhlgs5iSuAr7zzc3NxZw5czBkyBBYWFigR48erX6xAS0qKJQuSk5ODhwdHQHInS/nz5+Hn58fdu7ciSlTpuD06dOEr5BC6byocmHMnj0b7u7umDp1KtLT0wlfIbuYm5szQ9O4hBYVFEoXpa6ujvHY5+TkoLa2FiNHjgQAODo6EhmIRKF0FUi7MPjG398fv/zyC6fDFQHq/qBQuizGxsbIz8/HgAEDkJqaip49e8LIyAiAvODQ0NAgfIUUSueFtAuDbw4fPozy8nIEBQXB1NRUZR+O0NDQDsehRQWF0kUZPXo0Dh06hDt37iA1NVWpL8WDBw+UVO0UCkWZOXPmYMuWLQgODoaxsTECAwOZY9evX2fGoL8tWFlZwcrKivM41P1BoXRhEhISkJ2dDWtra4wePZoRfkVGRsLe3h7vv/8+2QukUDo5fLsw3nZoUUGhUCgUCoUV6PYHhdLFaWpqQmlpqUplN5fteCkUSteiuLgYV69exdOnT1V21Fy6dGmHY9CigkLpojQ2NmLfvn1ISEho0yrGRoc8CoXS9cnJyUFISAhMTExQUFCA3r17o66uDiUlJTAyMoK5uTkrcaillELposTExCA1NRUBAQEAgPnz5+Pzzz+Hk5MTTE1NsXLlSsJXSKFQOgsHDx7E8OHDsX37dgBAQEAAdu3ahX//+98QCARMZ9GOQosKCqWLcv36dUyfPh0jRowAILfIeXp6Ys2aNejXrx9SUlIIXyGFQuks5OXlwd3dnRGkKlY3+/Xrh2nTprHWQZQWFRRKF6WsrAwWFhYQCoVQV1dHbW0tc2zkyJFISkoieHUUCqUzIRAIoKamBoFAAH19fZSUlDDHTExMWGuWR4sKCqWLYmhoyHT9MzU1xf3795ljXHfNo1AoXQtLS0vme8He3h6nT5/G06dPUVJSgri4OJiZmbEShwo1KZQuysCBA5GRkQE3Nzd4eXnh0KFDKCwshLq6Oq5duwYPDw/Sl0ihUDoJY8eOZVYn/Pz8sHHjRgQFBQEAtLS0WHF+ALRPBYXSZamsrER1dTV69eoFADh16hSSkpIglUrh5OSEadOmQUtLi/BVUiiUzkh9fT0ePHgAqVSKvn37wsDAgJX3pUUFhdJFycvLQ3l5OQYPHtzqWGpqKoyNjdG7d28CV0ahUDobCQkJGDx4MDOEsCW1tbX4448/4Onp2eE4VFNBoXRRoqKikJWVpfJYdnY2oqKieL4iCoXSWdm9e3ebWqvi4mLs3r2blTi0qKBQuii5ubltDj2yt7dHbm4uz1dEoVC6IjU1NSqnlr4JVKhJoXRRZDIZJBKJymMSiQSNjY08XxGFQulMJCcnIzk5mflzTExMqyFpDQ0NyMjIgK2tLSsxaVFBoXRRbG1tceHCBQwdOrTVsQsXLrD2JUGhULomVVVV+PPPP5k/FxUVoaqqSukcNTU1ODs7Y+rUqazEpEJNCqWLcu/ePaxfvx59+vSBp6cnRCIRKioq8Pvvv+PRo0dYs2YNBgwYQPoyKRRKJ2DdunVYsGABevbsybzW3NyMuro66OrqshaHFhUUShcmPT0d0dHRjGBTIBCgb9++mDVrFi0oKBQKQ3x8POrr65kZH3l5edi8eTMqKipgbW2NFStWwNjYuMNxaFFBobwFSCQSPHv2DLq6utDU1CR9ORQKpZOxdOlSeHt7Y/z48QCAkJAQSKVS+Pj4IC4uDpaWlliyZEmH41BNBYXyFqCpqUmLCQqF0iYlJSV45513AADV1dXIyMjA2rVr4eDgADU1Nezdu5eVONRSSqFQKBTKW466ujrjCLt79y40NTWZLVI9PT1mjlBHoSsVFAqFQqG85djZ2SE+Ph7GxsY4e/YsXFxcIBTK1xWKiopgaGjIShy6UkGhUCgUylvOnDlzkJ+fj+DgYJSVleHjjz9mjl2/fr3NRnrthQo1KRQKhUL5i1BTUwM9PT0IBALmtcePH0MkErVqjPUm0KKCQqFQKBQKK9DtDwqFQqFQKKxAiwoKhUKhUCisQIsKCoXS5UlPT8eMGTMwY8YM0pdCofyloZZSCoVFpFIpEhIS8Mcff+DRo0eorq6GmpoajIyM0L9/f7i7u8PR0fGl77Fo0SKUlJS0el1LSws9evTAgAED4O3tDUtLy1bnfPPNN7h3795rXevAgQPxzTffvNa5r7o2VXh6emLRokXtev8XefbsGU6fPg0AmDhxIqszCjoLV65cQXFxMRwcHODg4ED6ciiUDkGLCgqFJdLS0hAREYGysjLmNW1tbTQ2NuLJkyd48uQJLl68iEGDBuGLL75A9+7dX/p+6urq0NHRASAf/FNTU4M///wTf/75Jy5evIiFCxdizJgxKn+2W7du0NPTe+n7v+r4615bW7zq+Ovw7NkzxMTEAADef//9NosKTU1NpltgV+PKlStMIUiLCkpXhxYVFAoLJCYmIiwsDE1NTTAyMsKMGTMwdOhQ5sb95MkTnD9/HvHx8bh16xa++uorrF+/HgYGBm2+54gRI5Se9KVSKf744w/s3bsXVVVViIyMhK2tLXr37t3qZ/v169fuVYj28OK1kcbOzg47d+4kfRkUyl8eqqmgUDpIfn4+IiIi0NTUhF69emHr1q0YM2aM0kpAz5498fe//x3Lly+HmpoaCgsL8f3337crjoaGBt577z0sXrwYACCTyXDu3DlWc6FQKJSOQFcqKJQO8vPPP0MikUBdXR1Lly59aQOZwYMHY8qUKTh69Cju3LmD1NRUDB48uF3xnJ2dYWhoiIqKCmRnZ3f08nmlrKwMJ0+eRFpaGkpKStDU1ITu3btDJBJhwIAB8PDwgJ2dHYDW+pAvvvhC6b1aakLS09Oxbt06AMDRo0eVzrty5Qp2796NHj16IDw8HPfv30dcXByysrIgkUhgYWEBb29vpa2k1NRUnD59Gnl5eZBIJLCysoKvry9GjBihMq/i4mIkJiYiPT0dxcXFKC8vBwCYmJjg3XffhY+PD0xMTFRel4KYmBhmq0fBrl27YGpqyvxZJpPhypUruHr1Kh4/foznz5+je/fu6NevHz744IM2t08Uf5fTpk3DlClTcPbsWVy7dg2FhYWoq6tDSEgI87NPnjzBqVOncO/ePZSVlaG5uRn6+vowMjKCg4MDPD090bNnT5VxKBRaVFAoHaCiogLJyckAAHd399fa1/fx8cHJkyfx/PlzxMfHt7uoAAAjIyNUVFTg+fPn7f5ZUuTl5WHdunXM4CKhUAhtbW1UVlaioqICubm5ePbsGVNU6OnpoXv37qipqQEAdO/enZlVoDjeXi5evIjIyEgAcr2LRCJBXl4e9uzZg8LCQsyaNQtHjx5FTEwMBAIBtLW1IZVKkZ2djZ07d6K2tpYZHd2S3bt3MwWQmpoatLW1UVtby2hprly5glWrVqF///7Mz2hoaMDAwAC1tbVoamqCpqYmtLS0lN63Zb51dXXYtm0b0tPTW/393bhxAzdu3ICvry/8/f3bzL+hoQHr1q1DZmYmunXrBi0tLaXOimlpadiyZQsaGhoAgDmnrKwMZWVlePjwIdTU1KjLhtImtKigUDpAeno6FE1phw0b9lo/o6WlBWdnZyQlJeH+/ftoampCt27d2hVX4cDoiNiSbw4ePIhnz56hT58+mD9/Pvr27QuBQIDGxkaUlJQgJSUFLRv8BgcHo7i4mFmhCA0NVXpqby/V1dX46aef4O3tjalTp0JfXx+1tbWIiopCQkIC4uLioKuri9jYWHz88cfw9vaGjo4OKioqEBERgdu3b+PgwYPw8PBoJUK1trbGe++9B2dnZ5iZmUEoFKKpqQm5ubk4evQobt++jR07diAsLAwaGhoA5LqUESNGMKsIvr6+L71ZR0REID09HWpqavD398eYMWOgqamJyspKHD58GJcvX8bJkydhZmamsvABgPj4eADA559/jhEjRkBDQwM1NTVMYfHf//4XDQ0NePfdd+Hv749evXoBkOt5ioqKkJSU1GrFhUJpCS0qKJQOkJ+fz/y+T58+r/1z1tbWSEpKQn19PUpKSmBubv7aP3vjxg1UV1cDAPr27avynMzMTCxcuPCl7zN37tw2l/NfRWJiIm7fvv3Sc4KDg5WGFGVmZgIA5s+fD3t7e+Z1NTU1WFhYwNfX942u5XWRSCQYM2YM5s6dy7ymp6eHwMBA3L9/H8XFxRCLxfj4448xZcoU5hxDQ0MEBQXhs88+g0QiQUpKCkaNGqX03n//+99bxevWrRvs7OywatUqrFy5Eo8ePcKNGzda/ezr8PDhQyQlJQEA5s2bh7FjxzLHRCIRAgMDUVdXh6SkJBw5cgTvv/8+U7y0pL6+HitWrICbmxvzmsKFVFVVhaKiIgDyoqPl1EoNDQ1YWVnBysqq3ddO+WtBhZoUSgdQLM0D7Vs1aGknra2tfeX5zc3NKCkpwdmzZxEREQFAfjP+4IMPVJ7f1NSEqqqql/6SSqWvfb0v0tDQ8Mr3b2xsVPoZhR20oqLijeN2lI8++qjVa0KhkOkdoq6ujgkTJrQ6R0dHhymEHj9+3K6YQqEQ7777LgAgIyOjnVcsJzExEQBgbGzcpo145syZAOSfybS0NJXnWFlZKRUULdHW1mZWLEj+G1G6NnSlgkLppCQkJCAhIUHlMS0tLSxatAgWFhYqj79JY6v28CaNrQYPHoyLFy8iPDwcmZmZcHNzg62tLTQ1NTm6SmX09PTaXBESiUQAAEtLy1a6BgUK+29bReD9+/dx6dIlPHz4EGVlZZBIJK3OUQg420tOTg4AeR+LljqLllhaWsLIyAjl5eXIyclRWTy8bLy1hoYGnJyckJaWhk2bNmHcuHEYPHgw+vTpAzU1equgvB70k0KhdIAXVxyMjIxe6+deZ4WjZYMpgUAATU1NmJiYYMCAAfDy8oKxsXEHrpx/Zs+ejcLCQqSnp+PUqVM4deoUhEIhrK2tMXjwYIwdO/a1//7eBG1t7TaPKW7ULztHoXtpampqdezQoUM4ceKE0vvp6uoyN+P6+npIJBKVhcbrUFVVBQCv/PsxNjZGeXk5c/6LvGq0dUBAALZs2YJHjx7h+PHjOH78ONTU1GBra4shQ4a0skpTKC9CiwoKpQO0bJWdk5Pz2jfF3NxcAP+/9bYqOluDqY6iq6uLkJAQZGRkICUlBZmZmcjJyWF+nThxAgEBAfDw8CB9qe0iLS2NKSjGjx+P8ePHw9LSUmlF4eeff0ZsbKySEJUEba1yKDAxMcGWLVuQlpaGW7duITMzE48ePUJmZiYyMzPxyy+/YNmyZa9sNU/560KLCgqlAzg4OEAgEKC5uRlJSUlt7le3pL6+Hnfu3AEADBgwoN3Oj65O//79GWulVCpFWloafv75Zzx+/BgRERFwdHRktiO6AteuXQMAvPvuu1iwYIHKcyorKzsUw8DAAAUFBUot4FWhOP6yTq2vQigUwsXFBS4uLgCA58+f448//kB0dDRKS0vx3XffISIigm6JUFRChZoUSgcwNDTEkCFDAMjFdAUFBa/8mVOnTjH9Jdqy/v1V0NDQgJubG4KDgwHIBaAtxYyverLuDChu5G25f5qbm5neEqpo2SeiLWxsbADILcwymUzlOU+ePGE0G7a2tq98z9dFW1sbHh4eCAgIACDfimmvWJXy16Hz/4+lUDo5M2fOhIaGBhoaGvDtt98ydk9V3Lp1C7GxsQDkqxxv0viqK9LU1NTmzRCAkv2xZSHRUuOgaJrV2VDoXh49eqTy+Pnz5xmrpioUOb4sP3d3dwByoeelS5dUnnPkyBEAcp2Pk5PTqy/8BV5067xIy3+j1ymEKH9NaFFBoXQQKysrBAQEQCgU4vHjx1i5ciUuXbqkdJMoKChAVFQUtm7disbGRpiZmeGf//znX+bLuaysDP/85z9x/Phx5ObmKokdHz16hLCwMADyaaMDBw5kjunq6jI6lcuXL6sUSZJGsU1w69YtxMTEoL6+HoC8SIiNjcXevXtfOpFW0WDq1q1bbbpD7OzsmOZqe/fuxW+//caIPisrK7Fnzx7cuHEDwP8vcttLZmYmgoODcerUKeTn5zNFYHNzMzIzM/Hjjz8CkItBVQ2xo1AAqqmgUFjBw8MDenp6zOjzPXv2YM+ePdDR0UFDQwPT9hiQ770vXrz4lUr8jvA6za8AeQfFN+F1ml+ZmJggNDSU+XNRURGOHDmCI0eOQCgUQkdHB/X19cwTspqaGhYtWtTKXTBu3DgcOXIEv/32Gy5evAh9fX0IhUL07dsXQUFBb3T9bDJq1CgkJCTg/v37OHr0KI4dOwYdHR3U1dWhubkZgwcPhrW1NbNC9SKenp44efIkCgsLERgYCH19faYo+Pe//824fAIDA1FTU4N79+5h7969iIqKgpaWFhMHAHx9fTu0pfb48WMcOHAABw4cQLdu3Zg8FMWctrY2lixZ0iW2pShkoEUFhcISLi4uCAsLw5UrV/DHH3/g0aNHqKmpgZqaGmMFdXd3f6Ol6faiaH7FFYrmVy+j5dOykZERVqxYgfT0dDx48ICxPXbr1g3m5uZwcHDAhAkTVPbdmDx5MrS1tXH16lVGN9Dc3Nyma4Zv1NTU8NVXX+HXX3/FtWvXmBbqdnZ28PT0xNixY1sNCmuJhYUFQkJC8Ouvv+Lhw4fMLBBA2b6qo6ODtWvXMgPF8vLyUF9fD5FIBHt7e3h7e7c5UOx1sLW1xZdffon09HRkZWWhoqIC1dXVUFdXh5WVFZydnTFhwgRObb+Uro+gmbTHiUKhUCgUylsBXcOiUCgUCoXCCrSooFAoFAqFwgq0qKBQKBQKhcIKtKigUCgUCoXCCrSooFAoFAqFwgq0qKBQKBQKhcIKtKigUCgUCoXCCrSooFAoFAqFwgq0qKBQKBQKhcIKtKigUCgUCoXCCrSooFAoFAqFwgr/DwmqoRFOY6DnAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 576x432 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
+    "alpha = 0.05\n",
     "plt.style.use(\"ggplot\")\n",
-    "fig, ax = plt.subplots(figsize=(8, 6))\n",
-    "sns.barplot(\n",
-    "    data=estimated_policy_value_df.reset_index(),\n",
-    "    hue=\"index\",\n",
-    "    x=\"reward_assumption\",\n",
-    "    y=\"relative-ee\",\n",
-    "    ax=ax,\n",
-    "    ci=None,\n",
+    "\n",
+    "def errplot(x, y, yerr, **kwargs):\n",
+    "    ax = plt.gca()\n",
+    "    data = kwargs.pop(\"data\")\n",
+    "    data.plot(x=x, y=y, yerr=yerr, kind=\"bar\", ax=ax, **kwargs)\n",
+    "    ax.hlines(data[\"ground_truth\"].iloc[0], -1, len(x)+1)\n",
+    "#     ax.set_xlabel(\"OPE estimator\")\n",
+    "    \n",
+    "g = sns.FacetGrid(\n",
+    "    estimated_intervals.reset_index().rename(columns={\"index\": \"OPE estimator\", \"mean\": \"Policy value\"}),\n",
+    "    col=\"policy_name\"\n",
     ")\n",
-    "plt.xlabel(\"OPE Estimators\", fontsize=25)\n",
-    "plt.ylabel(\n",
-    "    f\"Relative-ee\", fontsize=20\n",
-    ")\n",
-    "plt.yticks(fontsize=15)\n",
-    "plt.xticks(rotation=90, fontsize=15)"
+    "g.map_dataframe(errplot, \"OPE estimator\", \"Policy value\", \"errbar_length\")\n",
+    "plt.ylim((1.7, 1.9))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Unfortunately, we cannot say that our hypotheses are true by this experiment.\n",
-    "\n",
-    "We are going to add `n_rounds` and run experiments by using various random seeds.\n",
+    "It is surprising that `RIPS` estimator does not achieve the best performance even if the reward structure is not independent. If we run a simuration where the reward of each position depends heavily on those of other positions, `RIPS`estimator could achieve the best performance.\n",
     "\n",
     "Please see [../examples/synthetic_slate](../synthetic_slate) for a more sophisticated example of the evaluation of OPE with synthetic slate bandit data."
    ]
@@ -1217,7 +663,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/quickstart/synthetic_slate.ipynb
+++ b/examples/quickstart/synthetic_slate.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "The second step could be replaced by some Off-Policy Learning (OPL) step, but obp still does not implement any OPL module for slate bandit data. Implementing OPL for slate bandit data is our future work.\n",
     "\n",
-    "Please see [../examples/synthetic_slate](../synthetic_slate) for a more sophisticated example of the evaluation of OPE with synthetic slate bandit data."
+    "<!-- Please see [../examples/synthetic_slate](../synthetic_slate) for a more sophisticated example of the evaluation of OPE with synthetic slate bandit data. -->"
    ]
   },
   {
@@ -146,7 +146,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[sample_action_and_obtain_pscore]: 100%|██████████| 10000/10000 [00:01<00:00, 6317.55it/s]"
+      "[sample_action_and_obtain_pscore]: 100%|██████████| 10000/10000 [00:01<00:00, 6149.51it/s]"
      ]
     },
     {
@@ -165,8 +165,8 @@
     }
    ],
    "source": [
-    "# define Uniform Random Policy as a baseline evaluation policy\n",
-    "random_behavior_dataset = SyntheticSlateBanditDataset(\n",
+    "# define Uniform Random Policy as a baseline behavior policy\n",
+    "dataset_with_random_behavior = SyntheticSlateBanditDataset(\n",
     "    n_unique_action=n_unique_action,\n",
     "    len_list=len_list,\n",
     "    dim_context=dim_context,\n",
@@ -179,15 +179,15 @@
     ")\n",
     "\n",
     "# compute the factual action choice probabililties for the test set of the synthetic logged bandit feedback\n",
-    "random_behavior_feedback = random_behavior_dataset.obtain_batch_bandit_feedback(\n",
+    "bandit_feedback_with_random_behavior = dataset_with_random_behavior.obtain_batch_bandit_feedback(\n",
     "    n_rounds=n_rounds_test,\n",
     "    return_pscore_item_position=True,\n",
     ")\n",
     "\n",
     "# print policy value\n",
-    "random_policy_value = random_behavior_dataset.calc_on_policy_policy_value(\n",
-    "    reward=random_behavior_feedback[\"reward\"],\n",
-    "    slate_id=random_behavior_feedback[\"slate_id\"],\n",
+    "random_policy_value = dataset_with_random_behavior.calc_on_policy_policy_value(\n",
+    "    reward=bandit_feedback_with_random_behavior[\"reward\"],\n",
+    "    slate_id=bandit_feedback_with_random_behavior[\"slate_id\"],\n",
     ")\n",
     "print(random_policy_value)"
    ]
@@ -227,10 +227,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "base_expected_reward = random_behavior_dataset.base_reward_function(\n",
-    "    context=random_behavior_feedback[\"context\"],\n",
-    "    action_context=random_behavior_dataset.action_context,\n",
-    "    random_state=random_behavior_dataset.random_state,\n",
+    "base_expected_reward = dataset_with_random_behavior.base_reward_function(\n",
+    "    context=bandit_feedback_with_random_behavior[\"context\"],\n",
+    "    action_context=dataset_with_random_behavior.action_context,\n",
+    "    random_state=dataset_with_random_behavior.random_state,\n",
     ")"
    ]
   },
@@ -253,13 +253,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[obtain_pscore_given_evaluation_policy_logit]: 100%|██████████| 10000/10000 [00:09<00:00, 1054.20it/s]\n"
+      "[obtain_pscore_given_evaluation_policy_logit]: 100%|██████████| 10000/10000 [00:09<00:00, 1037.09it/s]\n"
      ]
     }
    ],
    "source": [
-    "random_policy_pscores = random_behavior_dataset.obtain_pscore_given_evaluation_policy_logit(\n",
-    "    action=random_behavior_feedback[\"action\"],\n",
+    "random_policy_pscores = dataset_with_random_behavior.obtain_pscore_given_evaluation_policy_logit(\n",
+    "    action=bandit_feedback_with_random_behavior[\"action\"],\n",
     "    evaluation_policy_logit_=random_policy_logit_\n",
     ")"
    ]
@@ -273,13 +273,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[obtain_pscore_given_evaluation_policy_logit]: 100%|██████████| 10000/10000 [00:09<00:00, 1019.17it/s]\n"
+      "[obtain_pscore_given_evaluation_policy_logit]: 100%|██████████| 10000/10000 [00:10<00:00, 995.15it/s]\n"
      ]
     }
    ],
    "source": [
-    "optimal_policy_pscores = random_behavior_dataset.obtain_pscore_given_evaluation_policy_logit(\n",
-    "    action=random_behavior_feedback[\"action\"],\n",
+    "optimal_policy_pscores = dataset_with_random_behavior.obtain_pscore_given_evaluation_policy_logit(\n",
+    "    action=bandit_feedback_with_random_behavior[\"action\"],\n",
     "    evaluation_policy_logit_=optimal_policy_logit_\n",
     ")"
    ]
@@ -293,16 +293,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[obtain_pscore_given_evaluation_policy_logit]: 100%|██████████| 10000/10000 [00:09<00:00, 1003.37it/s]\n"
+      "[obtain_pscore_given_evaluation_policy_logit]: 100%|██████████| 10000/10000 [00:10<00:00, 996.97it/s]\n"
      ]
     }
    ],
    "source": [
-    "anti_optimal_policy_pscores = random_behavior_dataset.obtain_pscore_given_evaluation_policy_logit(\n",
-    "    action=random_behavior_feedback[\"action\"],\n",
+    "anti_optimal_policy_pscores = dataset_with_random_behavior.obtain_pscore_given_evaluation_policy_logit(\n",
+    "    action=bandit_feedback_with_random_behavior[\"action\"],\n",
     "    evaluation_policy_logit_=anti_optimal_policy_logit_\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -330,16 +337,38 @@
     "rips = SlateRewardInteractionIPS(len_list=len_list)\n",
     "\n",
     "ope = SlateOffPolicyEvaluation(\n",
-    "    bandit_feedback=random_behavior_feedback,\n",
+    "    bandit_feedback=bandit_feedback_with_random_behavior,\n",
     "    ope_estimators=[sips, iips, rips]\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "          mean  95.0% CI (lower)  95.0% CI (upper) policy_name\n",
+      "sips  1.836816            1.8205          1.852505      random\n",
+      "iips  1.836816            1.8205          1.852505      random\n",
+      "rips  1.836816            1.8205          1.852505      random \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgwAAAGSCAYAAACPApmhAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAABScUlEQVR4nO3de1xUZf4H8M9wGS6DCCOCCBrKRQQUREUFU1NQ18z7JdvMzHbL1H6l5rZ2EXPbMEPzl5d+la7W2spFyktZioYXEEQdJUHAGygQIModBhDm94cvZh1hZs7IwCB83q/Xvl6d5zznOd9pTzNfnvNcRAqFQgEiIiIiDYwMHQARERG1f0wYiIiISCsmDERERKQVEwYiIiLSigkDERERacWEgYiIiLRiwkBERERaMWEgIiIirZgwEBERkVYmQivm5eXh999/x5UrV1BUVITy8nKIxWJYW1vDxcUF3t7e8PHxgVgsbs14iYiIyABE2paGjo+Px5EjR5Cenq61MYlEgjFjxmDixImwt7fXW5BERERkWGoThsuXL+Pbb79FdnY2LC0tMXToUHh6esLV1RU2NjawsrJCbW0tysvLkZeXh8zMTKSkpODq1aswMTHBn/70J8yYMQOWlpZt/ZmIiIhIz9QmDHPnzkWfPn0wdepUDBkyBKampoIa/OOPP3D06FEcPXoUU6dOxaxZs/QaMBEREbU9tQnD2bNnERAQ8NgNl5SUoLCwEB4eHo/dBhEREbUPWscwEBEREQmeJdFZ5eXlGToEIiKiNtGzZ0+157gOAxEREWmlsYdh6dKlOjcoEonwxRdfPHZARERE1P5oTBju3LnTVnEQERFRO6Zx0OPjJgzdu3d/7IDaG45hICKizkLTGAaNPQwd6YefiIiIHh8HPRIREZFWGnsYGhoa8Pnnn0MkEmHZsmUwMWm++v379/HFF19AJBLhrbfeao04iYiIyIA09jAkJSUhKSkJQ4YMUZssAICJiQmGDh2KM2fOIDExUe9BEhERkWFpTBjOnDkDqVSKkSNHam0oKCgIUqkUp0+f1ltwRERE1D5oTBiuX78Ob29viEQirQ2JRCL4+Pjgxo0beguOiIiI2geNCUNJSQm6desmuDGpVIrS0tIWB0VERETti8aEwcTEBHV1dYIbq6ur0zjWgYiIiJ5MGhMGW1tbZGdnC24sOzsbtra2LQ6KiIiI2heNCUO/fv2QlpaG/Px8rQ3l5+cjLS0Nnp6eeguOnjyzZs3CrFmzDB0GPcH4DFFL8RlqHRoThpCQEDQ0NGDjxo0axyaUlZVh06ZNaGhoQHBwsN6DJCIiIsPSmDC4ubkhODgY2dnZWL58Ofbu3YvLly8jLy8PeXl5uHz5Mvbu3Yvly5cjKysLISEhcHNza6vYqZ2JiYnB+fPncebMGQQEBCAmJsbQIdEThs8QtRSfodajcfMpAKivr8c333yD48ePa2xo3LhxePXVV2Fk1LFWm+bmU8LExMRg1apVqK6uVpZZWFjg008/xYwZMwwYGT0p+AxRS/EZajlNm09pTRgaZWRk4OjRo8jIyEBJSQkAwMbGBp6enggODka/fv30Emx7w4RBmICAAOTm5jYpd3JywtmzZw0QET1p+AxRS/EZarnH3q3yYf369euwSUFb+eOdVw0dQqvJa+Y/0sbyjvq5HTd80+b3fHn3mTa/Z1vJzW0+Oc/Nzeuwn3vXghFtfs9fD/zR5vdsK5qeoY76uSdMcWyze3Ws9wdkMA6W5jqVEz3K3Kb5ReLUlRM9qpvUQady0g0TBtKLJb4eMDdWfZzMjY2wxNfDQBHRk8Yt5AUYmYpVyoxMxXALecFAEdGTZsbUJRCLVf9IEYvNMWPqEgNF1LFwWUbSiz/1cQIAfJR0GXUNDehhaY4lvh7KciJtHAeNAgCkxWxDQ/19mNvYwS3kBWU5kTYjAv4EAPjXdx/h/v06dJP2wIypS5Tl1DJMGEhv/tTHCT9czwEAfBU8zMDR0JPIcdAo5J6LBQAM+ctHBo6GnkQjAv6Ek6d/AAD8bflXBo6mY+ErCSIiItKKPQykV+xZoJZizwK1FHsWWgd7GIiIiEirFvUwFBYWIifnwTtrZ2dn2Nvb6yUoIiIial8eK2Gorq7Gl19+icTERJXyESNG4PXXX4e5OefeExERdSSPlTDs2LEDKSkpmDNnDvr27Yu6ujqcO3cOJ06cgJmZGRYvXiy4rfz8fBw4cACZmZm4ffs2+vfvj9DQUI3XREZGIjo6utlz8+bNw/Tp0wEAW7duxYkTJ5rU2bRpE5ycON2PiIhIKI0JQ01NDczMzJqUJycn49VXX8XTTz+tLAsICEBNTQ3Onj2rU8Jw+/ZtyGQyuLu7o76+XtA148aNg5+fX5OY9u/fj0GDBqmUOzk5NYmne/fuguMjIiIiLQnDypUr8dprr8HHx0elvL6+HhYWFk3qW1hYoKGhQacABg8ejKFDhwIAwsPDUV5ervWabt26oVs31eVi9+3bBycnJ7i4uKiUm5mZwcODqw0SERG1hMaEwd3dHevWrcO4ceMwf/58ZZLg4+ODHTt2QC6Xo0+fPqirq8P58+dx4sQJDB48WKcA9LEddnl5OVJSUjBz5swWt0VERERNaUwY3nzzTYwcORJff/01ZDIZ/vrXv2LQoEF49dVXsWHDBnzxxRcq9fv27YtXXnmlVQNuTlJSEurr6xEUFNTkXE5ODhYsWIC6ujq4urpi3rx58PLyavMYiYiInmRaBz36+/sjPDwc3377LcLCwvD000/j5Zdfxvr165GSkqLce9zZ2RkDBgxo9YCbEx8fjz59+sDRUXWbzz59+sDd3R3Ozs4oKyvDwYMHsW7dOqxbtw5ubm7NthUbG4vY2AdL04aFhcHOzk5vcXbMzVU7L30+G9Q5GeYZ4jdRR9KWz5CgWRKWlpZ4/fXXERgYiK+++gorVqzAokWLEBAQgIEDB7Z2jBoVFxcjLS0Nf/7zn5ucmzRpksrxoEGDsHz5csTExGDVqlXNthccHIzg4GDlcVFRkX4Dpg6Dzwa1FJ8hail9P0M9e/ZUe06nAQQDBw7EZ599hoCAAISHh2PTpk0oKytrcYAtcebMGQBAYGCg1rpmZmYYNGgQbt682dphERERdSiCEoaysjLcuHEDZWVlMDc3x6JFixAaGoqsrCy8/fbbOH36dGvHqVZ8fDw8PT0Fd8uIRCKIRKJWjoqIiKhj0fhKQi6XY/v27SorOg4bNgxvvPEG+vfvjw0bNmDv3r3YunUrEhIS8Ne//hU2NjatHbNSYWEhrl69ildffVVQ/draWly4cAF9+/Zt5ciIiIg6Fo0Jw/fff4/ExESMHj0abm5uuH79OuLi4tC1a1csWrQIYrEYL730EgIDA7Ft2za8/fbbeOmll/DMM88IDqCmpgYymQwAcO/ePVRXVysTlEGDBsHMzAzLli2Dl5dXkwWYEhISYGxsjOHDhzdpt6qqSjlIs0ePHigvL8dPP/2E4uJiLF++XHB8REREpCVhSE5OVvYoNKqursa5c+ewaNEiZZmbmxs+/fRTREdH4+uvv9YpYSgtLcXGjRtVyhqPt2zZAnt7ezQ0NDS7IFR8fDx8fHxgbW3d9IOZmMDa2hoxMTEoLS2FqakpPDw8EBoaCldXV8HxERERkYCloR9dUbFbt264fPly04ZMTPD88883+9e+Jvb29oiMjNRYZ+vWrc2Wb9iwQe01YrEYK1eu1CkWIiIiap7GQY/u7u44efIk0tPTcf/+fWRmZuLUqVNwd3dXe82jSzMTERHRk09jD8PChQuxdu1arFmzRlkmlUrx8ssvt3ZcRERE1I5oTBh69OiBzz//HOfPn0dRURHs7Ozg7+8Pc3PztoqPiIiI2gGtKz2amZkJWhSJiIiIOq6WbxVJREREHZ6gvSSac+7cOVy5cgU1NTWwt7dHYGAgN+MhIiLqoLQu3DRw4ED4+PgoyyorK/Hpp58iPT1dpW5ERARee+01jBo1qnUiJSIiIoPRmDDs378fYrFYJWH4v//7P6Snp8Pe3h5BQUGwtrZGZmYmzpw5gy+//BIuLi7o3bt3qwdOREREbUenVxL5+flISkpCnz59sGbNGlhYWAB4sI20v78/tm7dip9//hmvv/56qwRLREREhqHToMcrV64AAObNm6dMFhqNGjUKbm5uSEtL0190RERE1C7olDCUlJQAgNq9GFxdXXHv3r0WB0VERETti04JQ2OvgqmpabPnTU1NIRKJWh4VERERtStaxzCkpqYq/zk/Px8AcOfOHTg7Ozepe/fuXXTp0kWP4REREVF7oDVhSEtLazIu4cKFC80mDDdu3ICTk5P+oiMiIqJ2QWPC8PCmUw+ztrZuUnbjxg3U19djwIAB+omMiIiI2g2NCYOXl5fghvr27YutW7e2OCAiIiJqf7iXBBEREWml08JN9fX1KCgoQGVlJUQiEbp27Yru3bu3VmxERETUTghKGM6ePYtff/0VV65cQX19vco5a2trBAUFYdq0abCxsWmNGImIiMjANCYMCoUC27Ztw8mTJ5ucs7Ozg7m5OfLz83H48GGcOnUK77zzDjw9PVstWCIiIjIMjQlDbGwsTp48CX9/f8ydOxcODg4oKChAZGQkMjIy8N5776F79+6Ij4/Hd999h/Xr1yM8PBxSqbSt4iciIqI2oHHQ4/Hjx+Hs7IyVK1fCxcUFFhYWcHFxwYoVK2BjY4Pvv/8epqamGDNmDD744API5XL8+OOPbRQ6ERERtRWNCUNOTg4GDBgAY2NjlXJjY2MMGDBAZRVIFxcX+Pv7QyaTtU6kREREZDAaEwaRSITa2tpmz9XW1qKurk6lzMnJiZtPERERdUAaE4ZevXrh3LlzqKioUCmvqKjAuXPn4OjoqFIul8shFov1HyUREREZlMZBj8888wy+/vprrF69GpMnT4a9vT0KCwvx008/obS0FJMnT1apf/v2bfTo0aNVAyYiIqK2pzFhCA4ORlpaGuLj47Fjxw6Vc35+fioJQ3V1NWpraxEYGNg6kRIREZHBaF246c0338Tw4cNx9uxZlJaWokuXLvD390dgYCCMjP77RsPCwgIff/xxqwZLREREhiFopceAgAAEBAS0SgD5+fk4cOAAMjMzcfv2bfTv3x+hoaEaryksLMTSpUublAcGBuKtt95SKUtOTsbevXuRn58Pe3t7zJ49m70gREREOtJpL4nWcPv2bchkMri7uzdZdlqb+fPno1+/fsrjR7fdTk9PR3h4OMaPH4+FCxdCJpNh8+bNkEgk8PX11Uv8REREnYHBE4bBgwdj6NChAIDw8HCUl5cLvrZnz57w8PBQe37fvn3o378/XnnlFQCAj48PcnJyEB0dzYSBiIhIBwbf3vrhcRD6VFdXh8uXL2PEiBEq5YGBgcjMzERVVVWr3JeIiKgjMngPQ0ts27YNFRUV6Nq1K4KCgjBv3jzlOhAFBQWor6+Hk5OTyjVOTk5QKBTIy8uDm5ubIcImIiJ64jyRCYOpqSkmTJgAX19fWFhYIDU1Ffv370dBQQFWrVoFAMrFpiQSicq1VlZWAIDKyspm246NjUVsbCwAICwsDHZ2dnqL+w+9tUTtgT6fDeqcDPMM8ZuoI2nLZ+iJTBhsbW2xaNEi5bG3tzdsbGzwzTffICsrCy4uLo/ddnBwMIKDg5XHRUVFLQmVOjA+G9RSfIaopfT9DPXs2VPtOYOPYdCX4cOHAwBu3LgB4L89CY+OVVDX80BERETqdZiEoZFIJAIAODg4wNjYGLm5uSrn8/LyIBKJNGZRREREpErnhCEtLQ3R0dE6n2ttiYmJAIC+ffsCeDDOwcfHR1neKCEhAR4eHrC0tGzzGImIiJ5UOicMqampiIqK0vmcOjU1NUhMTERiYiLu3buHsrIy5XFNTQ0AYNmyZdi+fbvymsjISHz77bdISkpCSkoKIiIisHv3bgQEBOCpp55S1ps5cyZSU1Oxa9cupKam4t///jdkMhlmzZql68cmIiLq1Aw+6LG0tBQbN25UKWs83rJlC+zt7dHQ0ICGhgbleScnJxw8eBDHjh1DbW0t7OzsMGXKFMyYMUOlHU9PTyxfvhwRERE4cuQI7O3t8eabb3LRJiIiIh0ZPGGwt7dHZGSkxjpbt25VOQ4KCkJQUJCg9ltzHwwiIqLOosMNeiQiIiL9E9TD8PA8z8YFjx6d+8lFbIiIiDouQQnDkiVLNJaJRCLs3btXf1ERERFRuyIoYZg5c6ZyfYO0tDSkpaVxpgEREVEnIihhmDNnjvKfo6KikJaWhtmzZ7daUERERNS+cNAjERERacWEgYiIiLRiwkBERERa6ZwwKBSKxzpHRERETy6dV3qcM2eOyiBIoeeIiIjoycVXEkRERKQVEwYiIiLSSm3CUFtb2+LG9dEGERERGZ7ahGHJkiX4+eefUVdXp3OjWVlZ+PTTT3HgwIEWBUdERETtg9pBj76+vti9ezeioqIQGBiIESNGwMPDA2KxuNn6BQUFuHTpEk6cOIFr167Bzs4OU6ZMabXAiYiIqO2oTRiWLl2KiRMnYu/evYiNjUVsbCyMjIzg7OwMGxsbSCQS1NXVoaKiAnl5eSgrKwMAWFtbY968eXj22WdhamraZh+EiIiIWo/GaZVubm54//338ccff+D48eO4fPkysrKycOvWLZV61tbWGDZsmPJ/JiY6z9YkIiKidkzQL7ujoyP+/Oc/AwBqampw7949lJeXQywWo2vXrrC1tW3VIImIiMiwdO4KMDMzg6OjIxwdHVsjHiIiImqHuA4DERERacWEgYiIiLRiwkBERERaMWEgIiIirZgwEBERkVZMGIiIiEgrJgxERESklc7rMNy/fx+XL19GTk4O5HI5Zs2aBeDBzpTV1dXo0qULjIyYhxAREXUkOiUMFy9exPbt21FSUqIsa0wYsrKy8MEHH2DZsmUYOXKkXoMkIiIiwxLcFXD9+nVs2LABIpEICxYsQFBQkMp5Dw8P2Nvb4+zZs3oPkoiIiAxLcA/Dvn37IBaLERYWBhsbG0RFRTWp4+rqips3b+oUQH5+Pg4cOIDMzEzcvn0b/fv3R2hoqMZrrl27hiNHjuDKlSsoLi5Gt27dMHLkSEydOlVl++3IyEhER0c3uX716tXw8/PTKU4iIqLOTHDCkJGRgaFDh8LGxkZtHTs7O8hkMp0CuH37NmQyGdzd3VFfXy/omoSEBBQUFGDq1KlwdHREdnY2IiIikJ2djZUrV6rUtbS0xOrVq1XKnJ2ddYqRiIiosxOcMMjlclhbW2usU1NTg4aGBp0CGDx4MIYOHQoACA8PR3l5udZrpk2bphKLt7c3xGIxvvrqK9y5cwfdu3dXnjM2NoaHh4dOMREREZEqwWMYpFIpbt++rbFOVlYWHBwcdAvgMWZUNJe4uLi4AACKi4t1bo+IiIg0E/xr7efnh0uXLiE9Pb3Z8zKZDJmZmfD399dbcLrIzMyESCRqkrBUVlZi0aJFmDdvHlatWoWkpCSDxEdERPQkE/xKYvr06UhISMA//vEPTJw4EXfu3AEAXLhwAWlpafj1119hY2ODyZMnt1qw6pSUlCAmJgajRo1C165dleU9evTAiy++CBcXF8jlchw9ehTh4eFYsWIFhg0b1mxbsbGxiI2NBQCEhYXBzs5Ob3H+obeWqD3Q57NBnZNhniF+E3UkbfkMCU4YpFIp3nvvPWzatAkHDx5Ulq9fvx4A4ODggJUrV2od56Bv9+/fx6ZNm2Bubo4FCxaonBs1apTK8eDBg/H+++8jOjpabcIQHByM4OBg5XFRUZH+g6YOgc8GtRSfIWopfT9DPXv2VHtOp4Wb+vbti82bN+PChQvIzMxEeXk5LC0t4e7ujqFDh8LY2LjFwepCoVBgy5YtuH37NtatWwcrKyuN9UUiEYYNG4Y9e/agoaGBK1ISEREJpPPS0EZGRhgyZAiGDBnSGvHoZNeuXUhOTsYHH3wAJycnQ4dDRETUYT2xf2L/8MMP+OWXX7Bs2TJ4enoKukahUCApKQkuLi7sXSAiItKB4B6GEydOCG509OjRguvW1NQoF3u6d+8eqqurkZiYCAAYNGgQzMzMsGzZMnh5eWHx4sUAgNOnT+M///kPxowZA6lUiszMTGV7PXr0UI6jWLNmDYYNGwYnJyfU1NTg2LFjuHbtGt555x3B8REREZEOCcO2bdsEN6pLwlBaWoqNGzeqlDUeb9myBfb29mhoaFBZEOrSpUsAgLi4OMTFxalc+8Ybb2DMmDEAHiQPP//8M4qLi2FkZIQ+ffrg3XffxaBBgwTHR0RERIBIoVAohFR89Ie5UVVVFa5du4aEhAQEBATA399f+YPdEeTl5emtrT/eeVVvbZHhOW74ps3v+fLuM21+T2o9uxaMaPN7/nqA0yo7kglTHPXanl5mSWhLAp555hmEhYVh0qRJggMjIiKiJ4PeRv4NGDAAvr6+iIiI0FeTRERE1E7odapAz549cePGDX02SURERO2AXhOGnJwcfTZHRERE7YTOCzc9qqGhAXfv3sWxY8cgk8k4A4GIiKgDEpwwzJ07V2sdKysrvPjiiy0KiIiIiNofwQlD//79IRKJmpSLRCJIJBK4ubnhmWeeafPNp4iIiKj1CU4YQkNDWzEMIiIias+4oQIRERFpxYSBiIiItFL7SkKXvSMeJhKJlJtEERERUcegNmHQZXfKRzFhICIi6ljUJgxbtmxpyziIiIioHVObMHTv3r0t4yAiIqJ2jIMeiYiISKvHWhq6oaEBZWVluH//frPn7ezsWhQUERERtS86JQy3bt3Cnj17kJqairq6umbriEQi7N27Vy/BERERUfsgOGHIycnB+++/DwAYOHAgzp8/j6eeegpdu3bFzZs3UV5eDm9vb/YuEBERdUCCE4aYmBjU19fjk08+Qe/evTF37lwEBARg1qxZkMvl+Ne//gWZTIY33nijNeMlIiIiAxA86DE1NRX+/v7o3bu3skyhUAAAzM3N8de//hUSiQQRERH6j5KIiIgMSnDCUF5eDkdHx/9eaGSEmpoa5bGxsTG8vb2RkpKi3wiJiIjI4AQnDFZWVpDL5cpja2trFBUVqdQxMTFBVVWV/qIjIiKidkFwwuDg4IDCwkLlcZ8+ffD777+jtLQUACCXy3Hu3DnY29vrP0oiIiIyKMGDHn19fbF//37I5XKYm5tj/PjxkMlkWLVqFfr164cbN27gzp07eOmll1ozXiIiIjIAwQnDuHHj0LNnT9TW1sLc3Bz+/v5YsGABoqKikJSUBLFYjKlTp+JPf/pTa8ZLREREBqAxYVi1ahWCg4Px9NNPw9bWFoGBgSrnJ02ahIkTJ6KsrAxdu3aFSCRq1WCJiIjIMDSOYcjOzsaOHTvw2muv4csvv8TVq1ebNmBkBBsbGyYLREREHZjGHoZ169YhNjYWiYmJ+O233/Dbb7+hd+/eGDduHEaNGgVLS8u2ipOIiIgMSGPC4OHhAQ8PDyxcuBCnTp3C8ePHcfPmTfzrX//Cnj17MHz4cIwbNw6enp6PHUB+fj4OHDiAzMxM3L59G/3790doaKjW66qqqrBr1y4kJyejoaEBgwcPxsKFC9GlSxeVesnJydi7dy/y8/Nhb2+P2bNnN3m1QkRERJoJGvRoYWGB8ePHY/z48cjKykJsbCzi4+Nx8uRJnDx5Es7OzspeBysrK50CuH37NmQyGdzd3VFfXy/4uk2bNiEvLw+vvfYajIyMsGfPHmzYsAEfffSRsk56ejrCw8Mxfvx4LFy4EDKZDJs3b4ZEIoGvr69OcRIREXVmOm9v7eLigldffRUvvfQSzpw5g2PHjiEjIwO7d+/G999/j2HDhmHZsmWC2xs8eDCGDh0KAAgPD0d5ebnWazIzM3Hp0iWEhobCy8sLACCVSrF69WqkpKRg4MCBAIB9+/ahf//+eOWVVwAAPj4+yMnJQXR0NBMGIiIiHQheuOlRYrEYo0ePxkcffYRNmzbB09MTdXV1OH36tG4BGOkegkwmQ9euXZXJAgC4ubnB3t4eFy9eBADU1dXh8uXLGDFihMq1gYGByMzM5IqUREREOtC5h+FhFRUVOHHiBI4fP46cnBwAaJOBkLm5uXBycmpS7uTkhNzcXABAQUEB6uvrm9RzcnKCQqFAXl4e3NzcWj1WIiKijuCxEobLly8jNjYWycnJuH//PgDA3d0dwcHBbTKgsLKystnERCKRKJevrqioUJY9rHGMRWVlZStHSURE1HEIThhKSkrw22+/4fjx48ofZYlEguDgYAQHB6NXr16tFmRbio2NRWxsLAAgLCwMdnZ2emv7D721RO2BPp8N6pwM8wzxm6gjactnSGPCoFAocOHCBRw7dgwymQwNDQ0AAE9PT4wbNw7Dhw+HWCxuk0AfJpFImh0cWVlZqexRaOxJeHSsgrqeh0aNCVCjR3fkJGrEZ4Nais8QtZS+n6GePXuqPacxYXjjjTdw7949AA9+gEeNGoXg4OBmxw+0JScnJxw7dqxJeV5ennLGhYODA4yNjZGbm6syODIvLw8ikUjjvxQiIiJSpTFhuHfvHry8vJS9CSYmLRojqTeDBg3Cvn37kJ6erlw06vr16ygoKICfnx8AwNTUFD4+PkhMTERISIjy2oSEBHh4eHCVSiIiIh1ozAA+//xzODo6tmoANTU1kMlkAB4kKNXV1UhMTATwIDEwMzPDsmXL4OXlhcWLFwN4sAKlr68vtmzZgvnz50MkEmHPnj3w9PRUrsEAADNnzkRoaCh27dqFoUOHQiaTQSaTYfXq1a36mYiIiDoajQlDaycLAFBaWoqNGzeqlDUeb9myBfb29mhoaFCOn2j01ltvYffu3di+fTsUCgX8/f2xcOFClTqenp5Yvnw5IiIicOTIEdjb2+PNN9/kok1EREQ6EikUCoWhg2jP8vLy9NbWH++8qre2yPAcN3zT5vd8efeZNr8ntZ5dC0Zor6Rnvx7gLImOZMIU/f5hr2l832Ov9EhERESdBxMGIiIi0ooJAxEREWnFhIGIiIi0EpwwJCUlNZmpQERERJ2D4JWYNm7cCFtbWzzzzDMYN24c19EnIiLqRAT3MEyYMAE1NTWIiYnBsmXLEBYWhvPnz4OzMomIiDo+wT0Mr7zyCl588UUkJCTg6NGjylUTpVIpxo0bh7Fjx0IqlbZmrERERGQgOm0OIRaLMWbMGIwZMwa3bt1CbGwsTp06haioKOzbtw/+/v4ICQlR7udAREREHcNj7ybVu3dvlV6HiIgInDt3DufOnYOdnR0mTJiA8ePHw9zcXJ/xEhERkQG0aFqlXC7HyZMn8csvvyi3wXZxcUFFRQX27NmDt99+G1lZWfqIk4iIiAzosXoYbt68iaNHjyI+Ph5yuRxisRhjx47FhAkT4OLiArlcjl9//RWRkZH417/+hbVr1+o7biIiImpDghOGmpoaxMfH4+jRo7hx4wYAwMnJCSEhIRg9ejQsLS2Vdc3NzTF16lTcvXsXx48f13/URERE1KYEJwyvvfYaqqurYWRkhGHDhmHChAnw9vbWeI1UKkVdXV2LgyQiIiLDEpwwWFhYYPLkyQgODoaNjY2ga8aPH4+goKDHjY2IiIjaCcEJw9atW2FkpNsYSUtLS5VXFURERPRkEpwB6JosEBERUcchOAvYt28f5s2bp5w++ah79+5h3rx5+PHHH/UVGxEREbUTghOG8+fPw8vLS+3yz1KpFD4+PkhOTtZbcERERNQ+CE4Y8vPz4ezsrLGOk5MT8vPzWxwUERERtS+CE4ba2lqYmZlprCMWiyGXy1scFBEREbUvghOGbt264erVqxrrXL16lTtWEhERdUCCEwZfX1+kpaUhISGh2fPx8fFIS0vjTpVEREQdkOB1GKZNm4bTp09j8+bNSEhIgJ+fH6RSKe7duweZTIZz587BysoK06ZNa8VwiYiIyBAEJwxSqRTvvfceNm7ciOTk5CazIbp3747ly5ejW7dueg+SiIiIDEun3SpdXV2xefNmnD9/HlevXkVlZSUkEgnc3d0xePBgmJg81uaXRERE1M7p/AtvYmKCYcOGYdiwYa0RDxEREbVDXO+ZiIiItFLbw3DixAkAQEBAACwsLJTHQowePbrlkREREVG7oTZh2LZtGwDA3d0dFhYWymMhdEkYcnJysHPnTmRmZkIikWDs2LGYPXu2xs2uIiMjER0d3ey5efPmYfr06QAe7LDZXKKzadMmODk5CY6RiIios1ObMCxevBgAYGtrq3KsTxUVFVi3bh2cnZ2xatUq5Ofn47vvvoNCocDzzz+v9rpx48Y1We8hOTkZ+/fvx6BBg1TKnZycmsTevXt3vX0GIiKizkBtwjBmzBiNx/pw9OhR1NbWYsWKFbC0tMTAgQNRXV2NqKgoTJkyBZaWls1e161btybTN/ft2wcnJye4uLiolJuZmcHDw0PvsRMREXUmBh30ePHiRfj6+qokBkFBQaitrUVaWprgdsrLy5GSkoKgoKDWCJOIiKjTM+jCCbm5ufD29lYps7Ozg5mZGfLy8gS3k5SUhPr6+mYThpycHCxYsAB1dXVwdXXFvHnz4OXl1eLYiYiIOhO1CcPSpUsfq0GRSIQvvvhCUN3GhZ8eJZFIUFFRIfie8fHx6NOnDxwdHVXK+/TpA3d3dzg7O6OsrAwHDx7EunXrsG7dOri5uTXbVmxsLGJjYwEAYWFhsLOzExyHNn/orSVqD/T5bFDnZJhniN9EHUlbPkNqEwaFQvFYDT7udY+ruLgYaWlp+POf/9zk3KRJk1SOBw0ahOXLlyMmJgarVq1qtr3g4GAEBwcrj4uKivQbMHUYfDaopfgMUUvp+xnq2bOn2nNqE4atW7fqNYjmSCQSVFVVNSmvrKyElZWVoDbOnDkDAAgMDNRa18zMDIMGDcL58+d1C5SIiKiTM+igRycnJ+Tm5qqUFRUVoaamRmOW87D4+Hh4enoK7pYRiUQQiUQ6x0pERNSZPXbCUF1djaKiomZ7CITy8/PDpUuXUF1drSxLSEiAWCwWNDCxsLAQV69eFTw7ora2FhcuXEDfvn0fO2YiIqLOSKdZEvX19Th48CCOHTuGwsJCZbm9vT3GjRuH5557DsbGxoLbCwkJweHDh/HZZ59h6tSpKCwsRFRUFCZPnqwy1XLZsmXw8vJqsgBTQkICjI2NMXz48CZtV1VVISwsDE8//TR69OiB8vJy/PTTTyguLsby5ct1+dhERESdnuCE4f79+/j444+RlpYGkUgEOzs72NjYoKSkBHfu3MF//vMfXLx4Ee+//77gba6trKzw4YcfYseOHVi/fj0kEgmeffZZzJkzR6VeQ0MDGhoamlwfHx8PHx8fWFtbN/1gJiawtrZGTEwMSktLYWpqCg8PD4SGhsLV1VXoxyYiIiLokDAcOnQIaWlp8Pf3x0svvaQyhTE/Px/ffvstzp8/j0OHDmHatGmCA3B2dsaaNWs01lE3AHPDhg1qrxGLxVi5cqXgOIiIiEg9wWMYTp8+jV69euGdd95pst5Bjx49sHLlSvTq1QunTp3Se5BERERkWIIThvz8fPj5+andRdLIyAh+fn4oKCjQW3BERETUPghOGExMTCCXyzXWqamp0WnQIxERET0ZBCcMTz31FJKSklBWVtbs+bKyMiQmJjbZLZKIiIiefIIThgkTJqCsrAx///vfcfz4cRQUFKC2thaFhYX47bff8N5776GsrAwTJkxozXiJiIjIAATPkggMDERWVhb279+P//u//2u2zpQpUwQt0UxERERPFp0WbnrhhRcwZMgQHD9+HFlZWaiqqoKlpSVcXFwwduxYeHh4tFacREREZECCE4by8nKIRCJ4eHgwMSAiIupktCYMycnJ+Pbbb5VLQffo0QPz58/HkCFDWj04IiIiah80DnrMzMxEeHi4yr4R+fn5CA8PR2ZmZqsHR0RERO2DxoTh0KFDUCgUmDlzJr7++mt89dVXmDFjBhoaGnDo0KG2ipGIiIgMTOMriatXr8LT01NlM6i5c+ciLS2NPQxERESdiMYehtLSUri7uzcpd3d3V7uAExEREXU8GhOG+vp6mJubNyk3MzNDfX19qwVFRERE7YvglR6JiIio89I6rTIuLg6pqakqZXfu3AEArF27tkl9kUiEDz/8UE/hERERUXugNWG4c+eOMkF4VFpamt4DIiIiovZHY8KwZs2atoqDiIiI2jGNCYOXl1dbxUFERETtGAc9EhERkVZMGIiIiEgrJgxERESkFRMGIiIi0ooJAxEREWnFhIGIiIi0YsJAREREWjFhICIiIq3ULtwUHR392I3OmjXrsa8lIiKi9kdtwhAVFfXYjeqSMOTk5GDnzp3IzMyERCLB2LFjMXv2bBgZqe/8KCwsxNKlS5uUBwYG4q233lIpS05Oxt69e5Gfnw97e3vMnj0bgYGBguMjIiIiDQlDc/tIHDp0CDKZDE8//TS8vLxgY2ODkpISpKam4vTp0/D398ezzz4r+OYVFRVYt24dnJ2dsWrVKuTn5+O7776DQqHA888/r/X6+fPno1+/fspja2trlfPp6ekIDw/H+PHjsXDhQshkMmzevBkSiQS+vr6C4yQiIurs1CYMj+4jceLECfz+++/4+OOP0bdvX5VzY8aMwcSJE7FmzRoMGzZM8M2PHj2K2tparFixApaWlhg4cCCqq6sRFRWFKVOmwNLSUuP1PXv2hIeHh9rz+/btQ//+/fHKK68AAHx8fJCTk4Po6GgmDERERDoQPOjxp59+wogRI5okC41cXV0xYsQI/PTTT4JvfvHiRfj6+qokBkFBQaitrW3x1tl1dXW4fPkyRowYoVIeGBiIzMxMVFVVtah9IiKizkRwwpCXlwdbW1uNdWxtbZGXlyf45rm5uejZs6dKmZ2dHczMzAS1s23bNsydOxd//etfsXv3btTW1irPFRQUoL6+Hk5OTirXODk5QaFQ6BQnERFRZ6dxe+uHWVhYICMjQ2OdjIwMmJubC755ZWUlJBJJk3KJRIKKigq115mammLChAnw9fWFhYUFUlNTsX//fhQUFGDVqlUAoLz+0fatrKyU9yYiIiJhBCcM/v7+iIuLw7fffovZs2fDwsJCea5x3EF6ejqeeeaZVgn0Yba2tli0aJHy2NvbGzY2Nvjmm2+QlZUFFxeXx247NjYWsbGxAICwsDDY2dm1NFylP/TWErUH+nw2qHMyzDPEb6KOpC2fIcEJwwsvvIC0tDT89NNPOH78OFxcXNC1a1eUlpYiKysL1dXVsLe3x7x58wTfXCKRNDuWoLKyUtkTINTw4cPxzTff4MaNG3BxcVFe/2j76noeGgUHByM4OFh5XFRUpFMc1Hnw2aCW4jNELaXvZ+jRYQIPE5wwdO3aFf/85z/x/fff4/Tp07hy5YrynFgsxrhx4zBv3jx06dJFcGBOTk7Izc1VKSsqKkJNTY3GoDURiUQAAAcHBxgbGyM3N1dlxkdeXh5EItFjt09ERNQZCU4YAKBLly547bXX8OqrryI3NxdVVVWwtLSEk5MTjI2Ndb65n58fDhw4gOrqauUrjoSEBIjF4ibTOrVJTEwEAOUsDlNTU/j4+CAxMREhISHKegkJCfDw8NA6ZZOIiIj+S6eEoZGxsTF69+7d4puHhITg8OHD+OyzzzB16lQUFhYiKioKkydPVvlBX7ZsGby8vLB48WIAQGRkJORyOfr16wcLCwtcuXIFBw4cQEBAAJ566inldTNnzkRoaCh27dqFoUOHQiaTQSaTYfXq1S2OnYiIqDPROWG4f/8+Ll++jJycHMjlcuUy0LW1taiurkaXLl00Luv8MCsrK3z44YfYsWMH1q9fD4lEgmeffRZz5sxRqdfQ0ICGhgblsZOTEw4ePIhjx46htrYWdnZ2mDJlCmbMmKFynaenJ5YvX46IiAgcOXIE9vb2ePPNN7loExERkY50ShguXryI7du3o6SkRFnWmDBkZWXhgw8+wLJlyzBy5EjBbTo7Oze7DPXDtm7dqnIcFBSEoKAgQe0HBAQgICBAcDxERETUlOCFm65fv44NGzZAJBJhwYIFTX6wPTw8YG9vj7Nnz+o9SCIiIjIswQnDvn37IBaLERYWhkmTJsHR0bFJHVdXV2RnZ+s1QCIiIjI8wQlDRkYGhg4dChsbG7V17OzsVF5XEBERUccgOGGQy+VNto9+VE1NjcrgRCIiIuoYBCcMUqkUt2/f1lgnKysLDg4OLQ6KiIiI2hfBCYOfnx8uXbqE9PT0Zs/LZDJkZmbC399fb8ERERFR+yB4WuX06dORkJCAf/zjH5g4cSLu3LkDALhw4QLS0tLw66+/wsbGBpMnT261YImIiMgwBCcMUqkU7733HjZt2oSDBw8qy9evXw/gwd4NK1eu1DrOgYiIiJ48Oi3c1LdvX2zevBkXLlxAZmYmysvLYWlpCXd3dwwdOvSx9pMgIiKi9k/npaGNjIwwZMgQDBkypDXiISIionZI8KDHtWvX4sSJExrrnDx5EmvXrm1xUERERNS+CE4Y0tLSlAMd1SkqKkJaWlqLgyIiIqL2RXDCIERtbS3HMRAREXVAOo9haI5CoUBRURFkMhm6deumjyaJiIioHdGYMMydO1flOCoqClFRURobnD59esujIiIionZFY8LQv39/iEQiAA/GMNjZ2cHe3r5JPSMjI1hZWWHAgAEYO3Zs60RKREREBqMxYQgNDVX+89y5c/HMM89g1qxZrR0TERERtTOCxzBs2bIFEomkNWMhIiKidkpwwtC9e/fWjIOIiIjaMZ1nSRQXF+P333/HvXv3cP/+/Wbr8LUFERFRx6JTwhAZGYkff/wR9fX1GusxYSAiIupYBCcMp06dwr59++Dj44MJEyYgPDwco0ePhq+vL1JTU/Hbb79h+PDhCAkJac14iYiIyAAEJwxHjhyBVCrF6tWrlas52tvbIygoCEFBQQgICEBYWBiCgoJaLVgiIiIyDMFLQ9+6dQuDBg1SWfq5oaFB+c9+fn7w9fXFwYMH9RshERERGZzghKG+vh5dunRRHovFYlRVVanU6dWrF7KysvQWHBEREbUPghMGW1tbFBcXK4/t7OyQnZ2tUqe4uJibTxEREXVAghMGFxcX3L59W3ns7e2N9PR0nDx5EnK5HBcuXEBiYiL69OnTKoESERGR4QhOGAYPHozbt2+jsLAQADBt2jRYWlpi69atWLBgAdavXw+g6YZVRERE9OQTPEtizJgxGDNmjPLYzs4On3zyCQ4ePIiCggJ0794dEyZMQO/evVsjTiIiIjIgnVd6fJi9vT0WLVrUogBycnKwc+dOZGZmQiKRYOzYsZg9ezaMjNR3fly7dg1HjhzBlStXUFxcjG7dumHkyJGYOnUqxGKxsl5kZCSio6ObXL969Wr4+fm1KG4iIqLOpEUJQ0tVVFRg3bp1cHZ2xqpVq5Cfn4/vvvsOCoUCzz//vNrrEhISUFBQgKlTp8LR0RHZ2dmIiIhAdnY2Vq5cqVLX0tISq1evVilzdnZulc9DRETUUemcMDQ0NODevXsa95Lw8vIS1NbRo0dRW1uLFStWwNLSEgMHDkR1dTWioqIwZcoUWFpaNnvdtGnTYG1trTz29vaGWCzGV199hTt37qhslGVsbAwPDw8dPiERERE9SqeE4cCBAzh48CDKyso01ouIiBDU3sWLF+Hr66uSGAQFBWHPnj1IS0vDkCFDmr3u4WShkYuLC4AHUzu5syYREZF+CU4YIiMjsW/fPlhZWWH06NGQSqUtXnMhNzcX3t7eKmV2dnYwMzNDXl6eTm1lZmZCJBLBwcFBpbyyshKLFi1CVVUVevXqhZkzZ2LYsGEtipuIiKizEZww/Pbbb7C3t8f69evVvirQVWVlJSQSSZNyiUSCiooKwe2UlJQgJiYGo0aNQteuXZXlPXr0wIsvvggXFxfI5XIcPXoU4eHhWLFihdqkITY2FrGxsQCAsLAw2NnZ6fip1PtDby1Re6DPZ4M6J8M8Q/wm6kja8hkSnDCUl5cjJCREb8mCvty/fx+bNm2Cubk5FixYoHJu1KhRKseDBw/G+++/j+joaLUJQ3BwMIKDg5XHRUVF+g+aOgQ+G9RSfIaopfT9DPXs2VPtOcELN/Xo0QOVlZV6CaiRRCJpsh8F8KDnwcrKSuv1CoUCW7Zswe3bt/H3v/9d6zUikQjDhg3DrVu3VDbOIiIiIs0EJwzjx4/H+fPnUVJSorebOzk5ITc3V6WsqKgINTU1GrOcRrt27UJycjJWrVoFJycnvcVFREREqgS/khg/fjz++OMPfPDBB5g5cyb69u2r9vWE0Hcqfn5+OHDgAKqrq2FhYQHgwRoLYrFY69TMH374Ab/88gvefvtteHp6CrqfQqFAUlISXFxcNC4MRURERKp0mlb51FNPIS4uDtu3b1dbRyQSYe/evYLaCwkJweHDh/HZZ59h6tSpKCwsRFRUFCZPnqySjCxbtgxeXl5YvHgxAOD06dP4z3/+gzFjxkAqlSIzM1NZt0ePHsppl2vWrMGwYcPg5OSEmpoaHDt2DNeuXcM777yjy8cmIiLq9AQnDMeOHcNXX30FY2NjeHt7w9bWtsXTKq2srPDhhx9ix44dWL9+PSQSCZ599lnMmTNHpV5DQ4PKmINLly4BAOLi4hAXF6dS94033lDuedGjRw/8/PPPKC4uhpGREfr06YN3330XgwYNalHcREREnY1IoVAohFR86623UFVVhX/84x+wt7dv7bjaDV3Xg9Dkj3de1VtbZHiOG75p83u+vPtMm9+TWs+uBSPa/J6/HuC0yo5kwhRHvbanl1kSd+7cwfDhwztVskBEREQPCE4YpFKp2r0jiIiIqGMTnDCMHj0aMpkM1dXVrRkPERERtUOCE4bp06fDzc0N69atQ2pqKhMHIiKiTkTwLIkXXnhB+c8fffSR2nq6TKskIiKiJ4PghKF///4QiUStGQsRERG1U4IThtDQ0FYMg4iIiNozro9MREREWjFhICIiIq3UvpKIjo4GAEycOBFWVlbKYyFmzZrV8siIiIio3VCbMERFRQEAAgMDYWVlpTwWggkDERFRx6I2YVizZg2A/25V3XhMREREnY/ahMHLy0vjMREREXUeggc9njhxAtnZ2Rrr3Lp1CydOnGhxUERERNS+CE4Ytm3bhuTkZI11zp07h23btrU4KCIiImpf9DqtsqGhgatBEhERdUB6TRjy8vIgkUj02SQRERG1AxqXhn709UJycjIKCwub1GtoaMDdu3dx5coV+Pv76zdCIiIiMjiNCcOjAxizsrKQlZWltr67uzsWLFigl8CIiIio/dCYMGzZsgUAoFAosGzZMkyaNAmTJk1qUs/IyAgSiQTm5uatEyUREREZlMaEoXv37sp/njVrFry9vVXKiIiIqHMQvL317NmzWzMOIiIiascEJww3b95EZmYmnn76aVhaWgIA5HI5vvnmG5w7dw5mZmaYOnVqs68siIiI6MkmeFrl/v37ERMTo0wWAOD777/HqVOnoFAoUF5ejt27d+PSpUutEigREREZjuCE4fr16/D29lYe379/HydOnICbmxu+/vprbNmyBdbW1jh8+HCrBEpERESGIzhhKCsrQ7du3ZTHN27cgFwuR3BwMMRiMaRSKYYMGaJ1vwkiIiJ68ui00mN9fb3yn9PT0wGo7mJpbW2NsrIyPYVGRERE7YXghMHOzg5Xr15VHicnJ6Nbt25wcHBQlhUXF8PKykq/ERIREZHBCZ4lMWLECERFRSE8PBympqbIzMzEs88+q1InNzdXJYEgIiKijkFwwjB58mRcunQJZ8+eBQC4uLhg1qxZyvOFhYW4du0apk+frlMAOTk52LlzJzIzMyGRSDB27FjMnj0bRkaaOz+qqqqwa9cuJCcno6GhAYMHD8bChQvRpUsXlXrJycnYu3cv8vPzYW9vj9mzZyMwMFCnGImIiDo7wQmDubk51q1bh1u3bgEAnJ2dm/yor1y5Eq6uroJvXlFRgXXr1sHZ2RmrVq1Cfn4+vvvuOygUCjz//PMar920aRPy8vLw2muvwcjICHv27MGGDRvw0UcfKeukp6cjPDwc48ePx8KFCyGTybB582ZIJBL4+voKjpOIiKizE5wwNOrdu3ez5fb29rC3t9epraNHj6K2thYrVqyApaUlBg4ciOrqakRFRWHKlCkqaz48LDMzE5cuXUJoaKhy0KVUKsXq1auRkpKCgQMHAgD27duH/v3745VXXgEA+Pj4ICcnB9HR0UwYiIiIdKCx3z8tLQ1FRUWCG8vOzm6yw6UmFy9ehK+vr0piEBQUhNraWqSlpam9TiaToWvXriozNNzc3GBvb4+LFy8CAOrq6nD58mWMGDFC5drAwEBkZmaiqqpKcJxERESdncaEYe3atYiLi1Mp+/HHH5V/sT/q7Nmz2LZtm+Cb5+bmomfPnipldnZ2MDMzQ15ensbrnJycmpQ7OTkhNzcXAFBQUID6+vom9ZycnKBQKDS2T0RERKp0fiVRV1eHyspKvdy8srISEomkSblEIkFFRYXG65p7XSGRSFBYWAgAyusfbb9x2qe6zxAbG4vY2FgAQFhYWJOEpiV67vlZb21R53Tk7zMNHQI94Ra+rr/vNOpcdFq4qTMIDg5GWFgYwsLCDB3KE+vdd981dAj0hOMzRC3FZ0j/DJowSCSSZscSVFZWalwASiKRoLq6utnrGnsUGq9/tH11PQ9ERESknkEThofHHDQqKipCTU2NxlcBzV0HAHl5ecoxCw4ODjA2Nm5SLy8vDyKRSK+vGoiIiDo6gyYMfn5+uHTpkkpvQUJCAsRiscoMiEcNGjQIJSUlyv0sgAe7aRYUFMDPzw8AYGpqCh8fHyQmJqpcm5CQAA8PD7VTNqnlgoODDR0CPeH4DFFL8RnSP4MmDCEhITA1NcVnn32GlJQUxMbGIioqCpMnT1b5QV+2bBm2b9+uPPbw8ICvry+2bNmCpKQknD17Fv/7v/8LT09P5RoMADBz5kykpqZi165dSE1Nxb///W/IZDKVFSpJ//gfKrUUnyFqKT5D+idSKBQKdSfnzp37WI1GREQIrpuTk4MdO3aoLA09Z84clVUklyxZAi8vLyxZskRZVllZid27d+Ps2bNQKBTw9/fHwoULYW1trdL+2bNnERERgT/++EO5NHRQUNBjfS4iIqLOyuAJAxEREbV/GhMGokfFxcVh27ZteOONNzBmzBhDh0PtWGpqKtauXYtZs2Zhzpw5AIA5c+bAy8sLoaGhhg2Onmj8HjIMrsNAREREWrGHgXRSVVWF4uJi2NracqYJaVRTU4OioiJ06dJFObYoNzcXZmZmsLOzM3B09CTj95BhMGEgIiIirXTeS4I6tvj4eBw+fBh//PEH5HI5rK2t0bdvX8ycORN9+/Zt9t1hYWEhli5ditGjR2PSpEn497//jatXr8LY2Bh+fn6YP38+pFKpyn2uXbuGmJgYXL9+HeXl5ZBIJOjZsydCQkIwcuRIA3xy0jehYxhCQ0ORlpaG7777Dt9//z0SExNRUVGB3r17Y9asWRg8eLBKuxUVFdi/fz/Onj2Lu3fvwsTEBFKpFD4+PnjppZdgYsKvtY7g4efHy8sLUVFRuHnzJhwcHPDss8/ye8gAOIaBlA4fPozNmzejtLQUQUFBmDRpEry8vHD9+nVkZmZqvb6goAChoaEwMTHBxIkT4eHhgfj4eHzwwQcqm4nduHEDH3zwAa5cuQJfX19MnjwZgwcPRnV1Nc6ePduaH5HasY0bN+LChQsICgrC6NGjkZeXh08//VRl8TWFQoGPP/4YBw4cgIODAyZOnIjRo0eje/fuOHbsGO7fv2/AT0CtISMjAx9//DEsLS0xfvx4DBgwQGN9fg+1HqbipBQXFwdbW1t89tlnMDMzU5Y3NDQ0u+fHo9LT0zFnzhyVhbGio6MRGRmJ6OhovPzyywCAU6dOob6+HmvWrIGLi4tKG+Xl5Xr5LPTkuXv3LjZs2ABzc3MAwOTJk7Fq1Srs2LEDQ4YMgYmJCW7duoXr169j0qRJyuepUWVlJcRisQEip9b0+++/480331T5iz8uLk5tfX4PtR72MJAKU1NTGBsbq5QZGRlp3AyskZWVFZ577jmVsueeew4SiQSnT59uUr/xh+FhXbp00TFi6iimT5+u8kz07NkTo0aNQmlpKVJSUlTqNvfsSCQSlQXfqGNwdXXV6fUAv4daD//rIqURI0agsLAQK1asQGRkJFJTU1FbWyv4+j59+qj0TACAmZkZ+vTpg7KyMhQXFyvvIxKJsHr1auzcuRPJyckqXYXUOXl6eqoty87OBgA4OzujV69e+OGHHxAWFoYjR440uxEddRx9+/bVqT6/h1oPX0mQ0tSpUyGRSHDkyBFER0cjOjoaZmZmePrppzF//nxYWFhovF5dVt44pa66uhq2trbw8PDAhx9+iJiYGBw9ehS//PILRCIRfH198fLLL3Mn0U7q0WXdHy5r3KDO2NgYa9asQUREBJKSknDhwgUAD3annTVrFkaPHt12AVOb6Nq1q071+T3UepgwkJJIJEJISAhCQkJQUlKCy5cv49ixY4iNjUVtbS2WLl2q8Xp17/3KysoAQCXh8Pb2hre3N+RyOdLT03HmzBnExcXhk08+waZNmzjSvRMqKytDt27dmpQBqs+OtbU1/vKXv2DRokW4desWLl68iJ9//hlbt26FVCrVOiiOOjZ+D7UevpKgZtnY2GDkyJF4//33IZVKcf78ea3X3Lx5EzU1NSplNTU1uHnzJqytrWFra9vkGnNzc/j5+WHx4sUYMWIECgoKkJOTo7fPQU+Oh7erf7TsqaeeanLOyMgILi4umDZtGt544w0AEPScUsfG76HWw4SBlNLS0pqUyeVy1NTUCMq0KyoqcPDgQZWygwcPorKyUmXQUmZmJurq6lTqKRQKlJaWAngw8JI6nx9++AFyuVx5nJeXh5MnT6Jr167KbesLCwtx586dJteWlJQA4LND/B5qTexvIaVPP/0UEokE7u7usLOzQ01NDc6dO4fKykq88MILWq/39PTEwYMHcfXqVTz11FPIzs6GTCZD9+7dVaY4/fjjj7hy5Qr69+8Pe3t7GBkZ4cqVK7h+/ToGDRoEJyen1vyY1E5169YN77zzDoYOHQq5XI6EhATU1dVh6dKlyoQ1KysL4eHh8PDwgJOTE6ytrZGfn49z587BwsICY8eONfCnIEPj91DrYcJASi+88AIuXLiAjIwMJCcnw9LSEs7Ozli4cCECAgK0Xu/g4ICXX34Ze/bswS+//AIjIyMEBgZi/vz5KtMyx48fD0tLS1y9ehW///47jI2NYW9vj5deegnjx49vzY9I7djy5cvx/fff4/Tp06isrISzszNmz56NIUOGKOu4urpiypQpuHz5MpKTkyGXyyGVSjFq1ChMmzYNPXr0MOAnoPaA30Oth3tJUIs9vCTrkiVLDB0OPWEal4aOjIw0dCj0BOP3UOvjGAYiIiLSigkDERERacWEgYiIiLTiGAYiIiLSij0MREREpBUTBiIiItKKCQMRERFpxYSBiNq11NRUzJkzB3PmzDF0KESdGld6JBKotrYWJ06cwPnz55GdnY2ysjKYmJhAKpXC09MTQUFB8PHx0djGkiVLmt0LwdzcHN27d0f//v0xceJEODs7N6nTuMCREF5eXggNDRVUV1tszdHH4jiVlZX46aefAADPPvssJBJJi9prj+Li4lBYWKjcFZHoScaEgUiAlJQUbN++HXfv3lWWWVhY4P79+8jNzUVubi6OHTuGQYMGYenSpejSpYvG9kxNTWFpaQngwYY35eXluH37Nm7fvo1jx47hL3/5i9p9EYyNjVWWuG2OtvNCY1NH23khKisrER0dDQAYM2aM2oTBzMwMPXv2bPH9DCEuLk6Z5DFhoCcdEwYiLRISEvDFF1+gvr4eUqkUc+bMQUBAgPJHOTc3F0ePHsWvv/4KmUyG9957D+vWrUPXrl3VthkYGKjyF3ptbS3Onz+PnTt3orS0FF999RVcXV2b3da5X79+Ovce6OLR2AzNzc0Nn3/+uaHDIOr0OIaBSIOcnBxs374d9fX16N27Nz799FOMHTtW5S94JycnvPzyy3jnnXdgYmKC/Px8/O///q9O9xGLxRgxYgSWLVsGAGhoaMCRI0f0+lmIiFqCPQxEGuzduxc1NTUwNTXF8uXLYW1trbauv78/ZsyYgcjISPz++++4cOEC/P39dbrfwIEDYWtri+LiYly/fr2l4bepu3fv4uDBg0hJScGdO3dQX1+PLl26wMbGBv3798fIkSPh5uYGoOl4jKVLl6q09fAYjNTUVKxduxYAmmxQFRcXh23btqF79+7YunUrrly5gv379+PatWuoqamBo6MjJk6cqPJ658KFC/jpp5+QlZWFmpoa9OrVC8899xwCAwOb/VyFhYVISEhAamoqCgsLce/ePQCAnZ0dfH19MXnyZNjZ2TUbV6Po6Gjl65dGW7Zsgb29vfK4oaEBcXFxOHXqFG7duoXq6mp06dIF/fr1w4QJE9S+0mj8dzlr1izMmDEDhw8fRnx8PPLz81FVVYU1a9Yor83NzcWhQ4eQlpaGu3fvQqFQwNraGlKpFN7e3hg9ejS3dSa1mDAQqVFcXIzk5GQAQFBQkKD36JMnT8bBgwdRXV2NX3/9VeeEAQCkUimKi4tRXV2t87WGkpWVhbVr16KyshIAYGRkBAsLC5SUlKC4uBg3b95EZWWlMmGwsrJCly5dUF5eDgDo0qULjIz+2+H5OGMwjh07hq+++grAg/ElNTU1yMrKwpdffon8/Hy88MILiIyMRHR0NEQiESwsLFBbW4vr16/j888/R0VFRbPbGm/btk2Z3JiYmMDCwgIVFRXKsStxcXF499134enpqbxGLBaja9euqKioQH19PczMzGBubq7S7sOft6qqChs2bEBqamqTf3+JiYlITEzEc889h/nz56v9/HV1dVi7di0yMjJgbGwMc3NziEQi5fmUlBSsX78edXV1AKCsc/fuXdy9exdXr16FiYkJZ6OQWkwYiNRITU1F48rpw4YNE3SNubk5Bg4ciKSkJFy5cgX19fUwNjbW6b6NMxVaMnCxrX333XeorKxEnz59sGjRIri7u0MkEuH+/fu4c+cOzp07h4dXoV+5cqVyO2IA+OSTT1T+2tZVWVkZduzYgYkTJ2LmzJmwtrZGRUUFdu/ejRMnTmD//v2QSCSIiYnB888/j4kTJ8LS0hLFxcXYvn07Ll68iO+++w4jR45sMqDTxcUFI0aMwMCBA+Hg4AAjIyPU19fj5s2biIyMxMWLF7Fp0yZ88cUXEIvFAB6MAwkMDFT+9f/cc89p/CHevn07UlNTYWJigvnz52Ps2LEwMzNDSUkJ/vOf/+C3337DwYMH4eDg0GxSAwC//vorAOCNN95AYGAgxGIxysvLlUnD119/jbq6Ovj6+mL+/Pno3bs3gAfjZwoKCpCUlNSkp4ToYUwYiNTIyclR/nOfPn0EX+fi4oKkpCTI5XLcuXMHPXr0EHxtYmIiysrKAADu7u7N1snIyMBf/vIXje0sXLhQbRe7NgkJCbh48aLGOitXrkS/fv1UYgKARYsWwcPDQ1luYmICR0dHPPfcc48Vi1A1NTUYO3YsFi5cqCyzsrLC4sWLceXKFRQWFmLPnj14/vnnMWPGDGUdW1tbvPXWW3jttddQU1ODc+fOYdSoUSptv/zyy03uZ2xsDDc3N7z77rv429/+huzsbCQmJja5VoirV68iKSkJAPDKK68gODhYec7GxgaLFy9GVVUVkpKSEBERgTFjxigTk4fJ5XKsWrUKQ4YMUZY1ztYpLS1FQUEBgAcJha2trbKOWCxGr1690KtXL51jp86Fgx6J1GjsLgd0+2v/4SmVFRUVWusrFArcuXMHhw8fxvbt2wE8+KGdMGFCs/Xr6+tRWlqq8X+1tbWC431UXV2d1vbv37+vck3jlMji4uLHvm9LTZs2rUmZkZGRcm0MU1NTTJo0qUkdS0tLZZJz69Ytne5pZGQEX19fAEB6erqOET+QkJAAAOjWrZvaqbRz584F8OCZTElJabZOr169VJKFh1lYWCh7Ggz5/xE92djDQGQAJ06cwIkTJ5o9Z25ujiVLlsDR0bHZ84+zKJMuHmdRJn9/fxw7dgxbt25FRkYGhgwZAldXV5iZmbVSlKqsrKzU9uTY2NgAAJydnZuMI2jUOAVWXYJ35coVHD9+HFevXsXdu3dRU1PTpE7jYEhd3bhxA8CDdRoeHtfwMGdnZ0ilUty7dw83btxoNjF4uMfnUWKxGAMGDEBKSgr++c9/IiQkBP7+/ujTpw9MTPgzQMLwSSFS49GeAqlUKug6IT0TDy+OJBKJYGZmBjs7O/Tv3x/jxo1Dt27dWhB523vxxReRn5+P1NRUHDp0CIcOHYKRkRFcXFzg7++P4OBgwf/+HoeFhYXac40/wprqNI4zqa+vb3Lu3//+Nw4cOKDSnkQiUf7QyuVy1NTUNJtECFFaWgoAWv/9dOvWDffu3VPWf5SmGTwA8Prrr2P9+vXIzs7Gvn37sG/fPpiYmMDV1RVDhw5tMl2Y6FFMGIjUeHh55hs3bgj+wbt58yaA/y733Jz2tjhSS0kkEqxZswbp6ek4d+4cMjIycOPGDeX/Dhw4gNdffx0jR440dKg6SUlJUSYL48ePx/jx4+Hs7KzSE7B3717ExMSoDOo0BHW9E43s7Oywfv16pKSkQCaTISMjA9nZ2cjIyEBGRgZ++OEHrFixQuvy5tR5MWEgUsPb2xsikQgKhQJJSUlq3w8/TC6X4/fffwcA9O/fX+cZEk86T09P5fTC2tpapKSkYO/evbh16xa2b98OHx8f5SuCJ0F8fDwAwNfXF6+++mqzdUpKSlp0j65duyIvL09l2fHmNJ7XtIKoNkZGRvDz84Ofnx8AoLq6GufPn8f333+PoqIibN68Gdu3b+drCmoWBz0SqWFra4uhQ4cCeDAwLS8vT+s1hw4dUq6foG76W2chFosxZMgQrFy5EsCDwZQPDwzU9hdxe9D4I61uloxCoVCundCch9dBUKdv374AHkzjbWhoaLZObm6ucoyEq6ur1jaFsrCwwMiRI/H6668DePB6RNeBn9R5tP//YokMaO7cuRCLxairq8PGjRuVUx6bI5PJEBMTA+BB78TjLNr0JKqvr1f7QwdAZQrgw0nCw2MKGhd8am8ax5lkZ2c3e/7o0aPK6YrNafyMmj5fUFAQgAeDJo8fP95snYiICAAPxtUMGDBAe+CPeHRWy6Me/v9ISJJDnRMTBiINevXqhddffx1GRka4desW/va3v+H48eMqPwB5eXnYvXs3Pv30U9y/fx8ODg74n//5n07zxXv37l38z//8D/bt24ebN2+qDBzMzs7GF198AeDBrpNeXl7KcxKJRDku5Lfffmt2wKGhNXbdy2QyREdHQy6XA3iQAMTExGDnzp0adyZtXBxJJpOpnUXh5uamXBhs586d+OWXX5QDKEtKSvDll18iMTERwH8TWF1lZGRg5cqVOHToEHJycpQJnkKhQEZGBr755hsADwZWNrfhGRHAMQxEWo0cORJWVlbK7a2//PJLfPnll7C0tERdXZ1yqV3gwbvuZcuWaR2x3hJCFm4CHqzs9ziELNxkZ2eHTz75RHlcUFCAiIgIREREwMjICJaWlpDL5cq/bE1MTLBkyZImo/BDQkIQERGBX375BceOHYO1tTWMjIzg7u6Ot95667Hi16dRo0bhxIkTuHLlCiIjIxEVFQVLS0tUVVVBoVDA398fLi4uyp6lR40ePRoHDx5Efn4+Fi9eDGtra+UP/kcffaScDbN48WKUl5cjLS0NO3fuxO7du2Fubq68DwA899xzLXrNdevWLXz77bf49ttvYWxsrPwcjYmahYUF3nzzzSfiVREZBhMGIgH8/PzwxRdfIC4uDufPn0d2djbKy8thYmKinA4ZFBT0WN3FumpcuKm1NC7cpMnDf+VKpVKsWrUKqampyMzMVE79MzY2Ro8ePeDt7Y1JkyY1u67E9OnTYWFhgVOnTinf0ysUCrWzS9qaiYkJ3nvvPfz444+Ij49XLtvt5uaG0aNHIzg4uMmmUg9zdHTEmjVr8OOPP+Lq1avKvSUA1SmclpaW+PDDD5WbT2VlZUEul8PGxgYeHh6YOHGi2s2nhHB1dcXbb7+N1NRUXLt2DcXFxSgrK4OpqSl69eqFgQMHYtKkSa069ZWefCKFoecCERERUbvHviciIiLSigkDERERacWEgYiIiLRiwkBERERaMWEgIiIirZgwEBERkVZMGIiIiEgrJgxERESkFRMGIiIi0ooJAxEREWn1/+e9u6ZDqRXCAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 576x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_, estimated_interval_random = ope.summarize_off_policy_estimates(\n",
     "    evaluation_policy_pscore=random_policy_pscores[0],\n",
@@ -347,7 +376,7 @@
     "    evaluation_policy_pscore_cascade=random_policy_pscores[2],\n",
     "    alpha=0.05,\n",
     "    n_bootstrap_samples=1000,\n",
-    "    random_state=random_behavior_dataset.random_state,\n",
+    "    random_state=dataset_with_random_behavior.random_state,\n",
     ")\n",
     "estimated_interval_random[\"policy_name\"] = \"random\"\n",
     "\n",
@@ -360,15 +389,37 @@
     "    evaluation_policy_pscore_cascade=random_policy_pscores[2],\n",
     "    alpha=0.05,\n",
     "    n_bootstrap_samples=1000, # number of resampling performed in the bootstrap procedure\n",
-    "    random_state=random_behavior_dataset.random_state,\n",
+    "    random_state=dataset_with_random_behavior.random_state,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "          mean  95.0% CI (lower)  95.0% CI (upper) policy_name\n",
+      "sips  1.830555          1.803695          1.860548     optimal\n",
+      "iips  1.843117          1.825576          1.859695     optimal\n",
+      "rips  1.838866          1.815574          1.862451     optimal \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgwAAAGSCAYAAACPApmhAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAABS/UlEQVR4nO3deVhU1/kH8O+wDMsgsomyaFAWEYgg7mDUKC41xn2JaYxb2sSo+SVqbGoWNTYNatDauKRJtJpUq4AkLolRUXEBQdRRIiC4gQICouwwA8L8/vBh6ggzc0cGBuH7eZ4+j/fcc899p72deTn3LCKFQqEAERERkQZGhg6AiIiIWj4mDERERKQVEwYiIiLSigkDERERacWEgYiIiLRiwkBERERaMWEgIiIirZgwEBERkVZMGIiIiEgrE6EVc3Jy8PvvvyM1NRUFBQUoLS2FWCyGtbU13Nzc4OvrCz8/P4jF4qaMl4iIiAxApG1p6NjYWBw9ehTXrl3T2phEIsHQoUMxevRoODo66i1IIiIiMiy1CcPVq1fxww8/IDMzE5aWlujbty+8vb3h7u4OGxsbWFlZoaqqCqWlpcjJyUF6ejqSkpJw/fp1mJiY4A9/+AMmTZoES0vL5v5MREREpGdqE4bp06eja9euGD9+PPr06QNTU1NBDd67dw/Hjh3DsWPHMH78eEyZMkWvARMREVHzU5swnD9/Hv369XvmhouKipCfnw8vL69nboOIiIhaBq1jGIiIiIgEz5Joq3JycgwdAhERUbNwdnZWe47rMBAREZFWGnsYFi5cqHODIpEIX3/99TMHRERERC2PxoTh/v37zRUHERERtWAaBz0+a8LQoUOHZw6opeEYBiIiais0jWHQ2MPQmn74iYiI6Nlx0CMRERFppbGHoba2Fv/4xz8gEomwaNEimJg0XP3Ro0f4+uuvIRKJ8P777zdFnERERGRAGnsYEhISkJCQgD59+qhNFgDAxMQEffv2xblz5xAfH6/3IImIiMiwNCYM586dg52dHQYNGqS1oeDgYNjZ2eHs2bN6C46IiIhaBo0Jw82bN+Hr6wuRSKS1IZFIBD8/P9y6dUtvwREREVHLoDFhKCoqgr29veDG7OzsUFxc3OigiIiIqGXRmDCYmJigurpacGPV1dUaxzoQERHR80ljwmBra4vMzEzBjWVmZsLW1rbRQREREVHLojFh6N69O1JSUpCbm6u1odzcXKSkpMDb21tvwdHzZ8qUKZgyZYqhwyCiNozfQ01DY8IwYsQI1NbWYv369RrHJpSUlGDDhg2ora1FSEiI3oMkIiIiw9I44MDDwwMhISGIjo7G4sWLMWLECPj5+cHOzg4A8PDhQ1y9ehXR0dEoLS3FiBEj4OHh0SyBE1HrVPeXYWRkpIEjIaInaR2hOHfuXNTW1uLEiRP46aef8NNPPzVYb/jw4Zg7d67eAyQiIiLD05owGBsb4+2338bQoUNx7NgxpKWloaioCABgY2MDb29vhISEoHv37k0dKxG1clFRUbh48SKqqqrQr18/fPTRR5g0aZKhwyIiCEgY6nTv3p1JARE1maioKCxbtgxVVVUAgOzsbCxbtgwAmDSQYEw6mw53qySiFiE0NBSVlZUqZZWVlQgNDTVQRPS8UZd0RkVFGTiy1kGkUCgUhg6iJcvJyTF0CM+NqKgoLFmyBFVVVXBxcWFm3wRm7zxn6BCazLHlUwE09HUkwoi/RzR3OM1ix6yBhg6hVenXrx+ys7Prlbu4uOD8+fMGiOj54+zsrPYcl2UkvWB3MjWWuY09ZEUFDZaT/hw5cM/QITSZ7OyG/8DLzs5ptZ971DinZrsXX0mQXrA7mRrLY8TrMDIVq5QZmYrhMeJ1A0VEzxt7u446lZNu2MPQjO59+JahQ2gyOQ10A9aVt9bP7bTue0OH0Ko49RoMAEiJ2oLamkcwt3GAx4jXleVE2kwavwA7d32BqiqZskwsNsek8QsMGFXrwYSB9KKjpTlyK2QNlhMJ5dRrMLIvRAMA+vzpcwNHQ8+bgf3+AAD494+f49GjatjbdcKk8QuU5dQ4fCVBerHA3wvmxqqPk7mxERb4exkoIiJqiwb2+wPcu76I7p6BWPfFISYLetSoHob8/HxkZWUBAFxdXeHo6KiXoOj584euLgCAzxOuorq2Fp0szbHA30tZTiQUexaIWqZnShgqKyvxzTffID4+XqV84MCBeOedd2Buzm7otugPXV3w083HCeS3If0NHA0REenTMyUM27ZtQ1JSEqZNm4Zu3bqhuroaFy5cwKlTp2BmZob58+frO04iIiIyII0Jg1wuh5mZWb3yxMREvPXWW3jppZeUZf369YNcLsf58+eZMBARkcH8ZfG3hg6hVdI46HHp0qW4evVqvfKamhpYWFjUK7ewsEBtba3+oiMiIqIWQWMPg6enJ1avXo3hw4dj5syZyiTBz88P27Ztg0wmQ9euXVFdXY2LFy/i1KlT6N27t04B5Obm4sCBA0hPT8fdu3fRo0cPrFy5UuM14eHhiIyMbPDcjBkzMHHiRADA5s2bcerUqXp1NmzYABcXDsYjIiISSmPC8N5772HQoEH47rvvIJVK8ec//xm9evXCW2+9hXXr1uHrr79Wqd+tWzfMnTtXpwDu3r0LqVQKT09P1NTUCLpm+PDhCAgIUClLTEzE/v370atXL5VyFxeXeq9IOnTooFOMJBwHOxIRtU5aBz0GBgYiLCwMP/zwA0JDQ/HSSy9h9uzZWLNmDZKSkpQbfbi6uuLFF1/UOYDevXujb9++AICwsDCUlpZqvcbe3h729qrry+/btw8uLi5wc3NTKTczM4OXF9cCICIiagxBsyQsLS3xzjvvICgoCN9++y2WLFmCefPmoV+/fujZs2ejAjAyavzaUaWlpUhKSsLkyZMb3RYRERHVp9O0yp49e+Krr77Crl27EBYWhgEDBmDevHmwtrZuqvgESUhIQE1NDYKDg+udy8rKwqxZs1BdXQ13d3fMmDEDPj4+BoiSiIjo+SUoYSgpKUFBQQEcHBxgbW2NefPmISgoCN988w0++OADzJkzB4MGDWrqWNWKjY1F165d4eSkus1n165d4enpCVdXV5SUlODgwYNYvXo1Vq9eDQ8Pjwbbio6ORnT047XsQ0ND4eDgoLc4W+fmqm2XPp8NapsM8wzxm6g1ac5nSGPCIJPJsHXrVpUVHfv37493330XPXr0wLp167Bnzx5s3rwZcXFx+POf/wwbG5umjllFYWEhUlJS8Mc//rHeuTFjxqgc9+rVC4sXL0ZUVBSWLVvWYHshISEICQlRHhcUFOg3YGo1+GxQY/EZosbS9zPk7Oys9pzGAQS7d+9GfHw8hgwZgnnz5mHo0KFISEjArl27AABisRhvvvkmVq9ejdzcXHzwwQc4efKkXoPX5ty5cwCAoKAgrXXNzMzQq1cv3L59u6nDIiIialU09jAkJiYqexTqVFZW4sKFC5g3b56yzMPDA2vXrkVkZCS+++47vPzyy00X8VNiY2Ph7e0tuFtGJBJBJBI1cVRERESti8YeBrlcXm/6or29PeRyeb26JiYmeO211/D3v/9dvxFqkJ+fj+vXrzc42LEhVVVVuHTpErp169bEkREREbUuWld6PH36NPr37w8PDw/cunULZ86cgaenp9prnl4HQRu5XA6pVAoAePjwISorK5VjJnr16gUzMzMsWrQIPj4+9RZgiouLg7GxMQYMGFCv3YqKCuW6EZ06dUJpaSl++eUXFBYWYvHixTrFSERE1NZpTBjmzJmDVatWYcWKFcoyOzs7zJ49W28BFBcXY/369SpldcebNm2Co6MjamtrG9yjIjY2Fn5+fg1O6zQxMYG1tTWioqJQXFwMU1NTeHl5YeXKlXB3d9db/ERERG2BSKFQKDRVkMvluHjxonJaZWBgIMzNzZsrPoPLycnRW1v3PnxLb22R4Tmt+77Z7zl757lmvyc1nR2zBjb7PY8c4LTK1mTUOCftlXSgaZaE1nUYzMzMBM1AICIiotar8esyExERUaun09LQT7pw4QJSU1Mhl8vh6OiIoKAgrnxHRETUSmlMGHbv3o2ePXvCz89PWVZeXo61a9fi2rVrKnX37t2Lt99+G4MHD26aSImIiMhgNCYM+/fvh1gsVkkY/vWvf+HatWtwdHREcHAwrK2tkZ6ejnPnzuGbb76Bm5sbunTp0uSBExERUfPR6ZVEbm4uEhIS0LVrV6xYsQIWFhYAHu/ZEBgYiM2bN+PXX3/FO++80yTBEhERkWHoNOgxNTUVADBjxgxlslBn8ODB8PDwQEpKiv6iIyIiohZBp4ShqKgIANQufOTu7o6HDx82OigiIiJqWXRKGOp6FUxNTRs8b2pqyo2diIiIWiGtYxiSk5OV/87NzQUA3L9/H66urvXqPnjwAO3atdNjeERERNQSaE0YUlJS6o1LuHTpUoMJw61bt+Di4qK/6IiIiKhF0JgwPLnp1JMa2uzp1q1bqKmpwYsvvqifyIiIiKjF0Jgw+Pj4CG6oW7du2Lx5c6MDIiIiopaHe0kQERGRVjot3FRTU4O8vDyUl5dDJBKhffv26NChQ1PFRkRERC2EoITh/PnzOHLkCFJTU1FTU6NyztraGsHBwZgwYQJsbGyaIkYiIiIyMI0Jg0KhwJYtW3D69Ol65xwcHGBubo7c3FwcPnwYZ86cwYcffghvb+8mC5aIiIgMQ2PCEB0djdOnTyMwMBDTp09Hx44dkZeXh/DwcKSlpeHjjz9Ghw4dEBsbix9//BFr1qxBWFgY7Ozsmit+IiIiagYaBz2eOHECrq6uWLp0Kdzc3GBhYQE3NzcsWbIENjY22L17N0xNTTF06FB8+umnkMlk+Pnnn5spdCIiImouGhOGrKwsvPjiizA2NlYpNzY2xosvvqiyCqSbmxsCAwMhlUqbJlIiIiIyGI0Jg0gkQlVVVYPnqqqqUF1drVLm4uLCzaeIiIhaIY0JQ+fOnXHhwgWUlZWplJeVleHChQtwcnJSKZfJZBCLxfqPkoiIiAxK46DHl19+Gd999x2WL1+OsWPHwtHREfn5+fjll19QXFyMsWPHqtS/e/cuOnXq1KQBExERUfPTmDCEhIQgJSUFsbGx2LZtm8q5gIAAlYShsrISVVVVCAoKappIiYiIyGC0Ltz03nvvYcCAATh//jyKi4vRrl07BAYGIigoCEZG/3ujYWFhgS+++KJJgyUiIiLDELTSY79+/dCvX7+mjoWIiIhaKG4+RURERFoxYSAiIiKtdNqtsink5ubiwIEDSE9Px927d9GjRw+sXLlS4zX5+flYuHBhvfKgoCC8//77KmWJiYnYs2cPcnNz4ejoiKlTp3JgJhERkY4MnjDcvXsXUqkUnp6e9XbC1GbmzJno3r278tja2lrl/LVr1xAWFoaRI0dizpw5kEql2LhxIyQSCfz9/fUSPxERUVtg8IShd+/e6Nu3LwAgLCwMpaWlgq91dnaGl5eX2vP79u1Djx49MHfuXACAn58fsrKyEBkZyYSBiIhIBwYfw/Dk1Ex9qq6uxtWrVzFw4ECV8qCgIKSnp6OioqJJ7ktERNQaGbyHoTG2bNmCsrIytG/fHsHBwZgxY4Zyaeq8vDzU1NTAxcVF5RoXFxcoFArk5OTAw8PDEGETERE9d57LhMHU1BSjRo2Cv78/LCwskJycjP379yMvLw/Lli0DAOX+FxKJROVaKysrAEB5eXmDbUdHRyM6OhoAEBoaCgcHB73FfU9vLVFLoM9ng9omwzxD/CZqTZrzGdI5YUhJSUFKSgqmTJmi0zl9srW1xbx585THvr6+sLGxwffff4+MjAy4ubk9c9shISEICQlRHhcUFDQmVGrF+GxQY/EZosbS9zPk7Oys9pzOAwiSk5MRERGh87mmNmDAAADArVu3APyvJ+HpsQrqeh6IiIhIPYMPetQ3kUgEAOjYsSOMjY2RnZ2tcj4nJwcikUhjFkVERESqWk3CEB8fDwDo1q0bgMfjHPz8/JTldeLi4uDl5QVLS8tmj5GIiOh5ZfBBj3K5HFKpFADw8OFDVFZWKn/ke/XqBTMzMyxatAg+Pj6YP38+ACA8PBwymQzdu3eHhYUFUlNTceDAAfTr1w8vvPCCsu3Jkydj5cqV2LFjB/r27QupVAqpVIrly5c3/wclIiJ6jglKGJ4cVFE3u+DpgRbPOlKzuLgY69evVymrO960aRMcHR1RW1uL2tpa5XkXFxccPHgQx48fR1VVFRwcHDBu3DhMmjRJpR1vb28sXrwYe/fuxdGjR+Ho6Ij33nuPizYRERHpSFDCsGDBAo1lIpEIe/bseaYAHB0dER4errHO5s2bVY6Dg4MRHBwsqH1uzU1ERNR4ghKGyZMnKwcTNtfUSSIiImo5BCUM06ZNU/47IiICKSkpmDp1apMFRURERC1Lq5klQURERE2HCQMRERFpxYSBiIiItNI5YVAoFM90joiIiJ5fOi/cNG3aNJVBkELPERER0fOLrySIiIhIKyYMREREpJXahKGqqqrRjeujDSIiIjI8tQnDggUL8Ouvv6K6ulrnRjMyMrB27VocOHCgUcERERFRy6B20KO/vz927tyJiIgIBAUFYeDAgfDy8oJYLG6wfl5eHq5cuYJTp07hxo0byg2hiIiI6PmnNmFYuHAhRo8ejT179iA6OhrR0dEwMjKCq6srbGxsIJFIUF1djbKyMuTk5KCkpAQAYG1tjRkzZuCVV16Bqalps30QIiIiajoap1V6eHjgk08+wb1793DixAlcvXoVGRkZuHPnjko9a2tr9O/fX/kfExOdZ2sSERFRCybol93JyQl//OMfAQByuRwPHz5EaWkpxGIx2rdvD1tb2yYNkoiIiAxL564AMzMzODk5wcnJqSniISIiohaI6zAQERGRVkwYiIiISCsmDERERKQVEwYiIiLSigkDERERacWEgYiIiLRiwkBERERa6bwOw6NHj3D16lVkZWVBJpNhypQpAB7vTFlZWYl27drByIh5CBERUWuiU8Jw+fJlbN26FUVFRcqyuoQhIyMDn376KRYtWoRBgwbpNUgiIiIyLMFdATdv3sS6desgEokwa9YsBAcHq5z38vKCo6Mjzp8/r/cgiYiIyLAEJwz79u2DWCxGaGgoxowZ0+DS0O7u7sjMzNRrgERERGR4ghOGtLQ09O3bFzY2NmrrODg4qLyuICIiotZB8BgGmUwGa2trjXXkcjlqa2t1CiA3NxcHDhxAeno67t69ix49emDlypUar7lx4waOHj2K1NRUFBYWwt7eHoMGDcL48eMhFouV9cLDwxEZGVnv+uXLlyMgIECnOImIiNoywQmDnZ0d7t69q7FORkYGOnbsqFMAd+/ehVQqhaenJ2pqagRdExcXh7y8PIwfPx5OTk7IzMzE3r17kZmZiaVLl6rUtbS0xPLly1XKXF1ddYqRiIiorROcMAQEBODYsWO4du0avL29652XSqVIT0/H+PHjdQqgd+/e6Nu3LwAgLCwMpaWlWq+ZMGGCSm+Hr68vxGIxvv32W9y/fx8dOnRQnjM2NoaXl5dOMREREZEqwQnDxIkTERcXh7/97W8YPXo07t+/DwC4dOkSUlJScOTIEdjY2GDs2LE6BfAsazY09GrEzc0NAFBYWKiSMBAREVHj6fRK4uOPP8aGDRtw8OBBZfmaNWsAAB07dsTSpUu1jnNoKunp6RCJRPVeiZSXl2PevHmoqKhA586dMXnyZPTv398gMRIRET2vdFq4qVu3bti4cSMuXbqE9PR0lJaWwtLSEp6enujbty+MjY2bKk6NioqKEBUVhcGDB6N9+/bK8k6dOuGNN96Am5sbZDIZjh07hrCwMCxZskRt0hAdHY3o6GgAQGhoKBwcHPQW5z29tUQtgT6fDWqbDPMM8ZuoNWnOZ0jnpaGNjIzQp08f9OnTpyni0dmjR4+wYcMGmJubY9asWSrnBg8erHLcu3dvfPLJJ4iMjFSbMISEhCAkJER5XFBQoP+gqVXgs0GNxWeIGkvfz5Czs7Pac8/1pg8KhQKbNm3C3bt38de//hVWVlYa64tEIvTv3x937tzRefonERFRWya4h+HUqVOCGx0yZMgzBaOrHTt2IDExEZ9++ilcXFya5Z5ERERtkeCEYcuWLYIbbY6E4aeffsJvv/2GDz74oMFpng1RKBRISEiAm5sbd9QkIiLSgeCEYf78+Q2WV1RU4MaNG4iLi0O/fv0QGBioUwByuRxSqRQA8PDhQ1RWViI+Ph4A0KtXL5iZmWHRokXw8fFRxnD27Fn897//xdChQ2FnZ4f09HRle506dVLO1FixYgX69+8PFxcXyOVyHD9+HDdu3MCHH36oU4xERERtneCEYejQoRrPv/zyy8qNqXRRXFyM9evXq5TVHW/atAmOjo6ora1VGXNw5coVAEBMTAxiYmJUrn333XeVsXbq1Am//vorCgsLYWRkhK5du+Kjjz5Cr169dIqRiIiorRMpFAqFvhpbu3YtKisrsWLFCn01aXA5OTl6a+veh2/prS0yPKd13zf7PWfvPNfs96Sms2PWwGa/55EDnFbZmowaV3/n6MZotlkSzs7OuHXrlj6bJCIiohZArwlDVlaWPpsjIiKiFkLnhZueVltbiwcPHuD48eOQSqUcH0BERNQKCU4Ypk+frrWOlZUV3njjjUYFRERERC2P4IShR48eEIlE9cpFIhEkEgk8PDzw8ssvG2zzKSIiImo6ghOGlStXNmEYRERE1JJxuUMiIiLSigkDERERaaX2lYQue0c8SSQSqV1GmoiIiJ5PahMGXXanfBoTBiIiotZFbcKwadOm5oyDiIiIWjC1CUOHDh2aMw4iIiJqwTjokYiIiLR6pqWha2trUVJSgkePHjV43sHBoVFBERERUcuiU8Jw584d7Nq1C8nJyaiurm6wjkgkwp49e/QSHBEREbUMghOGrKwsfPLJJwCAnj174uLFi3jhhRfQvn173L59G6WlpfD19WXvAhERUSskOGGIiopCTU0NvvzyS3Tp0gXTp09Hv379MGXKFMhkMvz73/+GVCrFu+++25TxEhERkQEIHvSYnJyMwMBAdOnSRVmmUCgAAObm5vjzn/8MiUSCvXv36j9KIiIiMijBCUNpaSmcnJz+d6GREeRyufLY2NgYvr6+SEpK0m+EREREZHCCEwYrKyvIZDLlsbW1NQoKClTqmJiYoKKiQn/RERERUYsgOGHo2LEj8vPzlcddu3bF77//juLiYgCATCbDhQsX4OjoqP8oiYiIyKAED3r09/fH/v37IZPJYG5ujpEjR0IqlWLZsmXo3r07bt26hfv37+PNN99syniJiIjIAAQnDMOHD4ezszOqqqpgbm6OwMBAzJo1CxEREUhISIBYLMb48ePxhz/8oSnjJSIiIgPQmDAsW7YMISEheOmll2Bra4ugoCCV82PGjMHo0aNRUlKC9u3bQyQSNWmwREREZBgaxzBkZmZi27ZtePvtt/HNN9/g+vXr9RswMoKNjQ2TBSIiolZMYw/D6tWrER0djfj4eJw8eRInT55Ely5dMHz4cAwePBiWlpbNFScREREZkMaEwcvLC15eXpgzZw7OnDmDEydO4Pbt2/j3v/+NXbt2YcCAARg+fDi8vb2bK14iIiIyAEGDHi0sLDBy5EiMHDkSGRkZiI6ORmxsLE6fPo3Tp0/D1dVV2etgZWXV1DETERFRM9N5e2s3Nze89dZbePPNN3Hu3DkcP34caWlp2LlzJ3bv3o3+/ftj0aJFgtvLzc3FgQMHkJ6ejrt376JHjx5YuXKl1usqKiqwY8cOJCYmora2Fr1798acOXPQrl07lXqJiYnYs2cPcnNz4ejoiKlTp9YbvElERESaCV646WlisRhDhgzB559/jg0bNsDb2xvV1dU4e/asTu3cvXsXUqkUzs7OcHZ2Fnzdhg0bkJycjLfffhsLFizAzZs3sW7dOpU6165dQ1hYGHx9ffHXv/4VgYGB2LhxI65cuaJTjERERG2dzj0MTyorK8OpU6dw4sQJZGVlAYDOAyF79+6Nvn37AgDCwsJQWlqq9Zr09HRcuXIFK1euhI+PDwDAzs4Oy5cvR1JSEnr27AkA2LdvH3r06IG5c+cCAPz8/JCVlYXIyEj4+/vrFCcREVFb9kwJw9WrVxEdHY3ExEQ8evQIAODp6YmQkBCdu/uNjHTv5JBKpWjfvr0yWQAADw8PODo64vLly+jZsyeqq6tx9epVzJkzR+XaoKAgbNmyBRUVFZzlQUREJJDghKGoqAgnT57EiRMnlHtKSCQShISEICQkBJ07d26yIJ+WnZ0NFxeXeuUuLi7Izs4GAOTl5aGmpqZePRcXFygUCuTk5MDDw6NZ4iUiInreaUwYFAoFLl26hOPHj0MqlaK2thYA4O3tjeHDh2PAgAEQi8XNEuiTysvLG+wdkEgkymSmrKxMWfakulkc5eXlDbYdHR2N6OhoAEBoaCgcHBz0Fvc9vbVELYE+nw1qmwzzDPGbqDVpzmdIY8Lw7rvv4uHDhwAe/9AOHjwYISEhDf5131rU9ZjUeXoLb6I6fDaosfgMUWPp+xnSNPlAY8Lw8OFD+Pj4KHsTTEwaNUZSbyQSSYODI8vLy5U9CnU9CRUVFSp11PU8EBERkXoaM4B//OMfcHJyaq5YBHNxccHx48frlefk5ChnXHTs2BHGxsbIzs5WGRyZk5MDkUik0xROIiKitk7jFIWWmCwAQK9evVBUVIRr164py27evIm8vDwEBAQAAExNTeHn54f4+HiVa+Pi4uDl5cUZEkRERDp45oWb9EUulyM+Ph7x8fF4+PAhSkpKlMdyuRwAsGjRImzdulV5jZeXF/z9/bFp0yYkJCTg/Pnz+Oc//wlvb2/lGgwAMHnyZCQnJ2PHjh1ITk7Gf/7zH0ilUkyZMqXZPycREdHzzOCDEoqLi7F+/XqVsrrjTZs2wdHREbW1tcoZGnXef/997Ny5E1u3boVCoUBgYGC9NRe8vb2xePFi7N27F0ePHoWjoyPee+89LtpERESkI5FCoVAYOoiWLCcnR29t3fvwLb21RYbntO77Zr/n7J3nmv2e1HR2zBrY7Pc8coDTKluTUeP0O3RA0/g+g7+SICIiopaPCQMRERFpJThhSEhIqDeOgIiIiNoGwYMe169fD1tbW7z88ssYPnw4l8UlIiJqQwT3MIwaNQpyuRxRUVFYtGgRQkNDcfHiRXDMJBERUesnuIdh7ty5eOONNxAXF4djx45BKpVCKpXCzs4Ow4cPx7Bhw2BnZ9eUsRIREZGB6LQOg1gsxtChQzF06FDcuXMH0dHROHPmDCIiIrBv3z4EBgZixIgRytUWiYiIqHV45oWbunTpotLrsHfvXly4cAEXLlyAg4MDRo0ahZEjR8Lc3Fyf8RIREZEBNGpapUwmw+nTp/Hbb78pt8F2c3NDWVkZdu3ahQ8++AAZGRn6iJOIiIgM6Jl6GG7fvo1jx44hNjYWMpkMYrEYw4YNw6hRo+Dm5gaZTIYjR44gPDwc//73v7Fq1Sp9x01ERETNSHDCIJfLERsbi2PHjuHWrVsAHm8zPWLECAwZMkRl90dzc3OMHz8eDx48wIkTJ/QfNRERETUrwQnD22+/jcrKShgZGaF///4YNWoUfH19NV5jZ2eH6urqRgdJREREhiU4YbCwsMDYsWMREhICGxsbQdeMHDkSwcHBzxobERERtRCCE4bNmzfDyEi3MZKWlpYqryqIiIjo+SQ4A9A1WSAiIqLWQ3AWsG/fPsyYMUM5ffJpDx8+xIwZM/Dzzz/rKzYiIiJqIQQnDBcvXoSPj4/a5Z/t7Ozg5+eHxMREvQVHRERELYPghCE3Nxeurq4a67i4uCA3N7fRQREREVHLIjhhqKqqgpmZmcY6YrEYMpms0UERERFRyyI4YbC3t8f169c11rl+/Tp3rCQiImqFBCcM/v7+SElJQVxcXIPnY2NjkZKSwp0qiYiIWiHB6zBMmDABZ8+excaNGxEXF4eAgADY2dnh4cOHkEqluHDhAqysrDBhwoQmDJeIiIgMQXDCYGdnh48//hjr169HYmJivdkQHTp0wOLFi2Fvb6/3IImIiMiwdNqt0t3dHRs3bsTFixdx/fp1lJeXQyKRwNPTE71794aJyTNtfklEREQtnM6/8CYmJujfvz/69+/fFPEQERFRC8T1nomIiEgrtT0Mp06dAgD069cPFhYWymMhhgwZ0vjIiIiIqMVQmzBs2bIFAODp6QkLCwvlsRBMGIiIiFoXtQnD/PnzAQC2trYqx/qWlZWF7du3Iz09HRKJBMOGDcPUqVM17o4ZHh6OyMjIBs/NmDEDEydOBPB4S+6GekY2bNgAFxcX/XwAIiKiNkBtwjB06FCNx/pQVlaG1atXw9XVFcuWLUNubi5+/PFHKBQKvPbaa2qvGz58eL0FohITE7F//3706tVLpdzFxaVestOhQwe9fQYiIqK2wKDzII8dO4aqqiosWbIElpaW6NmzJyorKxEREYFx48bB0tKywevs7e3rrfewb98+uLi4wM3NTaXczMwMXl5eTfURiIiI2gSDzpK4fPky/P39VRKD4OBgVFVVISUlRXA7paWlSEpKQnBwcFOESURE1Oap7WFYuHDhMzUoEonw9ddfC6qbnZ0NX19flTIHBweYmZkhJydH8D0TEhJQU1PTYMKQlZWFWbNmobq6Gu7u7pgxYwZ8fHwEt01EREQaEgaFQvFMDepyXd1KkU+TSCQoKysT3E5sbCy6du0KJycnlfKuXbvC09MTrq6uKCkpwcGDB7F69WqsXr0aHh4eDbYVHR2N6OhoAEBoaCgcHBwEx6HNPb21RC2BPp8NapsM8wzxm6g1ac5nSG3CsHnz5mYLojEKCwuRkpKCP/7xj/XOjRkzRuW4V69eWLx4MaKiorBs2bIG2wsJCUFISIjyuKCgQL8BU6vBZ4Mai88QNZa+nyFnZ2e15ww6hkEikaCioqJeeXl5OaysrAS1ce7cOQBAUFCQ1rpmZmbo1asXbt++rVugREREbdwzJwyVlZUoKCho8AdfKBcXF2RnZ6uUFRQUQC6Xa8xynhQbGwtvb2/B3TIikQgikUjnWImIiNoynaZV1tTU4ODBgzh+/Djy8/OV5Y6Ojhg+fDheffVVGBsbC24vICAABw4cQGVlJSwsLAAAcXFxEIvFggYm5ufn4/r163jrrbcE3a+qqgqXLl1Ct27dBMdIREREOiQMjx49whdffIGUlBSIRCI4ODjAxsYGRUVFuH//Pv773//i8uXL+OSTTwRvcz1ixAgcPnwYX331FcaPH4/8/HxERERg7NixKlMtFy1aBB8fn3oLMMXFxcHY2BgDBgyo13ZFRQVCQ0Px0ksvoVOnTigtLcUvv/yCwsJCLF68WOjHJiIiIuiQMBw6dAgpKSkIDAzEm2++qTIjITc3Fz/88AMuXryIQ4cOYcKECYLatLKywmeffYZt27ZhzZo1kEgkeOWVVzBt2jSVerW1taitra13fWxsLPz8/GBtbV3/g5mYwNraGlFRUSguLoapqSm8vLywcuVKuLu7C/3YREREBECkEDgPcunSpQCAtWvXNrjPQ21tLZYtWwaFQoGwsDD9RmlAuqwHoc29D4W9OqHng9O675v9nrN3nmv2e1LT2TFrYLPf88gBTqtsTUaNc9JeSQd6mSWRm5uLgIAAtZtCGRkZISAgAHl5ebpHSERERC2a4ITBxMQEMplMYx25XK7ToEciIiJ6PghOGF544QUkJCSgpKSkwfMlJSWIj4+vt/kTERERPf8EJwyjRo1CSUkJ/vrXv+LEiRPIy8tDVVUV8vPzcfLkSXz88ccoKSnBqFGjmjJeIiIiMgDBsySCgoKQkZGB/fv341//+leDdcaNGydoxUUiIiJ6vui0cNPrr7+OPn364MSJE8jIyEBFRQUsLS3h5uaGYcOGwcvLq6niJCIiIgMSnDCUlpZCJBLBy8uLiQEREVEbozVhSExMxA8//KBcCrpTp06YOXMm+vTp0+TBERERUcugcdBjeno6wsLCVPaNyM3NRVhYGNLT05s8OCIiImoZNCYMhw4dgkKhwOTJk/Hdd9/h22+/xaRJk1BbW4tDhw41V4xERERkYBpfSVy/fh3e3t4qeztMnz4dKSkp7GEgIiJqQzT2MBQXF8PT07Neuaenp9oFnIiIiKj10Zgw1NTUwNzcvF65mZkZampqmiwoIiIialkEr/RIREREbZfWaZUxMTFITk5WKbt//z4AYNWqVfXqi0QifPbZZ3oKj4iIiFoCrQnD/fv3lQnC01JSUvQeEBEREbU8GhOGFStWNFccRERE1IJpTBh8fHyaKw4iIiJqwTjokYiIiLRiwkBERERaMWEgIiIirZgwEBERkVZMGIiIiEgrJgxERESkFRMGIiIi0ooJAxEREWmlduGmyMjIZ250ypQpz3wtERERtTxqE4aIiIhnbpQJAxERUeuiNmFoaB+JQ4cOQSqV4qWXXoKPjw9sbGxQVFSE5ORknD17FoGBgXjllVd0CiArKwvbt29Heno6JBIJhg0bhqlTp8LISP3bkvz8fCxcuLBeeVBQEN5//32VssTEROzZswe5ublwdHTE1KlTERQUpFOMREREbZ3ahOHpfSROnTqF33//HV988QW6deumcm7o0KEYPXo0VqxYgf79+wu+eVlZGVavXg1XV1csW7YMubm5+PHHH6FQKPDaa69pvX7mzJno3r278tja2lrl/LVr1xAWFoaRI0dizpw5kEql2LhxIyQSCfz9/QXHSURE1NZp3d66zi+//IKBAwfWSxbquLu7Y+DAgfjll18wePBgQW0eO3YMVVVVWLJkCSwtLdGzZ09UVlYiIiIC48aNg6WlpcbrnZ2d4eXlpfb8vn370KNHD8ydOxcA4Ofnh6ysLERGRjJhICIi0oHgWRI5OTmwtbXVWMfW1hY5OTmCb3758mX4+/urJAbBwcGoqqpCSkqK4HYaUl1djatXr2LgwIEq5UFBQUhPT0dFRUWj2iciImpLBPcwWFhYIC0tTWOdtLQ0mJubC755dnY2fH19VcocHBxgZmYmKPHYsmULysrK0L59ewQHB2PGjBkQi8UAgLy8PNTU1MDFxUXlGhcXFygUCuTk5MDDw0NwrERERG2Z4IQhMDAQMTEx+OGHHzB16lRYWFgoz9W9Rrh27RpefvllwTcvLy+HRCKpVy6RSFBWVqb2OlNTU4waNQr+/v6wsLBAcnIy9u/fj7y8PCxbtgwAlNc/3b6VlZXy3kRERCSM4ITh9ddfR0pKCn755RecOHECbm5uaN++PYqLi5GRkYHKyko4OjpixowZTRkvgMevPubNm6c89vX1hY2NDb7//ntkZGTAzc3tmduOjo5GdHQ0ACA0NBQODg6NDVfpnt5aopZAn88GtU2GeYb4TdSaNOczJDhhaN++Pf7+979j9+7dOHv2LFJTU5XnxGIxhg8fjhkzZqBdu3aCby6RSBocS1BeXq7sCRBqwIAB+P7773Hr1i24ubkpr3+6fXU9D3VCQkIQEhKiPC4oKNApDmo7+GxQY/EZosbS9zPk7Oys9pzghAEA2rVrh7fffhtvvfUWsrOzUVFRAUtLS7i4uMDY2FjnwFxcXJCdna1SVlBQALlcrjFoTUQiEQCgY8eOMDY2RnZ2tsoU0ZycHIhEomdun4iIqC16pr0kjI2N0aVLF3h7e6NLly7PlCwAQEBAAK5cuYLKykplWVxcHMRicb11ILSJj48HAOW0T1NTU/j5+SnLn2zfy8tL65RNIiIi+h+dehgA4NGjR7h69SqysrIgk8mUy0BXVVWhsrIS7dq107hK45NGjBiBw4cP46uvvsL48eORn5+PiIgIjB07VuUHfdGiRfDx8cH8+fMBAOHh4ZDJZOjevTssLCyQmpqKAwcOoF+/fnjhhReU102ePBkrV67Ejh070LdvX0ilUkilUixfvlzXj01ERNSm6ZQwXL58GVu3bkVRUZGyrC5hyMjIwKeffopFixZh0KBBgtqzsrLCZ599hm3btmHNmjWQSCR45ZVXMG3aNJV6tbW1qK2tVR67uLjg4MGDOH78OKqqquDg4IBx48Zh0qRJKtd5e3tj8eLF2Lt3L44ePQpHR0e89957XLSJiIhIR4IThps3b2LdunVo164dZs2ahRs3biA2NlZ53svLC46Ojjh//rzghAEAXF1dG9y34kmbN29WOQ4ODkZwcLCg9vv164d+/foJjoeIiIjqEzyGYd++fRCLxQgNDcWYMWPg5ORUr467uzsyMzP1GiAREREZnuCEIS0tDX379oWNjY3aOg4ODiqvK4iIiKh1EJwwyGSyertBPk0ul6uMNSAiIqLWQXDCYGdnh7t372qsk5GRgY4dOzY6KCIiImpZBCcMdWsmXLt2rcHzUqkU6enpCAwM1FtwRERE1DIIniUxceJExMXF4W9/+xtGjx6N+/fvAwAuXbqElJQUHDlyBDY2Nhg7dmyTBUtERESGIThhsLOzw8cff4wNGzbg4MGDyvI1a9YAeLwU89KlS7WOcyAiIqLnj04LN3Xr1g0bN27EpUuXkJ6ejtLSUlhaWsLT0xN9+/Z95iWiiYiIqGXTeWloIyMj9OnTB3369GmKeIiIiKgFEjzocdWqVTh16pTGOqdPn8aqVasaHRQRERG1LIIThpSUFOVAR3UKCgqQkpLS6KCIiIioZXmm7a3Vqaqq4jgGIiKiVkjnMQwNUSgUKCgogFQqhb29vT6aJCIiohZEY8Iwffp0leOIiAhERERobHDixImNj4qIiIhaFI0JQ48ePSASiQA8HsPg4OAAR0fHevWMjIxgZWWFF198EcOGDWuaSImIiMhgNCYMK1euVP57+vTpePnllzFlypSmjomIiIhaGMFjGDZt2gSJRNKUsRAREVELJThh6NChQ1PGQURERC2YzrMkCgsL8fvvv+Phw4d49OhRg3X42oKIiKh10SlhCA8Px88//4yamhqN9ZgwEBERtS6CE4YzZ85g37598PPzw6hRoxAWFoYhQ4bA398fycnJOHnyJAYMGIARI0Y0ZbxERERkAIIThqNHj8LOzg7Lly9Xrubo6OiI4OBgBAcHo1+/fggNDUVwcHCTBUtERESGIXhp6Dt37qBXr14qSz/X1tYq/x0QEAB/f38cPHhQvxESERGRwQlOGGpqatCuXTvlsVgsRkVFhUqdzp07IyMjQ2/BERERUcsgOGGwtbVFYWGh8tjBwQGZmZkqdQoLC7n5FBERUSskOGFwc3PD3bt3lce+vr64du0aTp8+DZlMhkuXLiE+Ph5du3ZtkkCJiIjIcAQnDL1798bdu3eRn58PAJgwYQIsLS2xefNmzJo1C2vWrAFQf8MqIiIiev4JniUxdOhQDB06VHns4OCAL7/8EgcPHkReXh46dOiAUaNGoUuXLk0RJxERERmQzis9PsnR0RHz5s1rVABZWVnYvn070tPTIZFIMGzYMEydOhVGRuo7P27cuIGjR48iNTUVhYWFsLe3x6BBgzB+/HiIxWJlvfDwcERGRta7fvny5QgICGhU3ERERG1JoxKGxiorK8Pq1avh6uqKZcuWITc3Fz/++CMUCgVee+01tdfFxcUhLy8P48ePh5OTEzIzM7F3715kZmZi6dKlKnUtLS2xfPlylTJXV9cm+TxEREStlc4JQ21tLR4+fKhxLwkfHx9BbR07dgxVVVVYsmQJLC0t0bNnT1RWViIiIgLjxo2DpaVlg9dNmDAB1tbWymNfX1+IxWJ8++23uH//vspGWcbGxvDy8tLhExIREdHTdEoYDhw4gIMHD6KkpERjvb179wpq7/Lly/D391dJDIKDg7Fr1y6kpKSgT58+DV73ZLJQx83NDcDjqZ3cWZOIiEi/BCcM4eHh2LdvH6ysrDBkyBDY2dk1es2F7Oxs+Pr6qpQ5ODjAzMwMOTk5OrWVnp4OkUiEjh07qpSXl5dj3rx5qKioQOfOnTF58mT079+/UXETERG1NYIThpMnT8LR0RFr1qxR+6pAV+Xl5ZBIJPXKJRIJysrKBLdTVFSEqKgoDB48GO3bt1eWd+rUCW+88Qbc3Nwgk8lw7NgxhIWFYcmSJUwaiIiIdCA4YSgtLcWIESP0lizoy6NHj7BhwwaYm5tj1qxZKucGDx6scty7d2988skniIyMVJswREdHIzo6GgAQGhoKBwcHvcV6T28tUUugz2eD2ibDPEP8JmpNmvMZEpwwdOrUCeXl5Xq9uUQiqbcfBfC458HKykrr9QqFAps2bcLdu3exevVqrdeIRCL0798fu3btQm1tbYNTN0NCQhASEqI8LigoEPBJqC3is0GNxWeIGkvfz5Czs7Pac4JXehw5ciQuXryIoqIifcQEAHBxcUF2drZKWUFBAeRyucag6+zYsQOJiYlYtmwZXFxc9BYXERERqRLcwzBy5Ejcu3cPn376KSZPnoxu3bqpfT0htIskICAABw4cQGVlJSwsLAA8XmNBLBZrnZr5008/4bfffsMHH3wAb29vQfdTKBRISEiAm5ubxoWhiIiISJVO0ypfeOEFxMTEYOvWrWrriEQi7NmzR1B7I0aMwOHDh/HVV19h/PjxyM/PR0REBMaOHauSjCxatAg+Pj6YP38+AODs2bP473//i6FDh8LOzg7p6enKup06dVJOu1yxYgX69+8PFxcXyOVyHD9+HDdu3MCHH36oy8cmIiJq8wQnDMePH8e3334LY2Nj+Pr6wtbWttHTKq2srPDZZ59h27ZtWLNmDSQSCV555RVMmzZNpV5tbS1qa2uVx1euXAEAxMTEICYmRqXuu+++q9zzolOnTvj1119RWFgIIyMjdO3aFR999BF69erVqLiJiIjaGpFCoVAIqfj++++joqICf/vb3+Do6NjUcbUYuq4Hocm9D9/SW1tkeE7rvm/2e87eea7Z70lNZ8esgc1+zyMHOEuiNRk1zkmv7ell0OP9+/cxYMCANpUsEBER0WOCEwY7Ozu1e0cQERFR6yY4YRgyZAikUikqKyubMh4iIiJqgQQnDBMnToSHhwdWr16N5ORkJg5ERERtiOBZEq+//rry359//rnaerpMqyQiIqLng+CEoUePHhCJRE0ZCxEREbVQghOGlStXNmEYRERE1JJxfWQiIiLSigkDERERaaX2lURkZCQAYPTo0bCyslIeCzFlypTGR0ZEREQthtqEISIiAgAQFBQEKysr5bEQTBiIiIhaF7UJw4oVKwD8b6vqumMiIiJqe9QmDD4+PhqPiYiIqO0QPOjx1KlTyMzM1Fjnzp07OHXqVKODIiIiopZFcMKwZcsWJCYmaqxz4cIFbNmypdFBERERUcui12mVtbW1XA2SiIioFdJrwpCTkwOJRKLPJomIiKgF0Lg09NOvFxITE5Gfn1+vXm1tLR48eIDU1FQEBgbqN0IiIiIyOI0Jw9MDGDMyMpCRkaG2vqenJ2bNmqWXwIiIiKjl0JgwbNq0CQCgUCiwaNEijBkzBmPGjKlXz8jICBKJBObm5k0TJRERERmUxoShQ4cOyn9PmTIFvr6+KmVERETUNgje3nrq1KlNGQcRERG1YIIThtu3byM9PR0vvfQSLC0tAQAymQzff/89Lly4ADMzM4wfP77BVxZERET0fBM8rXL//v2IiopSJgsAsHv3bpw5cwYKhQKlpaXYuXMnrly50iSBEhERkeEIThhu3rwJX19f5fGjR49w6tQpeHh44LvvvsOmTZtgbW2Nw4cPN0mgREREZDiCE4aSkhLY29srj2/dugWZTIaQkBCIxWLY2dmhT58+WvebICIiouePTis91tTUKP997do1AKq7WFpbW6OkpERPoREREVFLIThhcHBwwPXr15XHiYmJsLe3R8eOHZVlhYWFsLKy0m+EREREZHCCZ0kMHDgQERERCAsLg6mpKdLT0/HKK6+o1MnOzlZJIIiIiKh1EJwwjB07FleuXMH58+cBAG5ubpgyZYryfH5+Pm7cuIGJEyfqFEBWVha2b9+O9PR0SCQSDBs2DFOnToWRkebOj4qKCuzYsQOJiYmora1F7969MWfOHLRr106lXmJiIvbs2YPc3Fw4Ojpi6tSpCAoK0ilGIiKitk5wwmBubo7Vq1fjzp07AABXV9d6P+pLly6Fu7u74JuXlZVh9erVcHV1xbJly5Cbm4sff/wRCoUCr732msZrN2zYgJycHLz99tswMjLCrl27sG7dOnz++efKOteuXUNYWBhGjhyJOXPmQCqVYuPGjZBIJPD39xccJxERUVsnOGGo06VLlwbLHR0d4ejoqFNbx44dQ1VVFZYsWQJLS0v07NkTlZWViIiIwLhx41TWfHhSeno6rly5gpUrVyoHXdrZ2WH58uVISkpCz549AQD79u1Djx49MHfuXACAn58fsrKyEBkZyYSBiIhIBxr7/VNSUlBQUCC4sczMzHo7XGpy+fJl+Pv7qyQGwcHBqKqqQkpKitrrpFIp2rdvrzJDw8PDA46Ojrh8+TIAoLq6GlevXsXAgQNVrg0KCkJ6ejoqKioEx0lERNTWaUwYVq1ahZiYGJWyn3/+WfkX+9POnz+PLVu2CL55dnY2nJ2dVcocHBxgZmaGnJwcjde5uLjUK3dxcUF2djYAIC8vDzU1NfXqubi4QKFQaGyfiIiIVOn8SqK6uhrl5eV6uXl5eTkkEkm9colEgrKyMo3XNfS6QiKRID8/HwCU1z/dft20T3WfITo6GtHR0QCA0NDQeglNYzjv+lVvbVHbdPSvkw0dAj3n5ryjv+80alt0WripLQgJCUFoaChCQ0MNHcpz66OPPjJ0CPSc4zNEjcVnSP8MmjBIJJIGxxKUl5drXABKIpGgsrKywevqehTqrn+6fXU9D0RERKSeQROGJ8cc1CkoKIBcLtf4KqCh6wAgJydHOWahY8eOMDY2rlcvJycHIpFIr68aiIiIWjuDJgwBAQG4cuWKSm9BXFwcxGKxygyIp/Xq1QtFRUXK/SyAx7tp5uXlISAgAABgamoKPz8/xMfHq1wbFxcHLy8vtVM2qfFCQkIMHQI95/gMUWPxGdI/gyYMI0aMgKmpKb766iskJSUhOjoaERERGDt2rMoP+qJFi7B161blsZeXF/z9/bFp0yYkJCTg/Pnz+Oc//wlvb2/lGgwAMHnyZCQnJ2PHjh1ITk7Gf/7zH0ilUpUVKkn/+H9Uaiw+Q9RYfIb0T6RQKBTqTk6fPv2ZGt27d6/gullZWdi2bZvK0tDTpk1TWUVywYIF8PHxwYIFC5Rl5eXl2LlzJ86fPw+FQoHAwEDMmTMH1tbWKu2fP38ee/fuxb1795RLQwcHBz/T5yIiImqrDJ4wEBERUcunMWEgelpMTAy2bNmCd999F0OHDjV0ONSCJScnY9WqVZgyZQqmTZsGAJg2bRp8fHywcuVKwwZHzzV+DxkG12EgIiIirdjDQDqpqKhAYWEhbG1tOdOENJLL5SgoKEC7du2UY4uys7NhZmYGBwcHA0dHzzN+DxkGEwYiIiLSSue9JKh1i42NxeHDh3Hv3j3IZDJYW1ujW7dumDx5Mrp169bgu8P8/HwsXLgQQ4YMwZgxY/Cf//wH169fh7GxMQICAjBz5kzY2dmp3OfGjRuIiorCzZs3UVpaColEAmdnZ4wYMQKDBg0ywCcnfRM6hmHlypVISUnBjz/+iN27dyM+Ph5lZWXo0qULpkyZgt69e6u0W1ZWhv379+P8+fN48OABTExMYGdnBz8/P7z55pswMeHXWmvw5PPj4+ODiIgI3L59Gx07dsQrr7zC7yED4BgGUjp8+DA2btyI4uJiBAcHY8yYMfDx8cHNmzeRnp6u9fq8vDysXLkSJiYmGD16NLy8vBAbG4tPP/1UZTOxW7du4dNPP0Vqair8/f0xduxY9O7dG5WVlTh//nxTfkRqwdavX49Lly4hODgYQ4YMQU5ODtauXauy+JpCocAXX3yBAwcOoGPHjhg9ejSGDBmCDh064Pjx43j06JEBPwE1hbS0NHzxxRewtLTEyJEj8eKLL2qsz++hpsNUnJRiYmJga2uLr776CmZmZsry2traBvf8eNq1a9cwbdo0lYWxIiMjER4ejsjISMyePRsAcObMGdTU1GDFihVwc3NTaaO0tFQvn4WePw8ePMC6detgbm4OABg7diyWLVuGbdu2oU+fPjAxMcGdO3dw8+ZNjBkzRvk81SkvL4dYLDZA5NSUfv/9d7z33nsqf/HHxMSorc/voabDHgZSYWpqCmNjY5UyIyMjjZuB1bGyssKrr76qUvbqq69CIpHg7Nmz9erX/TA8qV27djpGTK3FxIkTVZ4JZ2dnDB48GMXFxUhKSlKp29CzI5FIVBZ8o9bB3d1dp9cD/B5qOvx/FykNHDgQ+fn5WLJkCcLDw5GcnIyqqirB13ft2lWlZwIAzMzM0LVrV5SUlKCwsFB5H5FIhOXLl2P79u1ITExU6Sqktsnb21ttWWZmJgDA1dUVnTt3xk8//YTQ0FAcPXq0wY3oqPXo1q2bTvX5PdR0+EqClMaPHw+JRIKjR48iMjISkZGRMDMzw0svvYSZM2fCwsJC4/XqsvK6KXWVlZWwtbWFl5cXPvvsM0RFReHYsWP47bffIBKJ4O/vj9mzZ3Mn0Tbq6WXdnyyr26DO2NgYK1aswN69e5GQkIBLly4BeLw77ZQpUzBkyJDmC5iaRfv27XWqz++hpsOEgZREIhFGjBiBESNGoKioCFevXsXx48cRHR2NqqoqLFy4UOP16t77lZSUAIBKwuHr6wtfX1/IZDJcu3YN586dQ0xMDL788kts2LCBI93boJKSEtjb29crA1SfHWtra/zpT3/CvHnzcOfOHVy+fBm//vorNm/eDDs7O62D4qh14/dQ0+ErCWqQjY0NBg0ahE8++QR2dna4ePGi1mtu374NuVyuUiaXy3H79m1YW1vD1ta23jXm5uYICAjA/PnzMXDgQOTl5SErK0tvn4OeH09uV/902QsvvFDvnJGREdzc3DBhwgS8++67ACDoOaXWjd9DTYcJAymlpKTUK5PJZJDL5YIy7bKyMhw8eFCl7ODBgygvL1cZtJSeno7q6mqVegqFAsXFxQAeD7yktuenn36CTCZTHufk5OD06dNo3769ctv6/Px83L9/v961RUVFAPjsEL+HmhL7W0hp7dq1kEgk8PT0hIODA+RyOS5cuIDy8nK8/vrrWq/39vbGwYMHcf36dbzwwgvIzMyEVCpFhw4dVKY4/fzzz0hNTUWPHj3g6OgIIyMjpKam4ubNm+jVqxdcXFya8mNSC2Vvb48PP/wQffv2hUwmQ1xcHKqrq7Fw4UJlwpqRkYGwsDB4eXnBxcUF1tbWyM3NxYULF2BhYYFhw4YZ+FOQofF7qOkwYSCl119/HZcuXUJaWhoSExNhaWkJV1dXzJkzB/369dN6fceOHTF79mzs2rULv/32G4yMjBAUFISZM2eqTMscOXIkLC0tcf36dfz+++8wNjaGo6Mj3nzzTYwcObIpPyK1YIsXL8bu3btx9uxZlJeXw9XVFVOnTkWfPn2Uddzd3TFu3DhcvXoViYmJkMlksLOzw+DBgzFhwgR06tTJgJ+AWgJ+DzUd7iVBjfbkkqwLFiwwdDj0nKlbGjo8PNzQodBzjN9DTY9jGIiIiEgrJgxERESkFRMGIiIi0opjGIiIiEgr9jAQERGRVkwYiIiISCsmDERERKQVEwYiatGSk5Mxbdo0TJs2zdChELVpXOmRSKCqqiqcOnUKFy9eRGZmJkpKSmBiYgI7Ozt4e3sjODgYfn5+GttYsGBBg3shmJubo0OHDujRowdGjx4NV1fXenXqFjgSwsfHBytXrhRUV1tsDdHH4jjl5eX45ZdfAACvvPIKJBJJo9priWJiYpCfn6/cFZHoecaEgUiApKQkbN26FQ8ePFCWWVhY4NGjR8jOzkZ2djaOHz+OXr16YeHChWjXrp3G9kxNTWFpaQng8YY3paWluHv3Lu7evYvjx4/jT3/6k9p9EYyNjVWWuG2ItvNCY1NH23khysvLERkZCQAYOnSo2oTBzMwMzs7Ojb6fIcTExCiTPCYM9LxjwkCkRVxcHL7++mvU1NTAzs4O06ZNQ79+/ZQ/ytnZ2Th27BiOHDkCqVSKjz/+GKtXr0b79u3VthkUFKTyF3pVVRUuXryI7du3o7i4GN9++y3c3d0b3Na5e/fuOvce6OLp2AzNw8MD//jHPwwdBlGbxzEMRBpkZWVh69atqKmpQZcuXbB27VoMGzZM5S94FxcXzJ49Gx9++CFMTEyQm5uLf/7znzrdRywWY+DAgVi0aBEAoLa2FkePHtXrZyEiagz2MBBpsGfPHsjlcpiammLx4sWwtrZWWzcwMBCTJk1CeHg4fv/9d1y6dAmBgYE63a9nz56wtbVFYWEhbt682djwm9WDBw9w8OBBJCUl4f79+6ipqUG7du1gY2ODHj16YNCgQfDw8ABQfzzGwoULVdp6cgxGcnIyVq1aBQD1NqiKiYnBli1b0KFDB2zevBmpqanYv38/bty4AblcDicnJ4wePVrl9c6lS5fwyy+/ICMjA3K5HJ07d8arr76KoKCgBj9Xfn4+4uLikJycjPz8fDx8+BAA4ODgAH9/f4wdOxYODg4NxlUnMjJS+fqlzqZNm+Do6Kg8rq2tRUxMDM6cOYM7d+6gsrIS7dq1Q/fu3TFq1Ci1rzTq/rucMmUKJk2ahMOHDyM2Nha5ubmoqKjAihUrlNdmZ2fj0KFDSElJwYMHD6BQKGBtbQ07Ozv4+vpiyJAh3NaZ1GLCQKRGYWEhEhMTAQDBwcGC3qOPHTsWBw8eRGVlJY4cOaJzwgAAdnZ2KCwsRGVlpc7XGkpGRgZWrVqF8vJyAICRkREsLCxQVFSEwsJC3L59G+Xl5cqEwcrKCu3atUNpaSkAoF27djAy+l+H57OMwTh+/Di+/fZbAI/Hl8jlcmRkZOCbb75Bbm4uXn/9dYSHhyMyMhIikQgWFhaoqqrCzZs38Y9//ANlZWUNbmu8ZcsWZXJjYmICCwsLlJWVKceuxMTE4KOPPoK3t7fyGrFYjPbt26OsrAw1NTUwMzODubm5SrtPft6KigqsW7cOycnJ9f77i4+PR3x8PF599VXMnDlT7eevrq7GqlWrkJaWBmNjY5ibm0MkEinPJyUlYc2aNaiurgYAZZ0HDx7gwYMHuH79OkxMTDgbhdRiwkCkRnJyMupWTu/fv7+ga8zNzdGzZ08kJCQgNTUVNTU1MDY21um+dTMVGjNwsbn9+OOPKC8vR9euXTFv3jx4enpCJBLh0aNHuH//Pi5cuIAnV6FfunSpcjtiAPjyyy9V/trWVUlJCbZt24bRo0dj8uTJsLa2RllZGXbu3IlTp05h//79kEgkiIqKwmuvvYbRo0fD0tIShYWF2Lp1Ky5fvowff/wRgwYNqjeg083NDQMHDkTPnj3RsWNHGBkZoaamBrdv30Z4eDguX76MDRs24Ouvv4ZYLAbweBxIUFCQ8q//V199VeMP8datW5GcnAwTExPMnDkTw4YNg5mZGYqKivDf//4XJ0+exMGDB9GxY8cGkxoAOHLkCADg3XffRVBQEMRiMUpLS5VJw3fffYfq6mr4+/tj5syZ6NKlC4DH42fy8vKQkJBQr6eE6ElMGIjUyMrKUv67a9eugq9zc3NDQkICZDIZ7t+/j06dOgm+Nj4+HiUlJQAAT0/PBuukpaXhT3/6k8Z25syZo7aLXZu4uDhcvnxZY52lS5eie/fuKjEBwLx58+Dl5aUsNzExgZOTE1599dVnikUouVyOYcOGYc6cOcoyKysrzJ8/H6mpqcjPz8euXbvw2muvYdKkSco6tra2eP/99/H2229DLpfjwoULGDx4sErbs2fPrnc/Y2NjeHh44KOPPsJf/vIXZGZmIj4+vt61Qly/fh0JCQkAgLlz5yIkJER5zsbGBvPnz0dFRQUSEhKwd+9eDB06VJmYPEkmk2HZsmXo06ePsqxutk5xcTHy8vIAPE4obG1tlXXEYjE6d+6Mzp076xw7tS0c9EikRl13OaDbX/tPTqksKyvTWl+hUOD+/fs4fPgwtm7dCuDxD+2oUaMarF9TU4Pi4mKN/6mqqhIc79Oqq6u1tv/o0SOVa+qmRBYWFj7zfRtrwoQJ9cqMjIyUa2OYmppizJgx9epYWloqk5w7d+7odE8jIyP4+/sDAK5du6ZjxI/FxcUBAOzt7dVOpZ0+fTqAx89kUlJSg3U6d+6skiw8ycLCQtnTYMj/jej5xh4GIgM4deoUTp061eA5c3NzLFiwAE5OTg2ef5ZFmXTxLIsyBQYG4vjx49i8eTPS0tLQp08fuLu7w8zMrImiVGVlZaW2J8fGxgYA4OrqWm8cQZ26KbDqErzU1FScOHEC169fx4MHDyCXy+vVqRsMqatbt24BeLxOw5PjGp7k6uoKOzs7PHz4ELdu3WowMXiyx+dpYrEYL774IpKSkvD3v/8dI0aMQGBgILp27QoTE/4MkDB8UojUeLqnwM7OTtB1QnomnlwcSSQSwczMDA4ODujRoweGDx8Oe3v7RkTe/N544w3k5uYiOTkZhw4dwqFDh2BkZAQ3NzcEBgYiJCRE8H9/z8LCwkLtubofYU116saZ1NTU1Dv3n//8BwcOHFBpTyKRKH9oZTIZ5HJ5g0mEEMXFxQCg9b8fe3t7PHz4UFn/aZpm8ADAO++8gzVr1iAzMxP79u3Dvn37YGJiAnd3d/Tt27fedGGipzFhIFLjyeWZb926JfgH7/bt2wD+t9xzQ1ra4kiNJZFIsGLFCly7dg0XLlxAWloabt26pfzPgQMH8M4772DQoEGGDlUnSUlJymRh5MiRGDlyJFxdXVV6Avbs2YOoqCiVQZ2GoK53oo6DgwPWrFmDpKQkSKVSpKWlITMzE2lpaUhLS8NPP/2EJUuWaF3enNouJgxEavj6+kIkEkGhUCAhIUHt++EnyWQy/P777wCAHj166DxD4nnn7e2tnF5YVVWFpKQk7NmzB3fu3MHWrVvh5+enfEXwPIiNjQUA+Pv746233mqwTlFRUaPu0b59e+Tk5KgsO96QuvOaVhDVxsjICAEBAQgICAAAVFZW4uLFi9i9ezcKCgqwceNGbN26la8pqEEc9Eikhq2tLfr27Qvg8cC0nJwcrdccOnRIuX6CuulvbYVYLEafPn2wdOlSAI8HUz45MFDbX8QtQd2PtLpZMgqFQrl2QkOeXAdBnW7dugF4PI23tra2wTrZ2dnKMRLu7u5a2xTKwsICgwYNwjvvvAPg8esRXQd+UtvR8v8fS2RA06dPh1gsRnV1NdavX6+c8tgQqVSKqKgoAI97J55l0abnUU1NjdofOgAqUwCfTBKeHFNQt+BTS1M3ziQzM7PB88eOHVNOV2xI3WfU9PmCg4MBPB40eeLEiQbr7N27F8DjcTUvvvii9sCf8vSslqc9+b+RkCSH2iYmDEQadO7cGe+88w6MjIxw584d/OUvf8GJEydUfgBycnKwc+dOrF27Fo8ePULHjh3xf//3f23mi/fBgwf4v//7P+zbtw+3b99WGTiYmZmJr7/+GsDjXSd9fHyU5yQSiXJcyMmTJxsccGhodV33UqkUkZGRkMlkAB4nAFFRUdi+fbvGnUnrFkeSSqVqZ1F4eHgoFwbbvn07fvvtN+UAyqKiInzzzTeIj48H8L8EVldpaWlYunQpDh06hKysLGWCp1AokJaWhu+//x7A44GVDW14RgRwDAORVoMGDYKVlZVye+tvvvkG33zzDSwtLVFdXa1cahd4/K570aJFWkesN4aQhZuAxyv7PQshCzc5ODjgyy+/VB7n5eVh79692Lt3L4yMjGBpaQmZTKb8y9bExAQLFiyoNwp/xIgR2Lt3L3777TccP34c1tbWMDIygqenJ95///1nil+fBg8ejFOnTiE1NRXh4eGIiIiApaUlKioqoFAoEBgYCDc3N2XP0tOGDBmCgwcPIjc3F/Pnz4e1tbXyB//zzz9XzoaZP38+SktLkZKSgu3bt2Pnzp0wNzdX3gcAXn311Ua95rpz5w5++OEH/PDDDzA2NlZ+jrpEzcLCAu+9995z8aqIDIMJA5EAAQEB+PrrrxETE4OLFy8iMzMTpaWlMDExUU6HDA4OfqbuYl3VLdzUVOoWbtLkyb9y7ezssGzZMiQnJyM9PV059c/Y2BidOnWCr68vxowZ0+C6EhMnToSFhQXOnDmjfE+vUCjUzi5pbiYmJvj444/x888/IzY2Vrlst4eHB4YMGYKQkJB6m0o9ycnJCStWrMDPP/+M69evK/eWAFSncFpaWuKzzz5Tbj6VkZEBmUwGGxsbeHl5YfTo0Wo3nxLC3d0dH3zwAZKTk3Hjxg0UFhaipKQEpqam6Ny5M3r27IkxY8Y06dRXev6JFIaeC0REREQtHvueiIiISCsmDERERKQVEwYiIiLSigkDERERacWEgYiIiLRiwkBERERaMWEgIiIirZgwEBERkVZMGIiIiEgrJgxERESk1f8DRVTffyq9tWEAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 576x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_, estimated_interval_optimal = ope.summarize_off_policy_estimates(\n",
     "    evaluation_policy_pscore=optimal_policy_pscores[0],\n",
@@ -376,7 +427,7 @@
     "    evaluation_policy_pscore_cascade=optimal_policy_pscores[2],\n",
     "    alpha=0.05,\n",
     "    n_bootstrap_samples=1000,\n",
-    "    random_state=random_behavior_dataset.random_state,\n",
+    "    random_state=dataset_with_random_behavior.random_state,\n",
     ")\n",
     "\n",
     "estimated_interval_optimal[\"policy_name\"] = \"optimal\"\n",
@@ -390,15 +441,37 @@
     "    evaluation_policy_pscore_cascade=optimal_policy_pscores[2],\n",
     "    alpha=0.05,\n",
     "    n_bootstrap_samples=1000, # number of resampling performed in the bootstrap procedure\n",
-    "    random_state=random_behavior_dataset.random_state,\n",
+    "    random_state=dataset_with_random_behavior.random_state,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "          mean  95.0% CI (lower)  95.0% CI (upper)   policy_name\n",
+      "sips  1.854516          1.829643          1.877320  anti-optimal\n",
+      "iips  1.832793          1.815842          1.848599  anti-optimal\n",
+      "rips  1.844397          1.824965          1.864795  anti-optimal \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgwAAAGSCAYAAACPApmhAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAABSb0lEQVR4nO3deViU5f4/8PewDMsgAiIuoKEsIqAsKiaYmoJ6zHLX7GSmdiq3vqXm6WuLmKdvmKF53DqVnqxjySKlWJai4QKBqKMki7iBAgGi7DCs8/vDH3McYWaegYFBeL+uq+viuZ/7uecz9TTzmfu5F5FcLpeDiIiISA0DfQdAREREHR8TBiIiItKICQMRERFpxISBiIiINGLCQERERBoxYSAiIiKNmDAQERGRRkwYiIiISCMmDERERKSRkdCKubm5+OOPP5CWlobCwkKUlZVBLBbD0tISjo6O8PDwgKenJ8RicVvGS0RERHog0rQ0dFxcHI4dO4b09HSNjUkkEowbNw6TJ0+GnZ2dzoIkIiIi/VKZMFy5cgXffPMNsrKyYG5ujhEjRsDNzQ1OTk6wsrKChYUFampqUFZWhtzcXGRkZCA5ORnXrl2DkZER/vKXv2DmzJkwNzdv7/dEREREOqYyYZg3bx4GDBiAadOmYfjw4TA2NhbU4J9//onjx4/j+PHjmDZtGmbPnq3TgImIiKj9qUwYzp07Bz8/vxY3XFxcjIKCAri6ura4DSIiIuoYNI5hICIiIhI8S6Krys3N1XcIRERE7aJv374qz3EdBiIiItJIbQ/DihUrtG5QJBJh+/btLQ6IiIiIOh61CcPdu3fbKw4iIiLqwNQOemxpwtCzZ88WB9TRcAwDERF1FerGMKjtYehMX/xERETUchz0SERERBqp7WFoaGjAZ599BpFIhJUrV8LIqPnqdXV12L59O0QiEd588822iJOIiIj0SG0PQ2JiIhITEzF8+HCVyQIAGBkZYcSIEfj999+RkJCg8yCJiIhIv9QmDL///jtsbGwwevRojQ0FBATAxsYGZ8+e1VlwRERE1DGoTRhu3LgBDw8PiEQijQ2JRCJ4enri5s2bOguOiIiIOga1CUNxcTF69OghuDEbGxuUlJS0OigiIiLqWNQmDEZGRqitrRXcWG1trdqxDkRERPR4UpswWFtbIysrS3BjWVlZsLa2bnVQRERE1LGoTRgGDRqE1NRU5OXlaWwoLy8PqampcHNz01lw9PiZPXs2Zs+ere8wiIhIx9QmDEFBQWhoaMCWLVvUjk0oLS3F1q1b0dDQgMDAQJ0HSURERPqldsCBs7MzAgMDERMTg1WrViEoKAienp6wsbEBANy/fx9XrlxBTEwMysrKEBQUBGdn53YJnIiIiNqPxhGKixcvRkNDA06ePIkffvgBP/zwQ7P1JkyYgMWLF+s8QCIiIm00PhaNjIzUcySdi8aEwdDQEK+99hrGjRuH48eP4+rVqyguLgYAWFlZwc3NDYGBgRg0aFBbx0pERER6IngO5KBBg5gUkFpRUVG4cOECampq4Ofnh3feeQczZ87Ud1hERKQD3K2SdCIqKgpr165FTU0NACAnJwdr165FVFSUniOjxw1n2hB1TEwYSCdCQkJQVVWlVFZVVYWQkBA9RUREXVFjT+fvv/8OPz8//mjRIS7L2I7+fPsVfYfQZnJzclSWd9b33WfzV/oOgYgeoqqnEwAfj+oAexhIJ3qZm2pVTtQc/jqk1mBPZ9tiDwPpxHIvV3x07gpk9Q2KMlNDAyz3ctVjVPQ44a/D9vHr4T/1HUKbycnJVVneWd/3pOf6tNtrsYeBdOIvA+zxrp8njA0e3FK9zU3xrp8n/jLAXs+R0eOCvw6ptXrY9NKqnLTDHgbSmb8MsMcPN7IBAF8EjtRzNJ3Ty/t+13cIbUbdr8PO+r6/XjhK3yF0KjOnLce+/R+hpkamKBOLTTFz2nI9RtV5tCphKCgoQHb2gy8IBwcH2NnZ6SQoIup6TK16QFZc2Gw5kRCj/P4CAPj3tx+irq4WPWx6Y+a05Ypyap0WJQxVVVX4/PPPkZCQoFQ+atQovP766zA15UA3ItKOc9ALSP3xczTU1ijKDIzFcA56QY9R0eNmlN9fcPrsgy0M/r7qCz1H07m0KGHYs2cPkpOTMXfuXAwcOBC1tbU4f/48Tp06BRMTEyxdulTXcRJRJ9fHZwwAIDVqFxrq62BqZQvnoBcU5USkX2oThurqapiYmDQpT0pKwiuvvIKnnnpKUebn54fq6mqcO3eOCUMXxrEL1Bp9fMYg53wMAGD43z7UczT0uGLPQttQO0tizZo1uHLlSpPy+vp6mJmZNSk3MzNDQ0NDk3IiIqGG/+1DJgtEHZDaHgYXFxds3LgREyZMwIIFCxRJgqenJ/bs2QOZTIYBAwagtrYWFy5cwKlTpzBs2LB2CZyIiIjaj9qE4Y033sDo0aPx5ZdfQiqV4tVXX4WPjw9eeeUVbN68Gdu3b1eqP3DgQCxevLhNAyYiIqL2p3HQo6+vL0JDQ/HNN98gJCQETz31FF5++WVs2rQJycnJyPn/ewg4ODhgyJAhWgeQl5eHw4cPIyMjA3fu3MHgwYMRHBys9prw8HBERkY2e27+/PmYMWMGAGDnzp04depUkzpbt26FvT0XFCIiIhJK0CwJc3NzvP766/D398cXX3yB1atXY8mSJfDz88PQoUNbFcCdO3cglUrh4uKC+vp6QddMmDAB3t7eSmVJSUk4dOgQfHx8lMrt7e2bDMLs2bNnq2ImIiLqarSaVjl06FB8+umn2L9/P0JDQ/Hkk09iyZIlsLS0bHEAw4YNw4gRIwAAoaGhKCsr03hNjx490KOH8mIuBw8ehL29PRwdHZXKTUxM4OrK/QyIiIhaQ9BeEqWlpbh58yZKS0thamqKJUuWIDg4GJmZmXjrrbdw9uzZlgdg0PrtLMrKypCcnIyAgIBWt0VERERNqe1hkMlk2L17t9KKjiNHjsSyZcswePBgbN68GQcOHMDOnTsRHx+PV199FVZWVm0dcxOJiYmor69vNmHIzs7GwoULUVtbCycnJ8yfPx/u7u7tHiMREdHjTG3C8N133yEhIQFjx46Fs7Mzbty4gdjYWHTv3h1LliyBWCzGSy+9BH9/f+zatQtvvfUWXnrpJTz99NPtFT8AIC4uDgMGDECfPsrbfA4YMAAuLi5wcHBAaWkpoqOjsXHjRmzcuBHOzs7NthUTE4OYmAcLx4SEhMDW1lZncXbOzVW7Ll3eG9Q16ece4idRZ9Ke95DahCEpKUnRo9CoqqoK58+fx5IlSxRlzs7O+OSTTxAZGYkvv/yyXROGoqIipKam4q9//WuTc1OmTFE69vHxwapVqxAVFYW1a9c2215gYCACAwMVx4WFTTfDIQJ4b1Dr8R6i1tL1PdS3b1+V5zQuDf3o4MIePXo0u/qjkZERnn/+eTz55JMtDLNlfv/9wba3/v7+GuuamJjAx8cHFy5caOuwiIiIOhW1Iw5dXFxw+vRppKeno66uDhkZGThz5gxcXFxUXvPoLIW2FhcXBzc3N8HdMiKRCCKRqI2jIiIi6lzU9jAsWrQIGzZswPr16xVlNjY2ePnll9s6LkEKCgpw7do1vPLKK4Lq19TU4OLFixg4cGAbR0ZERNS5qE0Yevfujc8++wwXLlxAYWEhbG1t4evrC1NTU50FUF1dDalUCgC4f/8+qqqqFLMyfHx8YGJigpUrV8Ld3b3JAkzx8fEwNDRs9jFIZWWlYmXK3r17o6ysDD/99BOKioqwatUqncVPRETUFWhcuMnExETQ+ICWKikpwZYtW5TKGo937NgBOzs7NDQ0NLsLZlxcHDw9PZtdOMrIyAiWlpaIiopCSUkJjI2N4erqiuDgYDg5ObXNmyEiIuqktFrpsS3Y2dkhPDxcbZ2dO3c2W75582aV14jFYqxZs6ZVsREREdEDLU4Yzp8/j7S0NFRXV8POzg7+/v6cl05ERNRJaVy4aejQofD09FSUVVRU4JNPPkF6erpS3bCwMLz22msYM2ZM20RKREREeqM2YTh06BDEYrFSwvCvf/0L6enpsLOzQ0BAACwtLZGRkYHff/8dn3/+ORwdHdG/f/82D5yIiIjaj1aPJPLy8pCYmIgBAwZg/fr1MDMzA/BgRUVfX1/s3LkTP//8M15//fU2CZaIiIj0Q6utItPS0gAA8+fPVyQLjcaMGQNnZ2ekpqbqLjoiIiLqELRKGIqLiwFA5bREJycn3L9/v9VBERERUceiVcLQ2KtgbGzc7HljY2Muu0xERNQJaRzDkJKSovg7Ly8PAHD37l04ODg0qXvv3j1069ZNh+ERERFRR6AxYUhNTW0yLuHixYvNJgw3b96Evb297qIjIiKiDkFtwvDwplMPa24p5ps3b6K+vh5DhgzRTWRERETUYahNGNzd3QU3NHDgQJVLOBMREdHjTatBj0RERNQ1abVwU319PfLz81FRUQGRSITu3bujZ8+ebRUbERERdRCCEoZz587h119/RVpaGurr65XOWVpaIiAgANOnT4eVlVVbxEhERER6pjZhkMvl2LVrF06fPt3knK2tLUxNTZGXl4ejR4/izJkzePvtt+Hm5tZmwRIREZF+qE0YYmJicPr0afj6+mLevHno1asX8vPzER4ejqtXr+Ldd99Fz549ERcXh2+//RabNm1CaGgobGxs2it+IiIiagdqBz2ePHkSDg4OWLNmDRwdHWFmZgZHR0esXr0aVlZW+O6772BsbIxx48bh/fffh0wmw48//thOoRMREVF7UZswZGdnY8iQITA0NFQqNzQ0xJAhQ5RWgXR0dISvry+kUmnbREpERER6ozZhEIlEqKmpafZcTU0Namtrlcrs7e25+RQREVEnpDZh6NevH86fP4/y8nKl8vLycpw/fx59+vRRKpfJZBCLxbqPkoiIiPRK7aDHp59+Gl9++SXWrVuHqVOnws7ODgUFBfjpp59QUlKCqVOnKtW/c+cOevfu3aYBExERUftTmzAEBgYiNTUVcXFx2LNnj9I5b29vpYShqqoKNTU18Pf3b5tIiYiISG80Ltz0xhtv4Mknn8S5c+dQUlKCbt26wdfXF/7+/jAw+O8TDTMzM3z00UdtGiwRERHph6CVHv38/ODn59fWsRAREVEHxc2niIiISCMmDERERKQREwYiIiLSiAkDERERaSRo0GNbysvLw+HDh5GRkYE7d+5g8ODBCA4OVntNQUEBVqxY0aTc398fb775plJZUlISDhw4gLy8PNjZ2WHOnDmc+klERKQlvScMd+7cgVQqhYuLC+rr67W6dsGCBRg0aJDi2NLSUul8eno6QkNDMXHiRCxatAhSqRTbtm2DRCKBl5eXTuInIiLqCvSeMAwbNgwjRowAAISGhqKsrEzwtX379oWrq6vK8wcPHsTgwYOxePFiAICnpyeys7MRGRnJhIGIiEgLeh/D8PDiT7pUW1uLK1euYNSoUUrl/v7+yMjIQGVlZZu8LhERUWek9bd1amoqIiMjtT7XFnbt2oV58+bh1Vdfxb59+5R21szPz0d9fT3s7e2VrrG3t4dcLkdubm67xUlERPS40/qRREpKCiIjIzF79mytzumSsbExJk2aBC8vL5iZmSElJQWHDh1Cfn4+1q5dCwCKHTYlEonStRYWFgCAioqKZtuOiYlBTEwMACAkJAS2trY6i/tPnbVEHYEu7w3qmvRzD/GTqDNpz3tI72MYWsLa2hpLlixRHHt4eMDKygpfffUVMjMz4ejo2OK2AwMDERgYqDguLCxsTajUifHeoNbiPUStpet7qG/fvirP6X0Mg648+eSTAICbN28C+G9PwqNjFVT1PBAREZFqnSZhaCQSiQAAvXr1gqGhIXJycpTO5+bmQiQSqc2iiIiISJmgRxIPd3k0Pvt/tBtE389zExISAAADBw4E8GCcg6enJxISEhAUFKSoFx8fD1dXV5ibm+slTiIioseRoIRh+fLlastEIhEOHDjQogCqq6shlUoBAPfv30dVVZXiy9/HxwcmJiZYuXIl3N3dsXTpUgBAeHg4ZDIZBg0aBDMzM6SlpeHw4cPw8/PDE088oWh71qxZCA4Oxtdff40RI0ZAKpVCKpVi3bp1LYqViIioqxKUMMyaNUvR1Z+amorU1FSdzYQoKSnBli1blMoaj3fs2AE7Ozs0NDSgoaFBcd7e3h7R0dE4ceIEampqYGtri+eeew4zZ85UasfNzQ2rVq1CWFgYjh07Bjs7O7zxxhtctImIiEhLghKGuXPnKv6OiIhAamoq5syZo5MA7OzsEB4errbOzp07lY4DAgIQEBAgqH0/Pz/4+fm1OD4iIiLqhIMeiYiISPeYMBAREZFGTBiIiIhII60TBrlc3qJzRERE9PjSemnouXPnKg2CFHqOiIiIHl98JEFEREQaMWEgIiIijVQmDDU1Na1uXBdtEBERkf6pTBiWL1+On3/+GbW1tVo3mpmZiU8++QSHDx9uVXBERETUMagc9Ojl5YV9+/YhIiIC/v7+GDVqFFxdXSEWi5utn5+fj8uXL+PUqVO4fv26YrlmIiIievypTBhWrFiByZMn48CBA4iJiUFMTAwMDAzg4OAAKysrSCQS1NbWory8HLm5uSgtLQUAWFpaYv78+XjmmWdgbGzcbm+EiIiI2o7aaZXOzs5477338Oeff+LkyZO4cuUKMjMzcfv2baV6lpaWGDlypOIfIyOtZ2sSERFRBybom71Pnz7461//CuDBdtT3799HWVkZxGIxunfvDmtr6zYNkoiIiPRL664AExMT9OnTB3369GmLeIiIiKgD4joMREREpBETBiIiItKICQMRERFpxISBiIiINGLCQERERBoxYSAiIiKNmDAQERGRRlqvw1BXV4crV64gOzsbMpkMs2fPBvBgZ8qqqip069YNBgbMQ4iIiDoTrRKGS5cuYffu3SguLlaUNSYMmZmZeP/997Fy5UqMHj1ap0ESERGRfgnuCrhx4wY2b94MkUiEhQsXIiAgQOm8q6sr7OzscO7cOZ0HSURERPolOGE4ePAgxGIxQkJCMGXKlGaXhnZyckJWVpZOAyQiIiL9E5wwXL16FSNGjICVlZXKOra2tkqPK4iIiKhzEJwwyGQyWFpaqq1TXV2NhoaGVgdFREREHYvgQY82Nja4c+eO2jqZmZno1auXVgHk5eXh8OHDyMjIwJ07dzB48GAEBwerveb69es4duwY0tLSUFRUhB49emD06NGYNm0axGKxol54eDgiIyObXL9u3Tp4e3trFScREVFXJjhh8Pb2xvHjx5Geng43N7cm56VSKTIyMjBt2jStArhz5w6kUilcXFxQX18v6Jr4+Hjk5+dj2rRp6NOnD7KyshAWFoasrCysWbNGqa65uTnWrVunVObg4KBVjERERF2d4IRhxowZiI+Pxz/+8Q9MnjwZd+/eBQBcvHgRqamp+PXXX2FlZYWpU6dqFcCwYcMwYsQIAEBoaCjKyso0XjN9+nSlxyMeHh4Qi8X44osvcPfuXfTs2VNxztDQEK6urlrFRERERMq0eiTx7rvvYuvWrYiOjlaUb9q0CQDQq1cvrFmzRuM4h0e1ZJGn5l7D0dERAFBUVKSUMBAREVHrabVw08CBA7Ft2zZcvHgRGRkZKCsrg7m5OVxcXDBixAgYGhq2VZwaZWRkQCQSNRlDUVFRgSVLlqCyshL9+vXDrFmzMHLkSD1FSURE9HjSemloAwMDDB8+HMOHD2+LeFqkuLgYUVFRGDNmDLp3764o7927N1588UU4OjpCJpPh+PHjCA0NxerVq5k0EBERaUHrhKGjqaurw9atW2FqaoqFCxcqnRszZozS8bBhw/Dee+8hMjJSZcIQExODmJgYAEBISAhsbW11FuufOmuJOgJd3hvUNennHuInUWfSnveQ4ITh1KlTghsdO3Zsi4LRllwux44dO3Dnzh1s3LgRFhYWauuLRCKMHDkS+/fvR0NDQ7PjJwIDAxEYGKg4Liws1Hnc1Dnw3qDW4j1EraXre6hv374qzwlOGHbt2iX4BdsrYfj666+RlJSE999/H/b29u3ymkRERF2R4IRh6dKlzZZXVlbi+vXriI+Ph5+fH3x9fXUWnDo//PADfvnlF7z11lvNrgvRHLlcjsTERDg6OnILbiIiIi0IThjGjRun9vzTTz+t2JhKG9XV1ZBKpQCA+/fvo6qqCgkJCQAAHx8fmJiYYOXKlXB3d1ckLWfPnsX333+PcePGwcbGBhkZGYr2evfurZh2uX79eowcORL29vaorq7GiRMncP36dbz99ttaxUhERNTV6WzQ45AhQ+Dl5YWwsDCsX79e8HUlJSXYsmWLUlnj8Y4dO2BnZ4eGhgalPSouX74MAIiNjUVsbKzStcuWLVMkN71798bPP/+MoqIiGBgYYMCAAXjnnXfg4+PTgndIRETUdel0lkTfvn1x/Phxra6xs7NDeHi42jo7d+5UOl6+fDmWL1+usW1Vj1GIiIhIOzp9kJ+dna3L5oiIiKiDaHUPQ0NDA+7du4cTJ05AKpWyu5+IiKgTEpwwzJs3T2MdCwsLvPjii60KiIiIiDoewQnD4MGDIRKJmpSLRCJIJBI4Ozvj6aef1nrzKSIiIur4BCcMwcHBbRgGERERdWRcvYiIiIg0YsJAREREGql8JKHN3hEPE4lEXP+AiIiok1GZMGizO+WjmDAQERF1LioThh07drRnHERERNSBqUwYevbs2Z5xEBERUQfGQY9ERESkUYuWhm5oaEBpaSnq6uqaPW9ra9uqoIiIiKhj0SphuH37Nvbv34+UlBTU1tY2W0ckEuHAgQM6CY6IiIg6BsEJQ3Z2Nt577z0AwNChQ3HhwgU88cQT6N69O27duoWysjJ4eHiwd4GIiKgTEpwwREVFob6+Hh9//DH69++PefPmwc/PD7Nnz4ZMJsO///1vSKVSLFu2rC3jJSIiIj0QPOgxJSUFvr6+6N+/v6JMLpcDAExNTfHqq69CIpEgLCxM91ESERGRXglOGMrKytCnT5//XmhggOrqasWxoaEhPDw8kJycrNsIiYiISO8EJwwWFhaQyWSKY0tLSxQWFirVMTIyQmVlpe6iIyIiog5BcMLQq1cvFBQUKI4HDBiAP/74AyUlJQAAmUyG8+fPw87OTvdREhERkV4JHvTo5eWFQ4cOQSaTwdTUFBMnToRUKsXatWsxaNAg3Lx5E3fv3sVLL73UlvESERGRHghOGCZMmIC+ffuipqYGpqam8PX1xcKFCxEREYHExESIxWJMmzYNf/nLX9oyXiIiItIDtQnD2rVrERgYiKeeegrW1tbw9/dXOj9lyhRMnjwZpaWl6N69O0QiUZsGS0RERPqhdgxDVlYW9uzZg9deew2ff/45rl271rQBAwNYWVkxWSAiIurE1PYwbNy4ETExMUhISMBvv/2G3377Df3798eECRMwZswYmJubt1ecREREpEdqEwZXV1e4urpi0aJFOHPmDE6ePIlbt27h3//+N/bv348nn3wSEyZMgJubW3vFS0RERHogaNCjmZkZJk6ciIkTJyIzMxMxMTGIi4vD6dOncfr0aTg4OCh6HSwsLNo6ZiIiImpngtdhaOTo6IhXXnkF//rXv7Bs2TIMGjQI2dnZ2LdvH15//XVs3769LeIkIiIiPdJqe+uHicVijB07FmPHjkVubi7+9a9/IT09HWfPnsXKlSsFt5OXl4fDhw8jIyMDd+7cweDBgxEcHKzxusrKSnz99ddISkpCQ0MDhg0bhkWLFqFbt25K9ZKSknDgwAHk5eXBzs4Oc+bMaTLbg4iIiNRrccIAAOXl5Th16hROnjyJ7OxsANB6IOSdO3cglUrh4uKC+vp6wddt3boVubm5eO2112BgYID9+/dj8+bN+PDDDxV10tPTERoaiokTJ2LRokWQSqXYtm0bJBIJvLy8tIqTiIioK2tRwnDlyhXExMQgKSkJdXV1AAAXFxcEBgZq/et92LBhGDFiBAAgNDQUZWVlGq/JyMjA5cuXERwcDHd3dwCAjY0N1q1bh+TkZAwdOhQAcPDgQQwePBiLFy8GAHh6eiI7OxuRkZFMGIiIiLQgOGEoLi7Gb7/9hpMnTyr2lJBIJAgMDERgYCD69evXogAMDLQeRgGpVIru3bsrkgUAcHZ2hp2dHS5duoShQ4eitrYWV65cwaJFi5Su9ff3x65du1BZWclpoURERAKpTRjkcjkuXryIEydOQCqVoqGhAQDg5uaGCRMm4Mknn4RYLG6XQB+Wk5MDe3v7JuX29vbIyckBAOTn56O+vr5JPXt7e8jlcuTm5sLZ2bld4iUiInrcqU0Yli1bhvv37wN4sL31mDFjEBgY2OyXdXuqqKhotndAIpEoej/Ky8sVZQ9rnPZZUVHRbNsxMTGIiYkBAISEhMDW1lZncf+ps5aoI9DlvUFdk37uIX4SdSbteQ+pTRju378Pd3d3RW+CkVGrxkg+FhofsTQqLCzUYzTUkfHeoNbiPUStpet7qG/fvirPqc0APvvsM/Tp00enweiCRCJpdnBkRUWFokehsSehsrJSqY6qngciIiJSTe2Iw46YLADKYxUelpubq3hc0qtXLxgaGjapl5ubC5FIpDaLIiIiImXaT1HoAHx8fFBcXIz09HRF2Y0bN5Cfnw9vb28AgLGxMTw9PZGQkKB0bXx8PFxdXTlDgoiISAt6Txiqq6uRkJCAhIQE3L9/H6WlpYrj6upqAMDKlSuxe/duxTWurq7w8vLCjh07kJiYiHPnzuGf//wn3NzcFGswAMCsWbOQkpKCr7/+GikpKfjPf/4DqVSK2bNnt/v7JCIiepzpfRRjSUkJtmzZolTWeLxjxw7Y2dmhoaFBMaWz0Ztvvol9+/Zh9+7dkMvl8PX1bbLmgpubG1atWoWwsDAcO3YMdnZ2eOONN7hoExERkZZEcrlcru8gOrLc3FydtfXn26/orC3Svz6bv2r313x53+/t/prUdr5eOKrdX/PXw5xW2ZlMek63Yw3Vje/T+yMJIiIi6vgEJwyJiYlNHgsQERFR1yB4DMOWLVtgbW2Np59+GhMmTOAqd0RERF2I4B6GSZMmobq6GlFRUVi5ciVCQkJw4cIFcAgEERFR5ye4h2Hx4sV48cUXER8fj+PHj0MqlUIqlcLGxgYTJkzA+PHjYWNj05axEhERkZ5oNa1SLBZj3LhxGDduHG7fvo2YmBicOXMGEREROHjwIHx9fREUFKRYPImIiIg6hxavw9C/f3+lXoewsDCcP38e58+fh62tLSZNmoSJEyfC1NRUl/ESERGRHrRqWqVMJsPp06fxyy+/KLbBdnR0RHl5Ofbv34+33noLmZmZuoiTiIiI9KhFPQy3bt3C8ePHERcXB5lMBrFYjPHjx2PSpElwdHSETCbDr7/+ivDwcPz73//Ghg0bdB03ERERtSPBCUN1dTXi4uJw/Phx3Lx5E8CDXSODgoIwduxYpc2cTE1NMW3aNNy7dw8nT57UfdRERETUrgQnDK+99hqqqqpgYGCAkSNHYtKkSfDw8FB7jY2NDWpra1sdJBEREemX4ITBzMwMU6dORWBgIKysrARdM3HiRAQEBLQ0NiIiIuogBCcMO3fuhIGBdmMkzc3NlR5VEBER0eNJcAagbbJAREREnYfgLODgwYOYP3++Yvrko+7fv4/58+fjxx9/1FVsRERE1EEIThguXLgAd3d3lcs/29jYwNPTE0lJSToLjoiIiDoGwQlDXl4eHBwc1Naxt7dHXl5eq4MiIiKijkVwwlBTUwMTExO1dcRiMWQyWauDIiIioo5FcMLQo0cPXLt2TW2da9euccdKIiKiTkhwwuDl5YXU1FTEx8c3ez4uLg6pqancqZKIiKgTErwOw/Tp03H27Fls27YN8fHx8Pb2ho2NDe7fvw+pVIrz58/DwsIC06dPb8NwiYiISB8EJww2NjZ49913sWXLFiQlJTWZDdGzZ0+sWrUKPXr00HmQREREpF9a7Vbp5OSEbdu24cKFC7h27RoqKiogkUjg4uKCYcOGwcioRZtfEhERUQen9Te8kZERRo4ciZEjR7ZFPERERNQBcb1nIiIi0khlD8OpU6cAAH5+fjAzM1McCzF27NjWR0ZEREQdhsqEYdeuXQAAFxcXmJmZKY6FYMJARETUuahMGJYuXQoAsLa2VjomIiKirkdlwjBu3Di1x7qSnZ2NvXv3IiMjAxKJBOPHj8ecOXPUbqcdHh6OyMjIZs/Nnz8fM2bMAADs3Lmz2UcpW7duhb29vW7eABERUReg13mQ5eXl2LhxIxwcHLB27Vrk5eXh22+/hVwux/PPP6/yugkTJjRZUTIpKQmHDh2Cj4+PUrm9vX2T3pGePXvq7D0QERF1BXpNGI4fP46amhqsXr0a5ubmGDp0KKqqqhAREYHnnnsO5ubmzV7Xo0ePJgtEHTx4EPb29nB0dFQqNzExgaura1u9BSIioi5BZcKwYsWKFjUoEomwfft2QXUvXboELy8vpcQgICAA+/fvR2pqKoYPHy6onbKyMiQnJ2PWrFktipmIiIjUU5kwyOXyFjWozXU5OTnw8PBQKrO1tYWJiQlyc3MFt5OYmIj6+noEBAQ0OZednY2FCxeitrYWTk5OmD9/Ptzd3QW3TURERGoShp07d7b5izcuLf0oiUSC8vJywe3ExcVhwIAB6NOnj1L5gAED4OLiAgcHB5SWliI6OhobN27Exo0b4ezs3GxbMTExiImJAQCEhITA1tZWi3ek3p86a4k6Al3eG9Q16ece4idRZ9Ke99Bjv/lDUVERUlNT8de//rXJuSlTpigd+/j4YNWqVYiKisLatWubbS8wMBCBgYGK48LCQt0GTJ0G7w1qLd5D1Fq6vof69u2r8lyLl4auqqpCYWEhKisrW9oEJBJJs9dXVFTAwsJCUBu///47AMDf319jXRMTE/j4+ODWrVvaBUpERNTFadXDUF9fj+joaJw4cQIFBQWKcjs7O0yYMAHPPvssDA0NBbdnb2+PnJwcpbLCwkJUV1erzXIeFhcXBzc3N8HdMiKRCCKRSHCMREREpEUPQ11dHf7xj3/g+++/x927d2FrawtnZ2fY2tri7t27+P7777Fx40bU1dUJfnFvb29cvnwZVVVVirL4+HiIxWJBAxMLCgpw7dq1Zgc7NqempgYXL17EwIEDBcdIREREWvQwHDlyBKmpqfD19cVLL72kNMAwLy8P33zzDS5cuIAjR45g+vTpgtoMCgrC0aNH8emnn2LatGkoKChAREQEpk6dqjTVcuXKlXB3d2+yAFN8fDwMDQ3x5JNPNmm7srISISEheOqpp9C7d2+UlZXhp59+QlFREVatWiX0bRMRERG0SBjOnj2Lfv364e23326ybHPv3r2xZs0arF27FmfOnBGcMFhYWOCDDz7Anj17sGnTJkgkEjzzzDOYO3euUr2GhgY0NDQ0uT4uLg6enp6wtLRs+saMjGBpaYmoqCiUlJTA2NgYrq6uCA4OhpOTk9C3TURERNAiYcjLy8PkyZNV7vFgYGAAb29v/PLLL1oF4ODggPXr16uto2qK5+bNm1VeIxaLsWbNGq1iISIiouYJHsNgZGQEmUymtk51dbVWgx6JiIjo8SA4YXjiiSeQmJiI0tLSZs+XlpYiISGhyV4ORERE9PgTnDBMmjQJpaWl+N///V+cPHkS+fn5qKmpQUFBAX777Te8++67KC0txaRJk9oyXiIiItIDwWMY/P39kZmZiUOHDuFf//pXs3Wee+45QQsoERER0eNFq4WbXnjhBQwfPhwnT55EZmYmKisrYW5uDkdHR4wfP57bSBMREXVSghOGsrIyiEQiuLq6MjEgIiLqYjQmDElJSfjmm28US0H37t0bCxYswPDhw9s8OCIiIuoY1A56zMjIQGhoqNK+EXl5eQgNDUVGRkabB0dEREQdg9qE4ciRI5DL5Zg1axa+/PJLfPHFF5g5cyYaGhpw5MiR9oqRiIiI9EztI4lr167Bzc1NaanmefPmITU1lT0MREREXYjaHoaSkhK4uLg0KXdxcVG5gBMRERF1PmoThvr6epiamjYpNzExQX19fZsFRURERB2L4JUeiYiIqOvSOK0yNjYWKSkpSmV3794FAGzYsKFJfZFIhA8++EBH4REREVFHoDFhuHv3riJBeFRqaqrOAyIiIqKOR23CsH79+vaKg4iIiDowtQmDu7t7e8VBREREHRgHPRIREZFGTBiIiIhIIyYMREREpBETBiIiItKICQMRERFpxISBiIiINGLCQERERBoxYSAiIiKNVC7cFBkZ2eJGZ8+e3eJriYiIqONRmTBERES0uFEmDERERJ2LyoShuX0kjhw5AqlUiqeeegru7u6wsrJCcXExUlJScPbsWfj6+uKZZ55p04CJiIio/alMGB7dR+LUqVP4448/8NFHH2HgwIFK58aNG4fJkydj/fr1GDlypFYBZGdnY+/evcjIyIBEIsH48eMxZ84cGBioHl5RUFCAFStWNCn39/fHm2++qVSWlJSEAwcOIC8vD3Z2dpgzZw78/f21ipGIiKir07i9daOffvoJo0aNapIsNHJycsKoUaPw008/YcyYMYLaLC8vx8aNG+Hg4IC1a9ciLy8P3377LeRyOZ5//nmN1y9YsACDBg1SHFtaWiqdT09PR2hoKCZOnIhFixZBKpVi27ZtkEgk8PLyEhQjERERaZEw5ObmwsfHR20da2trJCQkCH7x48ePo6amBqtXr4a5uTmGDh2KqqoqRERE4LnnnoO5ubna6/v27QtXV1eV5w8ePIjBgwdj8eLFAABPT09kZ2cjMjKSCQMREZEWBE+rNDMzw9WrV9XWuXr1KkxNTQW/+KVLl+Dl5aWUGAQEBKCmpgapqamC22lObW0trly5glGjRimV+/v7IyMjA5WVla1qn4iIqCsRnDD4+voiLS0N33zzDaqqqpTOVVVV4ZtvvkF6ejqGDRsm+MVzcnLQt29fpTJbW1uYmJggNzdX4/W7du3CvHnz8Oqrr2Lfvn2oqalRnMvPz0d9fT3s7e2VrrG3t4dcLhfUPhERET0g+JHECy+8gNTUVPz00084efIkHB0d0b17d5SUlCAzMxNVVVWws7PD/PnzBb94RUUFJBJJk3KJRILy8nKV1xkbG2PSpEnw8vKCmZkZUlJScOjQIeTn52Pt2rUAoLj+0fYtLCwUr92cmJgYxMTEAABCQkJga2sr+P1o8qfOWqKOQJf3BnVN+rmH+EnUmbTnPSQ4YejevTv+7//+D9999x3Onj2LtLQ0xTmxWIwJEyZg/vz56NatW5sE+jBra2ssWbJEcezh4QErKyt89dVXyMzMhKOjY4vbDgwMRGBgoOK4sLCwNaFSJ8Z7g1qL9xC1lq7voUd7/R8mOGEAgG7duuG1117DK6+8gpycHFRWVsLc3Bz29vYwNDTUOjCJRNLsWIKKigpFT4BQTz75JL766ivcvHkTjo6OiusfbV9VzwMRERGpplXC0MjQ0BD9+/dv9Yvb29sjJydHqaywsBDV1dVqsxx1RCIRAKBXr14wNDRETk6O0poSubm5EIlELW6fiIioK9J686m6ujpcunQJR44cUdpvoqamBiUlJWhoaBDclre3Ny5fvqw0iDI+Ph5isbjJwlGaNE7nbFwnwtjYGJ6enk2mecbHx8PV1VXjlE0iIiL6L616GC5duoTdu3ejuLhYUda4b0RmZibef/99rFy5EqNHjxbUXlBQEI4ePYpPP/0U06ZNQ0FBASIiIjB16lSlL/SVK1fC3d0dS5cuBQCEh4dDJpNh0KBBMDMzQ1paGg4fPgw/Pz888cQTiutmzZqF4OBgfP311xgxYgSkUimkUinWrVunzdsmIiLq8gQnDDdu3MDmzZvRrVs3LFy4ENevX0dcXJzivKurK+zs7HDu3DnBCYOFhQU++OAD7NmzB5s2bYJEIsEzzzyDuXPnKtVraGhQ6rmwt7dHdHQ0Tpw4gZqaGtja2uK5557DzJkzla5zc3PDqlWrEBYWhmPHjsHOzg5vvPEGF20iIiLSkuCE4eDBgxCLxQgJCYGVlVWzu1k6OTnh1q1bWgXg4ODQ7EZXD9u5c6fScUBAAAICAgS17+fnBz8/P61iIiIiImWCxzBcvXoVI0aMgJWVlco6tra2So8riIiIqHMQnDDIZLImmzs9qrq6WqtBj0RERPR4EJww2NjY4M6dO2rrZGZmolevXq0OioiIiDoWwQlD4xTI9PT0Zs9LpVJkZGTA19dXZ8ERERFRxyB40OOMGTMQHx+Pf/zjH5g8eTLu3r0LALh48SJSU1Px66+/wsrKClOnTm2zYImIiEg/BCcMNjY2ePfdd7F161ZER0cryjdt2gTgwcqKa9as0TjOgYiIiB4/Wi3cNHDgQGzbtg0XL15ERkYGysrKYG5uDhcXF4wYMaJF+0kQERFRx6f1XhIGBgYYPnw4hg8f3hbxEBERUQckeNDjhg0bcOrUKbV1Tp8+jQ0bNrQ6KCIiIupYBCcMqampioGOqhQWFiI1NbXVQREREVHHovVulerU1NRwHAMREVEnpPUYhubI5XIUFhZCKpWiR48eumiSiIiIOhC1CcO8efOUjiMiIprddOphM2bMaH1URERE1KGoTRgGDx4MkUgE4MEYBltbW9jZ2TWpZ2BgAAsLCwwZMgTjx49vm0iJiIhIb9QmDMHBwYq/582bh6effhqzZ89u65iIiIiogxE8hmHHjh2QSCRtGQsRERF1UIIThp49e7ZlHERERNSBaT1LoqioCH/88Qfu37+Purq6ZuvwsQUREVHnolXCEB4ejh9//BH19fVq6zFhICIi6lwEJwxnzpzBwYMH4enpiUmTJiE0NBRjx46Fl5cXUlJS8Ntvv+HJJ59EUFBQW8ZLREREeiA4YTh27BhsbGywbt06xWqOdnZ2CAgIQEBAAPz8/BASEoKAgIA2C5aIiIj0Q/DS0Ldv34aPj4/S0s8NDQ2Kv729veHl5YXo6GjdRkhERER6JzhhqK+vR7du3RTHYrEYlZWVSnX69euHzMxMnQVHREREHYPghMHa2hpFRUWKY1tbW2RlZSnVKSoq4uZTREREnZDghMHR0RF37txRHHt4eCA9PR2nT5+GTCbDxYsXkZCQgAEDBrRJoERERKQ/ghOGYcOG4c6dOygoKAAATJ8+Hebm5ti5cycWLlyITZs2AWi6YRURERE9/gTPkhg3bhzGjRunOLa1tcXHH3+M6Oho5Ofno2fPnpg0aRL69+/fFnESERGRHmm90uPD7OzssGTJEl3FQkRERB1UqxIGXcjOzsbevXuRkZEBiUSC8ePHY86cOTAwUP205Pr16zh27BjS0tJQVFSEHj16YPTo0Zg2bRrEYrGiXnh4OCIjI5tcv27dOnh7e7fF2yEiIuqUtE4YGhoacP/+fbV7Sbi7uwtqq7y8HBs3boSDgwPWrl2LvLw8fPvtt5DL5Xj++edVXhcfH4/8/HxMmzYNffr0QVZWFsLCwpCVlYU1a9Yo1TU3N8e6deuUyhwcHATFR0RERA9olTAcPnwY0dHRKC0tVVsvLCxMUHvHjx9HTU0NVq9eDXNzcwwdOhRVVVWIiIjAc889B3Nz82avmz59OiwtLRXHHh4eEIvF+OKLL3D37l2lnTUNDQ3h6uoqKB4iIiJqnuCEITw8HAcPHoSFhQXGjh0LGxubVq+5cOnSJXh5eSklBgEBAdi/fz9SU1MxfPjwZq97OFlo5OjoCODBWhDcipuIiEi3BCcMv/32G+zs7LBp0yaVv/y1lZOTAw8PD6UyW1tbmJiYIDc3V6u2MjIyIBKJ0KtXL6XyiooKLFmyBJWVlejXrx9mzZqFkSNHtjp2IiKirkRwwlBWVoagoCCdJQvAgy9ziUTSpFwikaC8vFxwO8XFxYiKisKYMWPQvXt3RXnv3r3x4osvwtHRETKZDMePH0doaChWr16tMmmIiYlBTEwMACAkJAS2trZavivV/tRZS9QR6PLeoK5JP/cQP4k6k/a8hwQnDL1790ZFRUVbxtIidXV12Lp1K0xNTbFw4UKlc2PGjFE6HjZsGN577z1ERkaqTBgCAwMRGBioOC4sLNR90NQp8N6g1uI9RK2l63uob9++Ks8JXulx4sSJuHDhAoqLi3URE4AHPQmPbmAFPOh5sLCw0Hi9XC7Hjh07cOfOHfzv//6vxmtEIhFGjhyJ27dvK+20SUREROoJ7mGYOHEi/vzzT7z//vuYNWsWBg4cqPLxhNAuEnt7e+Tk5CiVFRYWorq6Wm2W0+jrr79GUlIS3n//fdjb2wt6TSIiItKeVtMqn3jiCcTGxmL37t0q64hEIhw4cEBQe97e3jh8+DCqqqpgZmYG4MEaC2KxWONaDj/88AN++eUXvPXWW3BzcxP0enK5HImJiXB0dFS7MBQREREpE5wwnDhxAl988QUMDQ3h4eEBa2vrVk+rDAoKwtGjR/Hpp59i2rRpKCgoQEREBKZOnarUe7Fy5Uq4u7tj6dKlAICzZ8/i+++/x7hx42BjY4OMjAxF3d69eyumXa5fvx4jR46Evb09qqurceLECVy/fh1vv/12q+ImIiLqagQnDNHR0ejevTv+8Y9/wM7OTicvbmFhgQ8++AB79uzBpk2bIJFI8Mwzz2Du3LlK9RoaGpTGHFy+fBkAEBsbi9jYWKW6y5YtU2yS1bt3b/z8888oKiqCgYEBBgwYgHfeeQc+Pj46iZ+IiKirEJww3L17FxMmTNBZstDIwcEB69evV1tn586dSsfLly/H8uXLNbbd2CNBRERErSP4Qb6NjY3KvSOIiIiocxOcMIwdOxZSqRRVVVVtGQ8RERF1QIIThhkzZsDZ2RkbN25ESkoKEwciIqIuRPAYhhdeeEHx94cffqiynjbTKomIiOjxIDhhGDx4MEQiUVvGQkRERB2U4IQhODi4DcMgIiKijozLHRIREZFGTBiIiIhII5WPJCIjIwEAkydPhoWFheJYiNmzZ7c+MiIiIuowVCYMERERAAB/f39YWFgojoVgwkBERNS5qEwYGpdrbtyqWtPyzURERNR5qUwYHt1eWtN200RERNR5CR70eOrUKWRlZamtc/v2bZw6darVQREREVHHIjhh2LVrF5KSktTWOX/+PHbt2tXqoIiIiKhj0em0yoaGBq4GSURE1AnpNGHIzc2FRCLRZZNERETUAahdGvrRxwtJSUkoKChoUq+hoQH37t1DWloafH19dRshERER6Z3ahOHRAYyZmZnIzMxUWd/FxQULFy7USWBERETUcahNGHbs2AEAkMvlWLlyJaZMmYIpU6Y0qWdgYACJRAJTU9O2iZKIiIj0Sm3C0LNnT8Xfs2fPhoeHh1IZERERdQ2Ct7eeM2dOW8ZBREREHZjghOHWrVvIyMjAU089BXNzcwCATCbDV199hfPnz8PExATTpk1r9pEFERERPd4ET6s8dOgQoqKiFMkCAHz33Xc4c+YM5HI5ysrKsG/fPly+fLlNAiUiIiL9EZww3LhxAx4eHorjuro6nDp1Cs7Ozvjyyy+xY8cOWFpa4ujRo20SKBEREemP4IShtLQUPXr0UBzfvHkTMpkMgYGBEIvFsLGxwfDhwzXuN0FERESPH61Weqyvr1f8nZ6eDkB5F0tLS0uUlpbqKDQiIiLqKAQnDLa2trh27ZriOCkpCT169ECvXr0UZUVFRbCwsNBthERERKR3gmdJjBo1ChEREQgNDYWxsTEyMjLwzDPPKNXJyclRSiCIiIiocxCcMEydOhWXL1/GuXPnAACOjo6YPXu24nxBQQGuX7+OGTNmaBVAdnY29u7di4yMDEgkEowfPx5z5syBgYH6zo/Kykp8/fXXSEpKQkNDA4YNG4ZFixahW7duSvWSkpJw4MAB5OXlwc7ODnPmzIG/v79WMRIREXV1ghMGU1NTbNy4Ebdv3wYAODg4NPlSX7NmDZycnAS/eHl5OTZu3AgHBwesXbsWeXl5+PbbbyGXy/H888+rvXbr1q3Izc3Fa6+9BgMDA+zfvx+bN2/Ghx9+qKiTnp6O0NBQTJw4EYsWLYJUKsW2bdsgkUjg5eUlOE4iIqKuTnDC0Kh///7NltvZ2cHOzk6rto4fP46amhqsXr0a5ubmGDp0KKqqqhAREYHnnntOac2Hh2VkZODy5csIDg5WDLq0sbHBunXrkJycjKFDhwIADh48iMGDB2Px4sUAAE9PT2RnZyMyMpIJAxERkRbU9vunpqaisLBQcGNZWVlNdrhU59KlS/Dy8lJKDAICAlBTU4PU1FSV10mlUnTv3l1phoazszPs7Oxw6dIlAEBtbS2uXLmCUaNGKV3r7++PjIwMVFZWCo6TiIioq1ObMGzYsAGxsbFKZT/++KPiF/ujzp07h127dgl+8ZycHPTt21epzNbWFiYmJsjNzVV7nb29fZNye3t75OTkAADy8/NRX1/fpJ69vT3kcrna9omIiEiZ1o8kamtrUVFRoZMXr6iogEQiaVIukUhQXl6u9rrmHldIJBIUFBQAgOL6R9tvnPap6j3ExMQgJiYGABASEtIkoWmNvvt/1llb1DUd+99Z+g6BHnOLXtfdZxp1LVot3NQVBAYGIiQkBCEhIfoO5bH1zjvv6DsEeszxHqLW4j2ke3pNGCQSSbNjCSoqKtQuACWRSFBVVdXsdY09Co3XP9q+qp4HIiIiUk2vCcPDYw4aFRYWorq6Wu2jgOauA4Dc3FzFmIVevXrB0NCwSb3c3FyIRCKdPmogIiLq7PSaMHh7e+Py5ctKvQXx8fEQi8VKMyAe5ePjg+LiYsV+FsCD3TTz8/Ph7e0NADA2NoanpycSEhKUro2Pj4erq6vKKZvUeoGBgfoOgR5zvIeotXgP6Z5eE4agoCAYGxvj008/RXJyMmJiYhAREYGpU6cqfaGvXLkSu3fvVhy7urrCy8sLO3bsQGJiIs6dO4d//vOfcHNzU6zBAACzZs1CSkoKvv76a6SkpOA///kPpFKp0gqVpHv8H5Vai/cQtRbvId0TyeVyuaqT8+bNa1GjYWFhgutmZ2djz549SktDz507V2kVyeXLl8Pd3R3Lly9XlFVUVGDfvn04d+4c5HI5fH19sWjRIlhaWiq1f+7cOYSFheHPP/9ULA0dEBDQovdFRETUVek9YSAiIqKOT23CQPSo2NhY7Nq1C8uWLcO4ceP0HQ51YCkpKdiwYQNmz56NuXPnAgDmzp0Ld3d3BAcH6zc4eqzxc0g/uA4DERERacQeBtJKZWUlioqKYG1tzZkmpFZ1dTUKCwvRrVs3xdiinJwcmJiYwNbWVs/R0eOMn0P6wYSBiIiINNJ6Lwnq3OLi4nD06FH8+eefkMlksLS0xMCBAzFr1iwMHDiw2WeHBQUFWLFiBcaOHYspU6bgP//5D65duwZDQ0N4e3tjwYIFsLGxUXqd69evIyoqCjdu3EBZWRkkEgn69u2LoKAgjB49Wg/vnHRN6BiG4OBgpKam4ttvv8V3332HhIQElJeXo3///pg9ezaGDRum1G55eTkOHTqEc+fO4d69ezAyMoKNjQ08PT3x0ksvwciIH2udwcP3j7u7OyIiInDr1i306tULzzzzDD+H9IBjGEjh6NGj2LZtG0pKShAQEIApU6bA3d0dN27cQEZGhsbr8/PzERwcDCMjI0yePBmurq6Ii4vD+++/r7SZ2M2bN/H+++8jLS0NXl5emDp1KoYNG4aqqiqcO3euLd8idWBbtmzBxYsXERAQgLFjxyI3NxeffPKJ0uJrcrkcH330EQ4fPoxevXph8uTJGDt2LHr27IkTJ06grq5Oj++A2sLVq1fx0UcfwdzcHBMnTsSQIUPU1ufnUNthKk4KsbGxsLa2xqeffgoTExNFeUNDQ7N7fjwqPT0dc+fOVVoYKzIyEuHh4YiMjMTLL78MADhz5gzq6+uxfv16ODo6KrVRVlamk/dCj5979+5h8+bNMDU1BQBMnToVa9euxZ49ezB8+HAYGRnh9u3buHHjBqZMmaK4nxpVVFRALBbrIXJqS3/88QfeeOMNpV/8sbGxKuvzc6jtsIeBlBgbG8PQ0FCpzMDAQO1mYI0sLCzw7LPPKpU9++yzkEgkOHv2bJP6jV8MD+vWrZuWEVNnMWPGDKV7om/fvhgzZgxKSkqQnJysVLe5e0cikSgt+Eadg5OTk1aPB/g51Hb4fxcpjBo1CgUFBVi9ejXCw8ORkpKCmpoawdcPGDBAqWcCAExMTDBgwACUlpaiqKhI8ToikQjr1q3D3r17kZSUpNRVSF2Tm5ubyrKsrCwAgIODA/r164cffvgBISEhOHbsWLMb0VHnMXDgQK3q83Oo7fCRBClMmzYNEokEx44dQ2RkJCIjI2FiYoKnnnoKCxYsgJmZmdrrVWXljVPqqqqqYG1tDVdXV3zwwQeIiorC8ePH8csvv0AkEsHLywsvv/wydxLtoh5d1v3hssYN6gwNDbF+/XqEhYUhMTERFy9eBPBgd9rZs2dj7Nix7RcwtYvu3btrVZ+fQ22HCQMpiEQiBAUFISgoCMXFxbhy5QpOnDiBmJgY1NTUYMWKFWqvV/Xcr7S0FACUEg4PDw94eHhAJpMhPT0dv//+O2JjY/Hxxx9j69atHOneBZWWlqJHjx5NygDle8fS0hJ/+9vfsGTJEty+fRuXLl3Czz//jJ07d8LGxkbjoDjq3Pg51Hb4SIKaZWVlhdGjR+O9996DjY0NLly4oPGaW7duobq6Wqmsuroat27dgqWlJaytrZtcY2pqCm9vbyxduhSjRo1Cfn4+srOzdfY+6PHx8Hb1j5Y98cQTTc4ZGBjA0dER06dPx7JlywBA0H1KnRs/h9oOEwZSSE1NbVImk8lQXV0tKNMuLy9HdHS0Ull0dDQqKiqUBi1lZGSgtrZWqZ5cLkdJSQmABwMvqev54YcfIJPJFMe5ubk4ffo0unfvrti2vqCgAHfv3m1ybXFxMQDeO8TPobbE/hZS+OSTTyCRSODi4gJbW1tUV1fj/PnzqKiowAsvvKDxejc3N0RHR+PatWt44oknkJWVBalUip49eypNcfrxxx+RlpaGwYMHw87ODgYGBkhLS8ONGzfg4+MDe3v7tnyb1EH16NEDb7/9NkaMGAGZTIb4+HjU1tZixYoVioQ1MzMToaGhcHV1hb29PSwtLZGXl4fz58/DzMwM48eP1/O7IH3j51DbYcJACi+88AIuXryIq1evIikpCebm5nBwcMCiRYvg5+en8fpevXrh5Zdfxv79+/HLL7/AwMAA/v7+WLBggdK0zIkTJ8Lc3BzXrl3DH3/8AUNDQ9jZ2eGll17CxIkT2/ItUge2atUqfPfddzh79iwqKirg4OCAOXPmYPjw4Yo6Tk5OeO6553DlyhUkJSVBJpPBxsYGY8aMwfTp09G7d289vgPqCPg51Ha4lwS12sNLsi5fvlzf4dBjpnFp6PDwcH2HQo8xfg61PY5hICIiIo2YMBAREZFGTBiIiIhII45hICIiIo3Yw0BEREQaMWEgIiIijZgwEBERkUZMGIioQ0tJScHcuXMxd+5cfYdC1KVxpUcigWpqanDq1ClcuHABWVlZKC0thZGREWxsbODm5oaAgAB4enqqbWP58uXN7oVgamqKnj17YvDgwZg8eTIcHBya1Glc4EgId3d3BAcHC6qrKbbm6GJxnIqKCvz0008AgGeeeQYSiaRV7XVEsbGxKCgoUOyKSPQ4Y8JAJEBycjJ2796Ne/fuKcrMzMxQV1eHnJwc5OTk4MSJE/Dx8cGKFSvQrVs3te0ZGxvD3NwcwIMNb8rKynDnzh3cuXMHJ06cwN/+9jeV+yIYGhoqLXHbHE3nhcamiqbzQlRUVCAyMhIAMG7cOJUJg4mJCfr27dvq19OH2NhYRZLHhIEed0wYiDSIj4/H9u3bUV9fDxsbG8ydOxd+fn6KL+WcnBwcP34cv/76K6RSKd59911s3LgR3bt3V9mmv7+/0i/0mpoaXLhwAXv37kVJSQm++OILODk5Nbut86BBg7TuPdDGo7Hpm7OzMz777DN9h0HU5XEMA5Ea2dnZ2L17N+rr69G/f3988sknGD9+vNIveHt7e7z88st4++23YWRkhLy8PPzzn//U6nXEYjFGjRqFlStXAgAaGhpw7Ngxnb4XIqLWYA8DkRoHDhxAdXU1jI2NsWrVKlhaWqqs6+vri5kzZyI8PBx//PEHLl68CF9fX61eb+jQobC2tkZRURFu3LjR2vDb1b179xAdHY3k5GTcvXsX9fX16NatG6ysrDB48GCMHj0azs7OAJqOx1ixYoVSWw+PwUhJScGGDRsAoMkGVbGxsdi1axd69uyJnTt3Ii0tDYcOHcL169dRXV2NPn36YPLkyUqPdy5evIiffvoJmZmZqK6uRr9+/fDss8/C39+/2fdVUFCA+Ph4pKSkoKCgAPfv3wcA2NrawsvLC1OnToWtrW2zcTWKjIxUPH5ptGPHDtjZ2SmOGxoaEBsbizNnzuD27duoqqpCt27dMGjQIEyaNEnlI43Gf5ezZ8/GzJkzcfToUcTFxSEvLw+VlZVYv3694tqcnBwcOXIEqampuHfvHuRyOSwtLWFjYwMPDw+MHTuW2zqTSkwYiFQoKipCUlISACAgIEDQc/SpU6ciOjoaVVVV+PXXX7VOGADAxsYGRUVFqKqq0vpafcnMzMSGDRtQUVEBADAwMICZmRmKi4tRVFSEW7duoaKiQpEwWFhYoFu3bigrKwMAdOvWDQYG/+3wbMkYjBMnTuCLL74A8GB8SXV1NTIzM/H5558jLy8PL7zwAsLDwxEZGQmRSAQzMzPU1NTgxo0b+Oyzz1BeXt7stsa7du1SJDdGRkYwMzNDeXm5YuxKbGws3nnnHbi5uSmuEYvF6N69O8rLy1FfXw8TExOYmpoqtfvw+62srMTmzZuRkpLS5N9fQkICEhIS8Oyzz2LBggUq339tbS02bNiAq1evwtDQEKamphCJRIrzycnJ2LRpE2prawFAUefevXu4d+8erl27BiMjI85GIZWYMBCpkJKSgsaV00eOHCnoGlNTUwwdOhSJiYlIS0tDfX09DA0NtXrdxpkKrRm42N6+/fZbVFRUYMCAAViyZAlcXFwgEolQV1eHu3fv4vz583h4Ffo1a9YotiMGgI8//ljp17a2SktLsWfPHkyePBmzZs2CpaUlysvLsW/fPpw6dQqHDh2CRCJBVFQUnn/+eUyePBnm5uYoKirC7t27cenSJXz77bcYPXp0kwGdjo6OGDVqFIYOHYpevXrBwMAA9fX1uHXrFsLDw3Hp0iVs3boV27dvh1gsBvBgHIi/v7/i1/+zzz6r9ot49+7dSElJgZGRERYsWIDx48fDxMQExcXF+P777/Hbb78hOjoavXr1ajapAYBff/0VALBs2TL4+/tDLBajrKxMkTR8+eWXqK2thZeXFxYsWID+/fsDeDB+Jj8/H4mJiU16SogexoSBSIXs7GzF3wMGDBB8naOjIxITEyGTyXD37l307t1b8LUJCQkoLS0FALi4uDRb5+rVq/jb3/6mtp1Fixap7GLXJD4+HpcuXVJbZ82aNRg0aJBSTACwZMkSuLq6KsqNjIzQp08fPPvssy2KRajq6mqMHz8eixYtUpRZWFhg6dKlSEtLQ0FBAfbv34/nn38eM2fOVNSxtrbGm2++iddeew3V1dU4f/48xowZo9T2yy+/3OT1DA0N4ezsjHfeeQd///vfkZWVhYSEhCbXCnHt2jUkJiYCABYvXozAwEDFOSsrKyxduhSVlZVITExEWFgYxo0bp0hMHiaTybB27VoMHz5cUdY4W6ekpAT5+fkAHiQU1tbWijpisRj9+vVDv379tI6duhYOeiRSobG7HNDu1/7DUyrLy8s11pfL5bh79y6OHj2K3bt3A3jwRTtp0qRm69fX16OkpETtPzU1NYLjfVRtba3G9uvq6pSuaZwSWVRU1OLXba3p06c3KTMwMFCsjWFsbIwpU6Y0qWNubq5Icm7fvq3VaxoYGMDLywsAkJ6ermXED8THxwMAevTooXIq7bx58wA8uCeTk5ObrdOvXz+lZOFhZmZmip4Gff43oscbexiI9ODUqVM4depUs+dMTU2xfPly9OnTp9nzLVmUSRstWZTJ19cXJ06cwM6dO3H16lUMHz4cTk5OMDExaaMolVlYWKjsybGysgIAODg4NBlH0KhxCqyqBC8tLQ0nT57EtWvXcO/ePVRXVzep0zgYUls3b94E8GCdhofHNTzMwcEBNjY2uH//Pm7evNlsYvBwj8+jxGIxhgwZguTkZPzf//0fgoKC4OvriwEDBsDIiF8DJAzvFCIVHu0psLGxEXSdkJ6JhxdHEolEMDExga2tLQYPHowJEyagR48erYi8/b344ovIy8tDSkoKjhw5giNHjsDAwACOjo7w9fVFYGCg4H9/LWFmZqbyXOOXsLo6jeNM6uvrm5z7z3/+g8OHDyu1J5FIFF+0MpkM1dXVzSYRQpSUlACAxn8/PXr0wP379xX1H6VuBg8AvP7669i0aROysrJw8OBBHDx4EEZGRnBycsKIESOaTBcmehQTBiIVHl6e+ebNm4K/8G7dugXgv8s9N6ejLY7UWhKJBOvXr0d6ejrOnz+Pq1ev4ubNm4p/Dh8+jNdffx2jR4/Wd6haSU5OViQLEydOxMSJE+Hg4KDUE3DgwAFERUUpDerUB1W9E41sbW2xadMmJCcnQyqV4urVq8jKysLVq1dx9epV/PDDD1i9erXG5c2p62LCQKSCh4cHRCIR5HI5EhMTVT4ffphMJsMff/wBABg8eLDWMyQed25uborphTU1NUhOTsaBAwdw+/Zt7N69G56enopHBI+DuLg4AICXlxdeeeWVZusUFxe36jW6d++O3NxcpWXHm9N4Xt0KopoYGBjA29sb3t7eAICqqipcuHAB3333HQoLC7Ft2zbs3r2bjymoWRz0SKSCtbU1RowYAeDBwLTc3FyN1xw5ckSxfoKq6W9dhVgsxvDhw7FmzRoADwZTPjwwUNMv4o6g8Uta1SwZuVyuWDuhOQ+vg6DKwIEDATyYxtvQ0NBsnZycHMUYCScnJ41tCmVmZobRo0fj9ddfB/Dg8Yi2Az+p6+j4/8cS6dG8efMgFotRW1uLLVu2KKY8NkcqlSIqKgrAg96Jliza9Diqr69X+UUHQGkK4MNJwsNjChoXfOpoGseZZGVlNXv++PHjiumKzWl8j+reX0BAAIAHgyZPnjzZbJ2wsDAAD8bVDBkyRHPgj3h0VsujHv5vJCTJoa6JCQORGv369cPrr78OAwMD3L59G3//+99x8uRJpS+A3Nxc7Nu3D5988gnq6urQq1cv/M///E+X+eC9d+8e/ud//gcHDx7ErVu3lAYOZmVlYfv27QAe7Drp7u6uOCeRSBTjQn777bdmBxzqW2PXvVQqRWRkJGQyGYAHCUBUVBT27t2rdmfSxsWRpFKpylkUzs7OioXB9u7di19++UUxgLK4uBiff/45EhISAPw3gdXW1atXsWbNGhw5cgTZ2dmKBE8ul+Pq1av46quvADwYWNnchmdEAMcwEGk0evRoWFhYKLa3/vzzz/H555/D3NwctbW1iqV2gQfPuleuXKlxxHprCFm4CXiwsl9LCFm4ydbWFh9//LHiOD8/H2FhYQgLC4OBgQHMzc0hk8kUv2yNjIywfPnyJqPwg4KCEBYWhl9++QUnTpyApaUlDAwM4OLigjfffLNF8evSmDFjcOrUKaSlpSE8PBwREREwNzdHZWUl5HI5fH194ejoqOhZetTYsWMRHR2NvLw8LF26FJaWloov/A8//FAxG2bp0qUoKytDamoq9u7di3379sHU1FTxOgDw7LPPtuox1+3bt/HNN9/gm2++gaGhoeJ9NCZqZmZmeOONNx6LR0WkH0wYiATw9vbG9u3bERsbiwsXLiArKwtlZWUwMjJSTIcMCAhoUXexthoXbmorjQs3qfPwr1wbGxusXbsWKSkpyMjIUEz9MzQ0RO/eveHh4YEpU6Y0u67EjBkzYGZmhjNnziie08vlcpWzS9qbkZER3n33Xfz444+Ii4tTLNvt7OyMsWPHIjAwsMmmUg/r06cP1q9fjx9//BHXrl1T7C0BKE/hNDc3xwcffKDYfCozMxMymQxWVlZwdXXF5MmTVW4+JYSTkxPeeustpKSk4Pr16ygqKkJpaSmMjY3Rr18/DB06FFOmTGnTqa/0+BPJ9T0XiIiIiDo89j0RERGRRkwYiIiISCMmDERERKQREwYiIiLSiAkDERERacSEgYiIiDRiwkBEREQaMWEgIiIijZgwEBERkUZMGIiIiEij/wdscsYQNQ3nfgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 576x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_, estimated_interval_anti_optimal = ope.summarize_off_policy_estimates(\n",
     "    evaluation_policy_pscore=anti_optimal_policy_pscores[0],\n",
@@ -406,7 +479,7 @@
     "    evaluation_policy_pscore_cascade=anti_optimal_policy_pscores[2],\n",
     "    alpha=0.05,\n",
     "    n_bootstrap_samples=1000,\n",
-    "    random_state=random_behavior_dataset.random_state,\n",
+    "    random_state=dataset_with_random_behavior.random_state,\n",
     ")\n",
     "estimated_interval_anti_optimal[\"policy_name\"] = \"anti-optimal\"\n",
     "\n",
@@ -419,7 +492,7 @@
     "    evaluation_policy_pscore_cascade=anti_optimal_policy_pscores[2],\n",
     "    alpha=0.05,\n",
     "    n_bootstrap_samples=1000, # number of resampling performed in the bootstrap procedure\n",
-    "    random_state=random_behavior_dataset.random_state,\n",
+    "    random_state=dataset_with_random_behavior.random_state,\n",
     ")"
    ]
   },
@@ -443,52 +516,109 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[calc_ground_truth_policy_value (pscore)]: 100%|██████████| 10000/10000 [00:04<00:00, 2268.03it/s]\n",
+      "[calc_ground_truth_policy_value (expected reward), batch_size=3334]: 100%|██████████| 3/3 [00:01<00:00,  1.64it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1.837144428308276"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "gt_random = random_behavior_dataset.calc_ground_truth_policy_value(\n",
-    "    context=random_behavior_feedback[\"context\"],\n",
+    "ground_truth_policy_value_random = dataset_with_random_behavior.calc_ground_truth_policy_value(\n",
+    "    context=bandit_feedback_with_random_behavior[\"context\"],\n",
     "    evaluation_policy_logit_=random_policy_logit_\n",
     ")\n",
-    "gt_random"
+    "ground_truth_policy_value_random"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[calc_ground_truth_policy_value (pscore)]: 100%|██████████| 10000/10000 [00:04<00:00, 2177.17it/s]\n",
+      "[calc_ground_truth_policy_value (expected reward), batch_size=3334]: 100%|██████████| 3/3 [00:01<00:00,  1.71it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1.8474242800908984"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "gt_optimal = random_behavior_dataset.calc_ground_truth_policy_value(\n",
-    "    context=random_behavior_feedback[\"context\"],\n",
+    "ground_truth_policy_value_optimal = dataset_with_random_behavior.calc_ground_truth_policy_value(\n",
+    "    context=bandit_feedback_with_random_behavior[\"context\"],\n",
     "    evaluation_policy_logit_=optimal_policy_logit_\n",
     ")\n",
-    "gt_optimal"
+    "ground_truth_policy_value_optimal"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[calc_ground_truth_policy_value (pscore)]: 100%|██████████| 10000/10000 [00:04<00:00, 2176.73it/s]\n",
+      "[calc_ground_truth_policy_value (expected reward), batch_size=3334]: 100%|██████████| 3/3 [00:01<00:00,  1.71it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1.8352871486686428"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "gt_anti_optimal = random_behavior_dataset.calc_ground_truth_policy_value(\n",
-    "    context=random_behavior_feedback[\"context\"],\n",
+    "ground_truth_policy_value_anti_optimal = dataset_with_random_behavior.calc_ground_truth_policy_value(\n",
+    "    context=bandit_feedback_with_random_behavior[\"context\"],\n",
     "    evaluation_policy_logit_=anti_optimal_policy_logit_\n",
     ")\n",
-    "gt_anti_optimal"
+    "ground_truth_policy_value_anti_optimal"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "estimated_interval_random[\"ground_truth\"] = gt_random\n",
-    "estimated_interval_optimal[\"ground_truth\"] = gt_optimal\n",
-    "estimated_interval_anti_optimal[\"ground_truth\"] = gt_anti_optimal\n",
+    "estimated_interval_random[\"ground_truth\"] = ground_truth_policy_value_random\n",
+    "estimated_interval_optimal[\"ground_truth\"] = ground_truth_policy_value_optimal\n",
+    "estimated_interval_anti_optimal[\"ground_truth\"] = ground_truth_policy_value_anti_optimal\n",
     "\n",
     "estimated_intervals = pd.concat(\n",
     "    [\n",
@@ -501,9 +631,132 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean</th>\n",
+       "      <th>95.0% CI (lower)</th>\n",
+       "      <th>95.0% CI (upper)</th>\n",
+       "      <th>policy_name</th>\n",
+       "      <th>ground_truth</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>sips</th>\n",
+       "      <td>1.836816</td>\n",
+       "      <td>1.820500</td>\n",
+       "      <td>1.852505</td>\n",
+       "      <td>random</td>\n",
+       "      <td>1.837144</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>iips</th>\n",
+       "      <td>1.836816</td>\n",
+       "      <td>1.820500</td>\n",
+       "      <td>1.852505</td>\n",
+       "      <td>random</td>\n",
+       "      <td>1.837144</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rips</th>\n",
+       "      <td>1.836816</td>\n",
+       "      <td>1.820500</td>\n",
+       "      <td>1.852505</td>\n",
+       "      <td>random</td>\n",
+       "      <td>1.837144</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sips</th>\n",
+       "      <td>1.830555</td>\n",
+       "      <td>1.803695</td>\n",
+       "      <td>1.860548</td>\n",
+       "      <td>optimal</td>\n",
+       "      <td>1.847424</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>iips</th>\n",
+       "      <td>1.843117</td>\n",
+       "      <td>1.825576</td>\n",
+       "      <td>1.859695</td>\n",
+       "      <td>optimal</td>\n",
+       "      <td>1.847424</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rips</th>\n",
+       "      <td>1.838866</td>\n",
+       "      <td>1.815574</td>\n",
+       "      <td>1.862451</td>\n",
+       "      <td>optimal</td>\n",
+       "      <td>1.847424</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sips</th>\n",
+       "      <td>1.854516</td>\n",
+       "      <td>1.829643</td>\n",
+       "      <td>1.877320</td>\n",
+       "      <td>anti-optimal</td>\n",
+       "      <td>1.835287</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>iips</th>\n",
+       "      <td>1.832793</td>\n",
+       "      <td>1.815842</td>\n",
+       "      <td>1.848599</td>\n",
+       "      <td>anti-optimal</td>\n",
+       "      <td>1.835287</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rips</th>\n",
+       "      <td>1.844397</td>\n",
+       "      <td>1.824965</td>\n",
+       "      <td>1.864795</td>\n",
+       "      <td>anti-optimal</td>\n",
+       "      <td>1.835287</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          mean  95.0% CI (lower)  95.0% CI (upper)   policy_name  ground_truth\n",
+       "sips  1.836816          1.820500          1.852505        random      1.837144\n",
+       "iips  1.836816          1.820500          1.852505        random      1.837144\n",
+       "rips  1.836816          1.820500          1.852505        random      1.837144\n",
+       "sips  1.830555          1.803695          1.860548       optimal      1.847424\n",
+       "iips  1.843117          1.825576          1.859695       optimal      1.847424\n",
+       "rips  1.838866          1.815574          1.862451       optimal      1.847424\n",
+       "sips  1.854516          1.829643          1.877320  anti-optimal      1.835287\n",
+       "iips  1.832793          1.815842          1.848599  anti-optimal      1.835287\n",
+       "rips  1.844397          1.824965          1.864795  anti-optimal      1.835287"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "estimated_intervals"
    ]
@@ -519,16 +772,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>relative-ee</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>sips</th>\n",
+       "      <td>0.000296</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>iips</th>\n",
+       "      <td>0.000296</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rips</th>\n",
+       "      <td>0.000296</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      relative-ee\n",
+       "sips     0.000296\n",
+       "iips     0.000296\n",
+       "rips     0.000296"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# evaluate the estimation performances of OPE estimators \n",
     "# by comparing the estimated policy values and its ground-truth.\n",
     "# `summarize_estimators_comparison` returns a pandas dataframe containing estimation performances of given estimators \n",
     "\n",
     "relative_ee_for_random_evaluation_policy = ope.summarize_estimators_comparison(\n",
-    "    ground_truth_policy_value=gt_random,\n",
+    "    ground_truth_policy_value=ground_truth_policy_value_random,\n",
     "    evaluation_policy_pscore=random_policy_pscores[0],\n",
     "    evaluation_policy_pscore_item_position=random_policy_pscores[1],\n",
     "    evaluation_policy_pscore_cascade=random_policy_pscores[2],\n",
@@ -538,16 +844,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>relative-ee</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>sips</th>\n",
+       "      <td>0.009303</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>iips</th>\n",
+       "      <td>0.002470</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rips</th>\n",
+       "      <td>0.004732</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      relative-ee\n",
+       "sips     0.009303\n",
+       "iips     0.002470\n",
+       "rips     0.004732"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# evaluate the estimation performances of OPE estimators \n",
     "# by comparing the estimated policy values and its ground-truth.\n",
     "# `summarize_estimators_comparison` returns a pandas dataframe containing estimation performances of given estimators \n",
     "\n",
     "relative_ee_for_optimal_evaluation_policy = ope.summarize_estimators_comparison(\n",
-    "    ground_truth_policy_value=gt_optimal,\n",
+    "    ground_truth_policy_value=ground_truth_policy_value_optimal,\n",
     "    evaluation_policy_pscore=optimal_policy_pscores[0],\n",
     "    evaluation_policy_pscore_item_position=optimal_policy_pscores[1],\n",
     "    evaluation_policy_pscore_cascade=optimal_policy_pscores[2],\n",
@@ -557,16 +916,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>relative-ee</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>sips</th>\n",
+       "      <td>0.010281</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>iips</th>\n",
+       "      <td>0.001506</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rips</th>\n",
+       "      <td>0.004751</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      relative-ee\n",
+       "sips     0.010281\n",
+       "iips     0.001506\n",
+       "rips     0.004751"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# evaluate the estimation performances of OPE estimators \n",
     "# by comparing the estimated policy values and its ground-truth.\n",
     "# `summarize_estimators_comparison` returns a pandas dataframe containing estimation performances of given estimators \n",
     "\n",
     "relative_ee_for_anti_optimal_evaluation_policy = ope.summarize_estimators_comparison(\n",
-    "    ground_truth_policy_value=gt_anti_optimal,\n",
+    "    ground_truth_policy_value=ground_truth_policy_value_anti_optimal,\n",
     "    evaluation_policy_pscore=anti_optimal_policy_pscores[0],\n",
     "    evaluation_policy_pscore_item_position=anti_optimal_policy_pscores[1],\n",
     "    evaluation_policy_pscore_cascade=anti_optimal_policy_pscores[2],\n",
@@ -583,7 +995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,9 +1006,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1.7, 1.9)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAoAAAADQCAYAAACX3ND9AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAt8klEQVR4nO3deVQUd7o+8KfZxQakWUUWFeKCXnFHERUNwzXxumRETNxHvS7RuMRj3FASl4QYNRoUNXGJmjFGjZngcWIyOHrFJWgkuKFG3BBQDCACYW34/v7gZ00Q0AZ6g3o+53gO1dVd9X6762nfruqqVgghBIiIiIhINkwMXQARERER6RcbQCIiIiKZYQNIREREJDNsAImIiIhkhg0gERERkcywASQiIiKSGTaAeqRQKJCcnAwAmD59OlauXGngiggATp48CXd3d0OXIWvMhnFQKpW4c+eO1pf75ZdfIjAwUOvLbSi4fRuH1157Dbt379bLulJSUqBUKlFWVqb1Zb///vsYO3ZsvZdjpoVaqA62bt1q6BKIjBKzoR9BQUEYO3YspkyZIt2Wn59vwIrkgdu3frz//vtITk7GV199Jd32ww8/6Gx9LVu2xPbt2xEcHAwA8PT0NPo8cQ8gNTi6+ERFREQkJ2wAa6lly5b46KOP4OvrC3t7e/ztb39DUVGRNP+LL76Aj48PVCoVhg4divT09GqXM3HiRISHh0vT33//PTp37gxbW1t4e3vj2LFjOHjwILp161bpcevXr8ewYcNeWOPEiRMxc+ZMDB48GDY2NvD398ft27el+XPmzIGHhwdsbW3RrVs3xMXFSfPef/99jBw5EmPHjoWNjQ3+67/+C7/99hs++ugjODs7w8PDAz/99JN0/6dPn2Ly5Mlo3rw5WrRogfDwcK03aBMnTsSMGTPw+uuvo2nTpjhx4gSOHj2KLl26wNbWFh4eHnj//fel+9+7dw8KhQK7d++Gp6cnHB0dsXr1aml+YWEhJk6cCHt7e/j6+uLChQuV1nf9+nUEBQWhWbNm6NChA2JiYirV8vbbb+O1116DUqlEnz598OjRI8ydOxf29vZo164dfv31V62Ov6FgNvSfjadPn2L8+PFwcnKCl5cXVq1ahfLycgAVh1379OmDWbNmwc7ODu3atcPx48cBAEuXLkVcXBxmzZoFpVKJWbNmAah8qLK223pkZCS8vb1hY2MDX19ffPfdd1odq6Fx+9b/9l3X9/ljx47hww8/xDfffAOlUgk/Pz8AFXu9t2/fXuP60tPTMXToUKhUKvj4+OCLL76o9PyEhoZi1KhRsLGxQdeuXXHp0iUAwLhx45CSkoIhQ4ZAqVRizZo1Un1qtVpad3h4OAICAqBUKjFkyBBkZWVhzJgxsLW1RY8ePXDv3j1pfS96rbRGUK14eXmJDh06iJSUFJGVlSUCAgLE0qVLhRBCHD9+XDg4OIiLFy+KoqIiMWvWLNG3b1/psQDErVu3hBBCTJgwQXpcfHy8sLW1FT/99JMoKysTqamp4vr166KoqEjY29uLpKQkaRmdO3cWhw4demGNEyZMECqVSsTHx4vS0lIxevRoMWrUKGn+3r17RWZmpigtLRVr164VLi4uorCwUAghREREhLC0tBTHjh0TpaWlYty4caJly5Zi1apVoqSkRHz++eeiZcuW0rKGDx8upk6dKvLz80VGRobo0aOH2Lp1a7V1/f3vfxd2dnY1/rt//36N47G1tRWnT58WZWVlorCwUJw4cUJcvnxZlJWViUuXLglnZ2fx3XffCSGEuHv3rgAgpkyZIgoKCkRiYqKwsLCQnseFCxeKwMBAkZWVJVJSUkSHDh1EixYthBBClJSUCG9vb7F69WpRXFwsjh8/LpRKpbhx44ZUi4ODg/jll19EYWGhGDBggGjZsqXYvXu3UKvVYunSpSIoKOiFr09jxWzoPxvjxo0TQ4cOFbm5ueLu3bvilVdeEdu3bxdCCLFr1y5hamoq1q9fL0pKSsT+/fuFra2tyMrKEkII0b9/f/HFF19UWt7zr0NttvUDBw6ItLQ0UVZWJvbv3y+sra1Fenq6VEufPn1e+NoYO27f+t++6/M+HxERIcaMGVNpedVt83/Wt29fMWPGDFFYWCh+/fVX4ejoKI4fPy4tz8zMTBw8eFCUlJSITz75RLRs2VKUlJQIISq2j3/961/Ssp7VV1paKq3b29tbJCcni5ycHNG+fXvxyiuviH/961/S8z1x4kSNX6vnx1YXbABrycvLS2zZskWaPnr0qGjdurUQQohJkyaJBQsWSPPy8vKEmZmZuHv3rhCi5jeBqVOnirlz51a7vunTp4slS5YIIYS4evWqaNasmSgqKnphjRMmTBCTJ0+uVGPbtm1rvH+zZs1EYmKiEKJiwwoODpbmxcTEiKZNmwq1Wi2EECI3N1cAEE+ePBGPHj0SFhYWoqCgQLr/vn37tN4ATZgwQYwbN+6F95kzZ470HD4L3oMHD6T5PXr0EF9//bUQQohWrVqJH374QZq3bds2qQE8deqUcHFxEWVlZdL8N998U0REREi1TJkyRZr32WefiXbt2knTly9fFnZ2dnUbaAPHbOg3G2q1Wpibm4tr165Jt23dulX0799fCFHRdDVv3lyUl5dL83v06CH27NkjhNCsAazPtu7n5yf+8Y9/SLU0hgaQ27d+3/ufV5v3+do2gCkpKcLExETk5uZKty1atEhMmDBBWp6/v780r6ysTLi6uopTp04JITRrAFetWiXNf/fdd8WgQYOk6ZiYGOHn51fj2J9/rbTRAPIQcB14eHhIf3t5eUm7+tPT0+Hl5SXNUyqVcHBwQFpa2guX9+DBA3h7e1c7b8KECdi3bx+EENi7dy/CwsJgaWn50hpdXV2lv62trSt9GXXt2rVo37497Ozs0KxZMzx9+hSZmZnSfBcXF+nvJk2awNHREaamptI0UPFl8fv376O0tBTNmzdHs2bN0KxZM0ybNg2PHz9+aX219efnHADi4+MxYMAAODk5wc7ODlu3bq00BqDm5yA9Pb3Ka/jMs3kmJiaV5v/5NXz++Xl+2ti/+KtLzIb+spGZmYnS0tJKz+vz22qLFi2gUCgqza/p0GR1arOt79mzB507d5bGe/Xq1SqZbOi4fev3vb8+7/Mv06FDByiVSiiVSsTFxSE9PR0qlQo2NjbSfZ7P059ffxMTE7i7u+ssTy97rbSBDWAdPHjwQPo7JSUFbm5uAAA3Nzfcv39fmvfHH38gKysLLVq0eOHyPDw8Kn1P48969eoFCwsLxMXFYd++fRg3bly9ao+Li8OaNWtw4MABPHnyBDk5ObCzs4MQotbL8vDwgKWlJTIzM5GTk4OcnBzk5ubi2rVr1d7/73//uxS46v6lpKTUuK4//ycGAKNHj8bQoUPx4MEDPH36FNOnT9d4DM2bN6/yGj7j5uaGBw8eSN+jejb/Za8hVWA2/lO3rrPh6OgIc3PzSs/r89tqWlpapfr//Jo8n6n6uH//Pv73f/8XmzZtQlZWFnJyctCxY8c6PXfGjNv3f+rWx3t/fd7nX7Z9X7t2Dfn5+cjPz0ffvn3h5uaG7Oxs5OXlSfd5Pk9/fv3Ly8uRmpqqkzxp87V6ETaAdbB582akpqYiOzsbq1evxqhRowAAb731Fnbt2oXExEQUFxdjyZIl8Pf3R8uWLV+4vMmTJ2PXrl04fvw4ysvLkZaWhhs3bkjzx48fj1mzZsHc3Lze19LKy8uDmZkZnJycoFarsWLFCuTm5tZpWc2bN0dISAjmz5+P3NxclJeX4/bt2/i///u/au8/ZswYKXDV/fP09KzVOFQqFaysrHD+/Hns27dP48eGhYXho48+wpMnT5CamoqoqChpnr+/P6ytrbFmzRqUlpbi5MmTOHLkCN58802Nly9nzEYFfWTD1NQUYWFhWLp0KfLy8nD//n2sX7++0vXBHj9+jM8++wylpaU4ePAgrl+/jtdffx1Axd4IbV3z748//oBCoYCTkxMAYNeuXbh69apWlm1MuH1X0Nd7f33e511cXHDv3r1KH+ZfxMPDAwEBAVi8eDGKiopw+fJl7Nixo1KeLl68iMOHD0OtVmPDhg2wtLREr169pPVpK0/afK1ehA1gHYwePRohISFo3bo1vL29pTO6goODsXLlSowYMQLNmzfH7du3sX///pcur2fPnti1axfmzZsHOzs79O/fv9KnyXHjxuHq1ataufDjf//3f2PQoEFo06YNvLy8YGVlVeXwam3s2bMHJSUl0plxoaGhePjwYb3rfJno6GgsX74cNjY2WLFiBcLCwjR+bEREBLy8vNCqVSuEhIRU+mRtYWGBI0eO4IcffoCjoyPefvtt7NmzB+3atdPFMBodZuM/9JGNqKgoNG3aFK1bt0ZgYCBGjx6NSZMmSfP9/f1x69YtODo6YunSpTh06BAcHBwAVJxleOjQIdjb22P27Nn1qsPX1xfz589H79694eLigitXrqBPnz71WqYx4vb9H/rYvuvzPj9y5EgAgIODA7p27arRY77++mvcu3cPbm5ueOONN/DBBx9I1/UDgGHDhuGbb76Bvb099u7di8OHD8Pc3BwAsHjxYqxatQrNmjXD2rVrazHKqrT9WtVEIRrbPnode/5ij/pQWFgIZ2dnJCQk4JVXXtHbeolqg9kwLl9++SW2b9+O06dPG7qURoHbt7xVd2Hpho57ABuALVu2oEePHnwDIHoOs0GNGbdv0iW9/BRcdHQ0EhISYGdnh3Xr1lWZn5+fjy1btiAjIwPm5uaYMWOG9J2AxMRE7Nq1C+Xl5Xj11VcxfPhwfZRsNFq2bAkhBP7xj39Uur1Dhw6VDhU8s23bNowZM0ZP1REZDrNBjRm3b9I1vRwCTkpKgpWVFTZv3lxtA7h3715YWVlh5MiRSEtLw44dO7B8+XKUl5djzpw5CA8Ph4ODAxYvXow5c+bA3d1d1yUTERERNVp6OQTs6+sLpVJZ4/zU1FR07NgRQMV1q37//Xfk5OQgOTkZrq6ucHFxgZmZGQICAqr8bBcRERER1Y5eDgG/jJeXF+Lj49G+fXskJyfj999/R3Z2NrKzs6Uz1oCKs3lu3bpV43JiY2MRGxsLoOJ3KUtKSnRe+/PMzMyk3/6TCzmOGTDcuC0sLGp1f+bCcOQ4buZCM6tWrYJCocDSpUv1ul5jwFzoV03ZMIoGcPjw4fjyyy+xYMECeHp6olWrVpV+iUFTwcHBlc7QMsRV6B0dHRvd1e9fRo5jBgw37mcXHtUUc2E4chw3c6GZ0tJSmJuby277AJgLfaspG0bRAFpbW+Ptt98GAAghMGvWLDg7O6OkpARZWVnS/bKysqBSqQxVJhEREVGjYBSXgfnjjz+kXaPHjx9H+/btYW1tDW9vbzx8+BCPHz+GWq3G2bNn0b17dwNXS0RERNSw6WUP4IYNG5CUlIS8vDxMnz4dYWFhUsMXEhKCtLQ0bN68GUDFz7FMnz4dQMVPHU2aNAmrV69GeXk5BgwYoJOrYRMRERHJiV4awLlz575wfps2bbBx48Zq53Xt2lXjn3EhIiIiopczikPARERERKQ/bACJiIiIZIYNIBEREZHMGMVlYIio8YqKioK5ubl0chcRERkeG0AiItIKNvtEDQcbQCIiIiIdMdYPRvwOIBEREZHMsAEkIiIikhk2gEREREQywwaQiIiISGZ4EggRkQ4Y6xe/iYgA7gEkIiIikh02gEREREQywwaQiIiISGbYABIRERHJDE8C0SI5fulbjmMG5DtuIiJqHLgHkIiIiEhm2AASERERyQwPARMREZFe8OszxoN7AImIiIhkhg0gERERkcywASQiIiKSGTaARERERDLDBpCIiIhIZtgAEhEREcmMXi4DEx0djYSEBNjZ2WHdunVV5hcUFOCzzz5DVlYWysrKMGTIEAwYMAAAMGrUKHh6egIAHB0dsXDhQn2UTERE9FJl/zu0bg+0ao7S+jwegOkXMXV+LJFeGsCgoCAMGjQImzdvrnb+sWPH4O7ujkWLFiE3Nxdz5sxB3759YWZmBgsLC3zyySf6KJOIiIhIFvRyCNjX1xdKpbLG+QqFAkVFRRBCoKioCEqlEiYmPDpNREREpAsa7wFMS0vDuXPnkJOTgylTpiAtLQ1qtRpeXl71LmLQoEFYs2YNpk2bhsLCQsybN09qAEtLS7Fo0SKYmppi2LBh6NmzZ43LiY2NRWxsLAAgMjISjo6O9a6tNszNzaFQKPS+XkOS45iBhjVu5sIw5DjuhjRmbeUiQ5tF1VJDeJ6f15C2EW0x1jFr1ACeO3cOO3bsQM+ePXHmzBlMmTIFRUVF2LdvH5YtW1bvIi5dugQvLy8sX74cGRkZWLlyJdq1awdra2tER0dDpVIhIyMDK1asgKenJ1xdXatdTnBwMIKDg6XpzMzMetdWG6WlpTA3N9f7eg1JjmMGDDtuNze3Wt3/+VxkLJyq7ZJe6PW0NCgUCr2v19DkOG5Djtnj0y9rdX9D/3+hDQ2xZjn+n2HoMdf0f4ZGx1kPHDiA8PBwTJ06Vdoz5+XlhXv37mmluBMnTsDf3x8KhQKurq5wdnZGeno6AEClUgEAXFxc4Ovrq7V1EhEREcmVRnsAnz59WuVQr0KhgEKh0EoRjo6OuHLlCtq3b4+cnBykp6fD2dkZ+fn5sLS0hLm5OXJzc3Hz5k0MGzZMK+skkivTBR/qdX3fy/TH3+U4bjmOmaih0qgBbN26NU6dOoX+/ftLt505cwY+Pj4arWTDhg1ISkpCXl4epk+fjrCwMKjVagBASEgIRowYgejoaMyfPx8AMGbMGNja2uLmzZv4/PPPYWJigvLycgwfPhzu7u61HSMRERFRvRjqkj+6utyPRg3g3/72N6xatQr//ve/UVxcjNWrVyM9PR3h4eEarWTu3LkvnK9SqapdVtu2bau9biARkT7U5xptxvqmT0QEaNgAtmjRAhs2bMDFixfRrVs3ODg4oFu3brCystJ1fURERESkZRpfBsbS0hIBAQG6rIWIiIiI9ECjBnD58uU1nvDxwQcfaLUgbSr7ZIle1zfs/18CoeyTFL2u15DkOGbAwOOu5eUuiGqrsX3XiYiq0qgBHDhwYKXpnJwcnDhxAn379tVJUQb329W6PU5hAVGfxwNAm451f2x9cMy1U99xG2rMRFQtve8wKM6q9zL0XbM2yHGnQX1f63q/zjXsNNCoAQwKCqpyW69evRAdHY3Q0ND6lKVTdb3cRV0/vX5v6QAAeLvoYZ0eD+j/Eh3PcMy1U99xG2rMREREQC2+A/g8lUqF+/fva7MWIiIig+AOA/1oyNeKNNRrravXWaMG8N///nel6ZKSEsTHx6NNmzY6KYqIiIiMEy+P1Dho1ADGxcVVmra0tETbtm0xePBgnRRFRMbHUCcGAHzTJyLSNo0awIiICF3XQURERER6UmMDmJGRodECXFxctFYMEREREelejQ3g7NmzNVrAN998o7ViiIiIiEj3amwA2dgRERERNU4mhi6AiIiIiPRLo5NAysrK8OOPPyIpKQl5eXmV5hnzT8ERERERUVUa7QHcvXs3YmNj4evrizt37sDf3x9Pnz5Fhw4ddF0fEREREWmZRg1gfHw8lixZgtdffx2mpqZ4/fXXsWDBAly7dk3X9RERERGRlmnUAJaUlMDBoeKnTCwsLFBcXIwWLVrg3r17uqyNiIiIiHRAo+8AtmjRArdv34aPjw9at26NgwcPokmTJlCpVLquj4iIiIi0TKM9gBMnToSJScVdJ0yYgLt37+LixYuYOnWqTosjIiIiIu3TaA+gj4+P9Hfz5s2xbNkynRVERERERLql0R7ABQsWICYmBpmZmbquh4iIiIh0TKM9gCNHjsTp06dx8OBBtG7dGoGBgejduzeUSqWu6yMiIiIiLdOoAezZsyd69uyJwsJCxMfH48yZM9izZw86duyIhQsX6rpGIqIG5+2ih4YugYioRho1gM80adIEgYGBaNq0KdRqNX799Vdd1UVERNRo8QMCGZpGDaAQAlevXsXp06dx/vx5ODk5ITAwEDNnztR1fURERESkZRo1gNOmTYOVlRUCAgKwcuVKuLu713pF0dHRSEhIgJ2dHdatW1dlfkFBAT777DNkZWWhrKwMQ4YMwYABAwAAJ0+exOHDhwEAf/3rXxEUFFTr9euDHD/RyXHMgHzHTUREtWOs/19o1AC+9957lS4FUxdBQUEYNGgQNm/eXO38Y8eOwd3dHYsWLUJubi7mzJmDvn37oqioCIcOHUJkZCQAYNGiRejevTtPQCEiIiKqI40uA1Pf5g8AfH19X9i0KRQKFBUVQQiBoqIiKJVKmJiYIDExEZ06dYJSqYRSqUSnTp2QmJhY73qIiIiI5KpWJ4Ho0qBBg7BmzRpMmzYNhYWFmDdvHkxMTJCdnS39DjEAqFQqZGdnV7uM2NhYxMbGAgAiIyPh6OhYp1oy6vQo7ahrzfXFMeuXPsfMXNSdHMcMGG7czEXtNMRc1PdwKHOhPUbTAF66dAleXl5Yvnw5MjIysHLlSrRr165WywgODkZwcLA03RAvXN0Qa64vjrl23NzcanV/5qJh4phrh7mQB4659mrKhkaHgPXhxIkT8Pf3h0KhgKurK5ydnZGeng6VSoWsrCzpftnZ2VCpVAaslIiIiKhh0/in4I4ePYqcnBydFeLo6IgrV64AAHJycpCeng5nZ2d07twZly5dQn5+PvLz83Hp0iV07txZZ3UQERERNXYaHQIODQ1FXFwc9u/fj/bt26Nfv37o2bMnLCwsNF7Rhg0bkJSUhLy8PEyfPh1hYWFQq9UAgJCQEIwYMQLR0dGYP38+AGDMmDGwtbUFAIwYMQKLFy+WauEZwERERER1p1ED6O/vD39/f+Tn5+Ps2bP48ccfsX37dvTs2RP9+vVDx44dX7qMuXPnvnC+SqVCeHh4tfMGDhyIgQMHalIqEREZiLFe74yIqqrVSSBKpRJBQUGwsrJCTEwM4uPjcf36dZiYmGDy5Mno1KmTruokIiIiIi3R+KfgLl26hFOnTiEhIQFt2rTB8OHDpcPAP//8M6KiovDFF1/oul4iIiIiqieNGsCpU6fC1tYW/fr1w9ixY6uchdurVy/8+OOPOimQiIiIiLRLowZw0aJF8Pb2fuF9IiIitFIQEREREemWRpeBSU1Nxf379yvddu/ePZw6dUonRRERERGR7mjUAH7zzTeVfo4NqLhu3/79+3VSFBERERHpjkYNYGFhIaytrSvdZm1tjT/++EMnRRERERGR7mjUALq7u+Pnn3+udNv58+fh7u6uk6KIiIiISHc0OglkzJgx+Oijj3D27Fm4urri0aNHuHLlivTrHERERETUcGjUALZr1w5r167FmTNnkJmZCR8fH0ycOBGOjo66ro+IiIiItEzjXwJxcnLC8OHDdVgKEREREelDjQ3gtm3bMG3aNABAVFQUFApFtfebNWuWbiojIiIiIp2osQF0dnaW/nZ1ddVLMUTU+Lxd9NDQJRAR0XNqbADfeOMN6e+RI0fqpRgiIiIi0r0aG8CrV69qtICOHTtqrRgiIiIi0r0aG8AtW7a89MEKhQKbNm3SakFEREREpFs1NoCbN2/WZx1EREREpCcaXwamrKwMN2/eRHZ2NhwcHNCmTRuYmprqsjYiIiIi0gGNGsC0tDR8/PHHKCkpgYODA7KysmBubo6FCxfy5+CIiIiIGhiNGsDt27cjODgYQ4YMka4HGBMTgx07diAiIkKnBRIRERGRdplocqd79+7hf/7nfypdDHrw4MG4d++eruoiIiIiIh3RqAFUqVRISkqqdNv169dhb2+vk6KIiIiISHc0OgT81ltv4eOPP0a3bt3g6OiIzMxMJCQk4J133tF1fURERESkZRo1gN27d8eaNWtw9uxZPHnyBB4eHggLC4Obm5uu6yMiIiIiLXthA1hcXIxvv/0WDx48QKtWrfDGG2/A3Ny81iuJjo5GQkIC7OzssG7duirzY2JiEBcXBwAoLy9HamoqduzYAaVSiZkzZ8LKygomJiYwNTVFZGRkrddPRERERP/xwgZwx44duH37Nrp06YL4+Hjk5+dj0qRJtV5JUFAQBg0aVOPFpYcOHYqhQ4cCAH755RccPXoUSqVSmh8REQFbW9tar5eIiIiIqnrhSSCJiYkIDw/H2LFjsXjxYly8eLFOK/H19a3U0L3ImTNn0KdPnzqth4iIiIhe7qWHgJ+d6evo6IiCggKdFlNcXIzExERMnjy50u2rV68GAPzlL39BcHBwjY+PjY1FbGwsACAyMhKOjo51qiOjTo/SjrrWXF8cs37pc8zMRd3JccyA4cbNXNQOc6FfjS0XL2wAy8rKcPXqVWm6vLy80jQAdOzYUWvFXLx4EW3btq20t3DlypVQqVR4+vQpVq1aBTc3N/j6+lb7+ODg4EoNYmZmptZq05eGWHN9ccy1U9uTr5iLholjrh3mQh445tqrKRsvbADt7OywZcsWaVqpVFaaVigU2LRpU70K+7MzZ84gMDCw0m0qlUqqpUePHkhOTq6xASQiIiKil3thA1jTSRu6UFBQgKSkpErXFiwqKoIQAk2aNEFRUREuX76M0NBQvdVERERE1BhpdB3A+tqwYQOSkpKQl5eH6dOnIywsDGq1GgAQEhICADh//jz8/PxgZWUlPe7p06dYu3YtgIrD0YGBgejcubM+SiYiIiJqtPTSAM6dO/el9wkKCkJQUFCl21xcXPDJJ5/opigiIiIimdLot4CJiIiIqPFgA0hEREQkM2wAiYiIiGSGDSARERGRzLABJCIiIpIZNoBEREREMsMGkIiIiEhm2AASERERyQwbQCIiIiKZYQNIREREJDNsAImIiIhkhg0gERERkcywASQiIiKSGTaARERERDLDBpCIiIhIZtgAEhEREckMG0AiIiIimWEDSERERCQzbACJiIiIZIYNIBEREZHMsAEkIiIikhk2gEREREQywwaQiIiISGbYABIRERHJDBtAIiIiIpkx08dKoqOjkZCQADs7O6xbt67K/JiYGMTFxQEAysvLkZqaih07dkCpVCIxMRG7du1CeXk5Xn31VQwfPlwfJRMRERE1WnppAIOCgjBo0CBs3ry52vlDhw7F0KFDAQC//PILjh49CqVSifLycuzYsQPh4eFwcHDA4sWL0b17d7i7u+ujbCIiIqJGSS+HgH19faFUKjW675kzZ9CnTx8AQHJyMlxdXeHi4gIzMzMEBATgwoULuiyViIiIqNHTyx5ATRUXFyMxMRGTJ08GAGRnZ8PBwUGa7+DggFu3btX4+NjYWMTGxgIAIiMj4ebmVrdCjv5St8c1ZBxzo8Vc1IMcxwzIYtzMRT3IccxAoxu3UZ0EcvHiRbRt21bjvYXPCw4ORmRkJCIjI7VcmeYWLVpksHUbihzHDDSccTMXhiPHcTeUMTMXhiPHcRvjmI2qATxz5gwCAwOlaZVKhaysLGk6KysLKpXKEKURERERNRpG0wAWFBQgKSkJ3bt3l27z9vbGw4cP8fjxY6jVapw9e7bSfCIiIiKqPb18B3DDhg1ISkpCXl4epk+fjrCwMKjVagBASEgIAOD8+fPw8/ODlZWV9DhTU1NMmjQJq1evRnl5OQYMGAAPDw99lFxnwcHBhi5B7+Q4ZkC+464LuT5Xchy3HMdcV3J9ruQ4bmMcs0IIIQxdBBERERHpj9EcAiYiIiIi/WADSERERCQzbACJiIiIZIYNIBEREZHMsAHUsvLychQUFBi6DJ07d+4cCgsLAQDffvst1q5dizt37hi4Kt376quvUFBQALVajRUrVmDy5Mk4deqUocsyenLJBSDPbDAXdcNcMBeGxAZQCzZu3IiCggIUFRVh/vz5ePfddxETE2PosnTq22+/RZMmTXDjxg1cuXIFAwcOxPbt2w1dls5dunQJ1tbWSEhIgJOTE6KionDkyBFDl2WU5JgLQJ7ZYC40x1wwF8aCDaAWpKamwtraGhcuXECXLl2wadMmo+rydcHEpGLTSUhIQHBwMLp27Spd27ExKy8vB1Ax7t69e8Pa2trAFRkvOeYCkGc2mAvNMRfMhbFgA6gFZWVlUKvVuHDhArp37w4zMzMoFApDl6VTKpUKn3/+Oc6ePYsuXbqgtLQUcrikZNeuXTF37lzcuXMHHTt2RG5uLszNzQ1dllGSYy4AeWaDudAcc8FcGAteCFoL/vnPf+L7779Hy5YtsWjRImRmZiIqKgorVqwwdGk6U1xcjMTERHh6eqJ58+Z48uQJUlJS4OfnZ+jSdC4/Px/W1tYwMTFBcXExCgsL0axZM0OXZXTkmAtAvtlgLjTDXDAXxpILNoA6UlZWBlNTU0OXoVN37tzBjRs3oFAo0LZtW7Ru3drQJelcSUkJfvrpJ9y4cQMA0K5dO4SEhMDCwsLAlTUMcsgFIL9sMBf1w1w0TsaeCzaAWpCXl4eDBw/i5s2bACpe5NDQUNjY2Bi4Mt05dOgQzp07B39/fwDAhQsX0KtXL4wYMcLAlenW+vXr0aRJE/Tt2xcAcPr0aRQUFODdd981cGXGR465AOSZDeZCc8wFc2E0uRBUbytWrBAHDx4UGRkZIiMjQxw6dEisWLHC0GXp1OzZs0VxcbE0XVxcLGbPnm3AivRj7ty5Gt1G8syFEPLMBnOhOeaiAnNheDwJRAtycnIQGhoKZ2dnODs7Y8SIEcjJyTF0WTqlUqlQWloqTZeWlkKlUhmwIv1o1aoVfvvtN2n61q1b8Pb2NmBFxkuOuQDkmQ3mQnPMRQXmwvB4CFgLdu/eDR8fH/Tu3RsA8PPPPyM5ORnjx483cGW6s2bNGty+fRudOnWCQqHA5cuX4ePjIwV60qRJBq5QN+bNm4f09HQ4OjoCADIzM+Hm5gYTExMoFAqsXbvWwBUaDznmApBnNpgLzTEXzIWx5IINoBaMHz8excXFMDExgRACQghYWloCABQKBXbv3m3gCrXv5MmTL5wfFBSklzr07ffff3/hfCcnJz1VYvzkmAtAntlgLjTHXFSPudA/NoBEGigoKIC1tTXy8/Orna9UKvVcEZHhMRdEVTWUXLABrIe0tDS0aNGixt8zbIynuK9fvx7vvvsu5s+fX+3FSw29S1tXIiMjsXDhQrz55ptwcnKqdAFThUKBTZs2GbA64yLHXADyzAZzoTnmgrkAjCsXbADrYdu2bZg2bRo++OCDaudHRETouSLde/LkCezt7WvctW3oXdq6Nn/+fKxbt87QZRg1OeYCkHc2mIuXYy6YC2PDBlALzp49i86dO8Pa2hqHDh3C3bt3MWLEiEb7iU7ONm3ahEGDBsHHx8fQpRg95kI+mAvNMRfyYey5MDN0AY3B4cOHERAQgBs3buDatWsYMmQItm/fjg8//NDQpWndsmXLsHLlSowfP77S7nwhRKP+AvMzycnJCA8Ph5OTEywtLaVxN8bDGPUlp1wA8s4Gc6E55qICc2F4bAC1wMSk4nKKCQkJePXVV9G1a1fs37/fwFXpxsqVKwEAe/bsMXAlhrF06VJDl9BgyCkXgLyzwVxojrmQD2PPBRtALVCpVPj8889x+fJlDBs2DKWlpeCR9capMX9fRduYC/lgLjTHXMiHseeC3wHUguLiYiQmJsLT0xPNmzfHkydPkJKSAj8/P0OXRmQwzAVRVcwFGQs2gEREREQyw98CJiIiIpIZNoBEREREMsMGkLTu8OHD2Lp1q6HLIDI6zAZRVcyFYfA7gEbu5MmTOHLkCDIyMtCkSRP07NkTo0ePRtOmTQEABw4cwHfffQczMzOYmprC3d0d48ePR5s2bXDy5Els2bIFFhYWlZa5ceNGqFQqrdR37do1REVF6S28M2fOxLRp09CpUye9rI+MF7NRGbNBAHPxPOaiZrwMjBE7cuQIYmJiMHPmTHTs2BHZ2dnYsWMHVq1ahZUrV8LMrOLl6927N2bPng21Wo39+/dj7dq12LZtGwCgTZs20nWY5K6srAympqaGLoO0gNnQLmajcWAutKux54INoJEqKCjAgQMHMGPGDHTu3BkA4OzsjHnz5mHmzJk4deoUBg4cWOkxZmZm6N+/P2JiYpCXl1frdaalpWHnzp24c+cObG1tMWrUKAQEBACouGjp3r17kZWVhSZNmmDw4MEICQnBhx9+CLVajXHjxgGo+KQYGxuLR48eYfbs2Xj8+DFmzZqFGTNm4MCBAygqKsJbb72F1q1bY+vWrcjMzETfvn0xefJkAMCjR4+wbds23L9/HwqFAn5+fpg8eTKaNm2KqKgoZGZm4uOPP4aJiQlCQ0MxbNgw/PLLL9i3bx+ys7PRsmVLTJkyBe7u7gAqPv395S9/wenTp5Geno69e/c26kDLAbPBbFBVzAVzUVtsAI3Ub7/9htLSUvj7+1e63crKCl26dMHly5erhLm0tBQnT56Eg4MDbG1ta7W+oqIirFq1CmFhYViyZAlSUlKwatUqeHp6wt3dHVu3bsW8efPQvn175Ofn4/Hjx7CyssKSJUs02p1/69YtbNy4EdevX8eaNWvg5+eHZcuWoaysDO+99x569+4NX19fAMAbb7yB9u3bo7CwEOvWrcPBgwcxceJEvPPOO7hx40al3fnp6enYuHEjFixYAF9fXxw9ehQff/wxPv30U+nT7pkzZ7Bo0SLY2to22iDLCbPBbFBVzAVzUVtsAI1Ubm4ubGxsqt347O3tcefOHWn63LlzSEhIgJmZGTw8PLBgwQJp3q1btzBx4kRp2sbGBlFRUVWWmZCQACcnJwwYMAAA0KpVK/j7++PcuXMYOXIkTE1NkZqaCi8vLyiVSiiVylqNJzQ0FBYWFvDz84OlpSUCAwNhZ2cHAGjXrh3u3r0LX19fuLq6wtXVFQBgbm6OwYMH49ChQzUu9+zZs+jSpYsU7iFDhuCf//wnbt68iQ4dOgAAXnvtNTg6OtaqXjJezAazQVUxF8xFbbEBNFK2trbIy8ur9jsIT548gY2NjTT97Psc1XnllVc0+j7H77//XiX4ZWVl6NevHwBg/vz5OHz4MPbt2wdPT0+MGTMGbdq00Xg8z4ILABYWFlWmi4qKAAA5OTn48ssvcf36dRQVFaG8vPyFbxxPnjyp9HM7JiYmcHR0RHZ2tnSbHIIsJ8wGs0FVMRfMRW2xATRSbdq0gbm5OeLj46XvVAAVu90TExPx1ltvaXV9Dg4O8PX1xbJly6qd7+Pjg/feew9qtRrHjh3Dp59+ii1btkChUGi1jq+//hoAsG7dOiiVSpw/fx47d+6s8f729vZISUmRpoUQyMzM1NoZa2R8mA1mg6piLpiL2uJ1AI2UtbU1QkNDsWvXLiQmJkKtVuPx48f49NNP4eDgIH3K0pZu3brh4cOHOHXqFNRqNdRqNZKTk5Gamgq1Wo24uDgUFBTAzMwM1tbWUojt7OyQl5eHgoICrdRRWFgIKysrWFtbIzs7G0eOHKk0v1mzZnj8+LE0HRAQgF9//RVXrlyBWq3GkSNHYG5ujrZt22qlHjI+zAazQVUxF8xFbXEPoBEbNmwYbGxssHfvXjx69AjW1tbo0aMH3nnnHZibm2u0jN9++0062+qZiIgI+Pj4VLqtSZMmCA8Px+7du7F7924IIeDl5YUJEyYAAE6dOoWdO3eivLwcbm5u0uGDFi1aoE+fPpg1axbKy8uxfv36eo155MiR2LRpEyZMmABXV1f069cPR48eleYPHz4cO3fuxFdffYW//vWvGDp0KN555x3s3LlTOqNr4cKF0pd5qXFiNpgNqoq5YC5qgxeCJiIiIpIZHgImIiIikhk2gEREREQywwaQiIiISGbYABIRERHJDBtAIiIiIplhA0hEREQkM2wAiYiIiGSGDSARERGRzPw/FM3ixZyo6LEAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 648x216 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "alpha = 0.05\n",
     "plt.style.use(\"ggplot\")\n",
@@ -624,19 +1057,11 @@
    "source": []
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is surprising that `RIPS` estimator does not achieve the best performance even if the reward structure is not independent. If we run a simuration where the reward of each position depends heavily on those of other positions, `RIPS`estimator could achieve the best performance.\n",
-    "\n",
-    "Please see [../examples/synthetic_slate](../synthetic_slate) for a more sophisticated example of the evaluation of OPE with synthetic slate bandit data."
+    "It is surprising that `RIPS` estimator does not achieve the best performance even if the reward structure is not independent. If we run a simulation where the reward of each position depends heavily on those of other positions, `RIPS`estimator could achieve the best performance.\n",
+    "<!-- Please see [../examples/synthetic_slate](../synthetic_slate) for a more sophisticated example of the evaluation of OPE with synthetic slate bandit data. -->"
    ]
   },
   {


### PR DESCRIPTION
# Overview

- Simplify the process of `Evaluation of OPE`
  - Generate random behavior policy (`cascade-additive` reward structure)
  - Define three evaluation policies (`random`, `optimal`, and `anti-optimal`)
  - Conduct OPE
  - Evaluate three OPE estimators (`SIPS`, `IIPS`, and `RIPS`) using the ground truth policy value of the three evaluation policies


# Changes

- Remove evaluations of various types of reward structures and click models.
- Reflect the notebook structure of `synthetic.ipynb`.


# Remark

- `RIPS` estimator does not achieve the best performance even if the reward structure is not independent.