### PR TITLE
Feature: Add subsample option to obp.dataset.OpenBanditDataset

### DIFF
--- a/obp/dataset/real.py
+++ b/obp/dataset/real.py
@@ -80,9 +80,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
             logger.info(
                 "When `data_path` is not given, this class downloads the example small-sized version of the Open Bandit Dataset."
             )
-            self.data_path = (
-                Path(__file__).parent / "obd"
-            )
+            self.data_path = Path(__file__).parent / "obd"
         else:
             if isinstance(self.data_path, Path):
                 pass

--- a/obp/dataset/real.py
+++ b/obp/dataset/real.py
@@ -81,17 +81,16 @@ class OpenBanditDataset(BaseRealBanditDataset):
                 "When `data_path` is not given, this class downloads the example small-sized version of the Open Bandit Dataset."
             )
             self.data_path = (
-                Path(__file__).parent / "obd" / self.behavior_policy / self.campaign
+                Path(__file__).parent / "obd"
             )
         else:
             if isinstance(self.data_path, Path):
-                self.data_path = self.data_path / self.behavior_policy / self.campaign
+                pass
             elif isinstance(self.data_path, str):
-                self.data_path = Path(
-                    f"{self.data_path}/{self.behavior_policy}/{self.campaign}"
-                )
+                self.data_path = Path(self.data_path)
             else:
                 raise ValueError("data_path must be a string or Path")
+        self.data_path = self.data_path / self.behavior_policy / self.campaign
         self.raw_data_file = f"{self.campaign}.csv"
 
         self.load_raw_data()

--- a/obp/dataset/real.py
+++ b/obp/dataset/real.py
@@ -318,13 +318,6 @@ class OpenBanditDataset(BaseRealBanditDataset):
             - action_context: item-related context vectors
 
         """
-        if sample_size:
-            check_scalar(
-                sample_size,
-                name="sample_size",
-                target_type=(int),
-                min_val=0,
-            )
         if is_timeseries_split:
             bandit_feedback = self.obtain_batch_bandit_feedback(
                 test_size=test_size, is_timeseries_split=is_timeseries_split
@@ -337,10 +330,13 @@ class OpenBanditDataset(BaseRealBanditDataset):
         if sample_size is None:
             sample_size = bandit_feedback["n_rounds"]
         else:
-            if sample_size > n_rounds:
-                raise ValueError(
-                    "`sample_size` must be smaller than the original data size (`n_rounds`)."
-                )
+            check_scalar(
+                sample_size,
+                name="sample_size",
+                target_type=(int),
+                min_val=0,
+                max_val=n_rounds,
+            )
         random_ = check_random_state(random_state)
         bootstrap_idx = random_.choice(
             np.arange(n_rounds), size=sample_size, replace=True

--- a/obp/dataset/real.py
+++ b/obp/dataset/real.py
@@ -5,15 +5,13 @@
 from dataclasses import dataclass
 from logging import getLogger, basicConfig, INFO
 from pathlib import Path
-from typing import Optional
-from typing import Union
-from typing import Tuple
+from typing import Optional, Union, Tuple
 
 import numpy as np
 import pandas as pd
 from scipy.stats import rankdata
 from sklearn.preprocessing import LabelEncoder
-from sklearn.utils import check_random_state
+from sklearn.utils import check_random_state, check_scalar
 
 from .base import BaseRealBanditDataset
 from ..types import BanditFeedback
@@ -37,11 +35,12 @@ class OpenBanditDataset(BaseRealBanditDataset):
         Must be either 'random' or 'bts'.
 
     campaign: str
-        One of the three possible campaigns considered in ZOZOTOWN, "all", "men", and "women".
+        One of the three possible campaigns considered in ZOZOTOWN.
+        Must be one of "all", "men", or "women".
 
-    data_path: Path, default=None
-        Path where the Open Bandit Dataset exists.
-        When `None` is given, this class downloads the example small-sized version of the dataset.
+    data_path: str or Path, default=None
+        Path where the Open Bandit Dataset is stored.
+        When `None` is given, this class downloads the example small-sized data.
 
     dataset_name: str, default='obd'
         Name of the dataset.
@@ -55,7 +54,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
 
     behavior_policy: str
     campaign: str
-    data_path: Optional[Path] = None
+    data_path: Optional[Union[str, Path]] = None
     dataset_name: str = "obd"
 
     def __post_init__(self) -> None:
@@ -74,18 +73,25 @@ class OpenBanditDataset(BaseRealBanditDataset):
             "women",
         ]:
             raise ValueError(
-                f"campaign must be one of 'all', 'men', and 'women', but {self.campaign} is given"
+                f"campaign must be one of 'all', 'men', or 'women', but {self.campaign} is given"
             )
 
         if self.data_path is None:
             logger.info(
                 "When `data_path` is not given, this class downloads the example small-sized version of the Open Bandit Dataset."
             )
-            self.data_path = Path(__file__).parent / "obd"
+            self.data_path = (
+                Path(__file__).parent / "obd" / self.behavior_policy / self.campaign
+            )
         else:
-            if not isinstance(self.data_path, Path):
-                raise ValueError("data_path must be a Path type")
-        self.data_path = self.data_path / self.behavior_policy / self.campaign
+            if isinstance(self.data_path, Path):
+                self.data_path = self.data_path / self.behavior_policy / self.campaign
+            elif isinstance(self.data_path, str):
+                self.data_path = Path(
+                    f"{self.data_path}/{self.behavior_policy}/{self.campaign}"
+                )
+            else:
+                raise ValueError("data_path must be a string or Path")
         self.raw_data_file = f"{self.campaign}.csv"
 
         self.load_raw_data()
@@ -136,7 +142,9 @@ class OpenBanditDataset(BaseRealBanditDataset):
             When `None` is given, this class downloads the example small-sized version of the dataset.
 
         test_size: float, default=0.3
-            If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the test split.
+            Proportion of the dataset included in the test split.
+            If float, should be between 0.0 and 1.0.
+            This argument matters only when `is_timeseries_split=True` (the out-sample case).
 
         is_timeseries_split: bool, default=False
             If true, split the original logged bandit feedback data by time series.
@@ -202,12 +210,12 @@ class OpenBanditDataset(BaseRealBanditDataset):
         Parameters
         -----------
         test_size: float, default=0.3
-            If float, should be between 0.0 and 1.0 and represent the proportion of
-            the dataset to include in the evaluation split.
+            Proportion of the dataset included in the test split.
+            If float, should be between 0.0 and 1.0.
             This argument matters only when `is_timeseries_split=True` (the out-sample case).
 
         is_timeseries_split: bool, default=False
-            If true, split the original logged bandit feedback data by time series.
+            If true, split the original logged bandit feedback data into train and test sets based on time series.
 
         Returns
         --------
@@ -224,11 +232,19 @@ class OpenBanditDataset(BaseRealBanditDataset):
             - action_context: item-related context vectors
 
         """
+        if not isinstance(is_timeseries_split, bool):
+            raise TypeError(
+                f"`is_timeseries_split` must be a bool, but {type(is_timeseries_split)} is given"
+            )
+
         if is_timeseries_split:
-            if not isinstance(test_size, float) or (test_size <= 0 or test_size >= 1):
-                raise ValueError(
-                    f"test_size must be a float in the (0,1) interval, but {test_size} is given"
-                )
+            check_scalar(
+                test_size,
+                name="target_size",
+                target_type=(float),
+                min_val=0.0,
+                max_val=1.0,
+            )
             n_rounds_train = np.int(self.n_rounds * (1.0 - test_size))
             bandit_feedback_train = dict(
                 n_rounds=n_rounds_train,
@@ -265,6 +281,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
 
     def sample_bootstrap_bandit_feedback(
         self,
+        sample_size: Optional[int] = None,
         test_size: float = 0.3,
         is_timeseries_split: bool = False,
         random_state: Optional[int] = None,
@@ -273,13 +290,18 @@ class OpenBanditDataset(BaseRealBanditDataset):
 
         Parameters
         -----------
+        sample_size: int, default=None
+            Number of data sampled by bootstrap.
+            When None is given, the original data size (n_rounds) is used as `sample_size`.
+            The value must be smaller than the original data size.
+
         test_size: float, default=0.3
-            If float, should be between 0.0 and 1.0 and represent the proportion of
-            the dataset to include in the evaluation split.
+            Proportion of the dataset included in the test split.
+            If float, should be between 0.0 and 1.0.
             This argument matters only when `is_timeseries_split=True` (the out-sample case).
 
         is_timeseries_split: bool, default=False
-            If true, split the original logged bandit feedback data by time series.
+            If true, split the original logged bandit feedback data into train and test sets based on time series.
 
         random_state: int, default=None
             Controls the random seed in bootstrap sampling.
@@ -299,6 +321,13 @@ class OpenBanditDataset(BaseRealBanditDataset):
             - action_context: item-related context vectors
 
         """
+        if sample_size:
+            check_scalar(
+                sample_size,
+                name="sample_size",
+                target_type=(int),
+                min_val=0,
+            )
         if is_timeseries_split:
             bandit_feedback = self.obtain_batch_bandit_feedback(
                 test_size=test_size, is_timeseries_split=is_timeseries_split
@@ -308,8 +337,18 @@ class OpenBanditDataset(BaseRealBanditDataset):
                 test_size=test_size, is_timeseries_split=is_timeseries_split
             )
         n_rounds = bandit_feedback["n_rounds"]
+        if sample_size is None:
+            sample_size = bandit_feedback["n_rounds"]
+        else:
+            if sample_size > n_rounds:
+                raise ValueError(
+                    "`sample_size` must be smaller than the original data size (`n_rounds`)."
+                )
         random_ = check_random_state(random_state)
-        bootstrap_idx = random_.choice(np.arange(n_rounds), size=n_rounds, replace=True)
+        bootstrap_idx = random_.choice(
+            np.arange(n_rounds), size=sample_size, replace=True
+        )
         for key_ in ["action", "position", "reward", "pscore", "context"]:
             bandit_feedback[key_] = bandit_feedback[key_][bootstrap_idx]
+        bandit_feedback["n_rounds"] = sample_size
         return bandit_feedback

--- a/tests/dataset/test_real.py
+++ b/tests/dataset/test_real.py
@@ -19,9 +19,7 @@ def test_real_init():
 
     # data_path
     with pytest.raises(ValueError):
-        OpenBanditDataset(
-            behavior_policy="random", campaign="all", data_path="raw_str_path"
-        )
+        OpenBanditDataset(behavior_policy="random", campaign="all", data_path=5)
 
     # load_raw_data
     obd = OpenBanditDataset(behavior_policy="random", campaign="all")
@@ -50,6 +48,14 @@ def test_obtain_batch_bandit_feedback():
     with pytest.raises(ValueError):
         dataset = OpenBanditDataset(behavior_policy="random", campaign="all")
         dataset.obtain_batch_bandit_feedback(is_timeseries_split=True, test_size=-0.5)
+
+    with pytest.raises(TypeError):
+        dataset = OpenBanditDataset(behavior_policy="random", campaign="all")
+        dataset.obtain_batch_bandit_feedback(is_timeseries_split=True, test_size="0.5")
+
+    with pytest.raises(TypeError):
+        dataset = OpenBanditDataset(behavior_policy="random", campaign="all")
+        dataset.obtain_batch_bandit_feedback(is_timeseries_split="True", test_size=0.5)
 
     # existence of keys
     # is_timeseries_split=False (default)
@@ -95,6 +101,30 @@ def test_calc_on_policy_policy_value_estimate():
 
 
 def test_sample_bootstrap_bandit_feedback():
+    with pytest.raises(ValueError):
+        dataset = OpenBanditDataset(behavior_policy="random", campaign="all")
+        dataset.sample_bootstrap_bandit_feedback(
+            is_timeseries_split=True, test_size=1.3
+        )
+
+    with pytest.raises(ValueError):
+        dataset = OpenBanditDataset(behavior_policy="random", campaign="all")
+        dataset.sample_bootstrap_bandit_feedback(
+            is_timeseries_split=True, test_size=-0.5
+        )
+
+    with pytest.raises(ValueError):
+        dataset = OpenBanditDataset(behavior_policy="random", campaign="all")
+        dataset.sample_bootstrap_bandit_feedback(sample_size=-50)
+
+    with pytest.raises(TypeError):
+        dataset = OpenBanditDataset(behavior_policy="random", campaign="all")
+        dataset.sample_bootstrap_bandit_feedback(sample_size=50.0)
+
+    with pytest.raises(ValueError):
+        dataset = OpenBanditDataset(behavior_policy="random", campaign="all")
+        dataset.sample_bootstrap_bandit_feedback(sample_size=10000000)
+
     dataset = OpenBanditDataset(behavior_policy="random", campaign="all")
     bandit_feedback = dataset.obtain_batch_bandit_feedback()
     bootstrap_bf = dataset.sample_bootstrap_bandit_feedback()
@@ -111,3 +141,10 @@ def test_sample_bootstrap_bandit_feedback():
     )
     for k in bf_keys:
         assert len(bandit_feedback_timeseries[k]) == len(bootstrap_bf_timeseries[k])
+
+    sample_size = 1000
+    dataset = OpenBanditDataset(behavior_policy="random", campaign="all")
+    bootstrap_bf = dataset.sample_bootstrap_bandit_feedback(sample_size=sample_size)
+    assert bootstrap_bf["n_rounds"] == sample_size
+    for k in bf_keys:
+        assert len(bootstrap_bf[k]) == sample_size


### PR DESCRIPTION
### new feature
- add `sample_size` option to the `sample_bootstrap_bandit_feedback` method of `obp.dataset.OpenBanditDataset`
https://github.com/st-tech/zr-obp/blob/e85ba78e1e31423da3926141059f4b9ba4f70168/obp/dataset/real.py#L281-L283

This works as follows.

![スクリーンショット 2021-07-18 14 56 19（2）](https://user-images.githubusercontent.com/32621707/126057405-59239265-1497-40ef-900e-c5195e61a951.png)

### tests
- added some tests wrt the new feature in [test_real.py](https://github.com/st-tech/zr-obp/blob/add-subsample-option/tests/dataset/test_real.py)

### refactor
- allow string as the input of `data_path` as follows

![スクリーンショット 2021-07-18 14 51 52（2）](https://user-images.githubusercontent.com/32621707/126057349-c8aa2318-56a5-4ba1-b079-f8c5a28b0e39.png)

- fix some english expressions in the docstring