### PR TITLE
Add some arguments to SyntheticBanditDataset

### DIFF
--- a/obp/dataset/synthetic.py
+++ b/obp/dataset/synthetic.py
@@ -465,7 +465,7 @@ def linear_behavior_policy(
     Returns
     ---------
     behavior_policy: array-like, shape (n_rounds, n_actions)
-        Action choice probabilities given context (:math:`x`), i.e., :math:`\\pi: \\mathcal{X} \\rightarrow \\Delta(\\mathcal{A})`.
+        Logit values given context (:math:`x`), i.e., :math:`\\pi: \\mathcal{X} \\rightarrow \\Delta(\\mathcal{A})`.
 
     """
     if not isinstance(context, np.ndarray) or context.ndim != 2:

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -93,6 +93,33 @@ def estimate_confidence_interval_by_bootstrap(
     }
 
 
+def sample_action_fast(
+    action_dist: np.ndarray, random_state: Optional[int] = None
+) -> np.ndarray:
+    """Sample actions faster based on a given action distribution.
+
+    Parameters
+    ----------
+    action_dist: array-like, shape (n_rounds, n_actions)
+        Distribution over actions.
+
+    random_state: Optional[int], default=None
+        Controls the random seed in sampling synthetic bandit dataset.
+
+    Returns
+    ---------
+    sampled_action: array-like, shape (n_rounds,)
+        Actions sampled based on `action_dist`.
+
+    """
+    random_ = check_random_state(random_state)
+    uniform_rvs = random_.uniform(size=action_dist.shape[0])[:, np.newaxis]
+    cum_action_dist = action_dist.cumsum(axis=1)
+    flg = cum_action_dist > uniform_rvs
+    sampled_action = flg.argmax(axis=1)
+    return sampled_action
+
+
 def convert_to_action_dist(
     n_actions: int,
     selected_actions: np.ndarray,

--- a/tests/dataset/test_synthetic.py
+++ b/tests/dataset/test_synthetic.py
@@ -28,6 +28,20 @@ def test_synthetic_init():
     with pytest.raises(ValueError):
         SyntheticBanditDataset(n_actions=2, reward_type="aaa")
 
+    # reward_std
+    with pytest.raises(TypeError):
+        SyntheticBanditDataset(n_actions=2, reward_std="aaa")
+
+    with pytest.raises(ValueError):
+        SyntheticBanditDataset(n_actions=2, reward_std=-1)
+
+    # tau
+    with pytest.raises(TypeError):
+        SyntheticBanditDataset(n_actions=2, tau="aaa")
+
+    with pytest.raises(ValueError):
+        SyntheticBanditDataset(n_actions=2, tau=-1)
+
     # random_state
     with pytest.raises(ValueError):
         SyntheticBanditDataset(n_actions=2, random_state=None)

--- a/tests/dataset/test_synthetic.py
+++ b/tests/dataset/test_synthetic.py
@@ -7,6 +7,7 @@ from obp.dataset.synthetic import (
     linear_reward_function,
     linear_behavior_policy,
 )
+from obp.utils import softmax
 
 
 def test_synthetic_init():
@@ -324,6 +325,8 @@ def test_synthetic_linear_behavior_policy():
     n_actions = 5
     context = np.ones([n_rounds, dim_context])
     action_context = np.ones([n_actions, dim_action_context])
-    action_prob = linear_behavior_policy(context=context, action_context=action_context)
+    action_prob = softmax(
+        linear_behavior_policy(context=context, action_context=action_context)
+    )
     assert action_prob.shape[0] == n_rounds and action_prob.shape[1] == n_actions
     assert np.all(0 <= action_prob) and np.all(action_prob <= 1)

--- a/tests/ope/test_regression_models.py
+++ b/tests/ope/test_regression_models.py
@@ -825,8 +825,8 @@ def test_performance_of_binary_outcome_models(
     auc_scores: Dict[str, float] = {}
     # check ground truth
     print(f"gt_mean: {gt_mean}")
-    # check the performance of regression models using doubly robust criteria (|\hat{q} - q| <= |q| is satisfied with a high probability)
-    dr_criteria_pass_rate = 0.8
+    # check the performance of regression models using doubly robust criterion (|\hat{q} - q| <= |q| is satisfied with a high probability)
+    dr_criterion_pass_rate = 0.7
     fit_methods = ["normal", "iw", "mrdr"]
     for fit_method in fit_methods:
         for model_name, model in binary_model_dict.items():
@@ -864,16 +864,16 @@ def test_performance_of_binary_outcome_models(
                     np.zeros_like(bandit_feedback["action"], dtype=int),
                 ],
             )
-            # compare dr criteria
-            dr_criteria = np.abs((gt_mean - estimated_rewards_by_reg_model)) - np.abs(
+            # compare dr criterion
+            dr_criterion = np.abs((gt_mean - estimated_rewards_by_reg_model)) - np.abs(
                 gt_mean
             )
             print(
-                f"Dr criteria is satisfied with probability {np.mean(dr_criteria <= 0)} ------ model: {model_name} ({fit_method}),"
+                f"Dr criterion is satisfied with probability {np.mean(dr_criterion <= 0)} ------ model: {model_name} ({fit_method}),"
             )
             assert (
-                np.mean(dr_criteria <= 0) >= dr_criteria_pass_rate
-            ), f" should be satisfied with a probability at least {dr_criteria_pass_rate}"
+                np.mean(dr_criterion <= 0) >= dr_criterion_pass_rate
+            ), f" should be satisfied with a probability at least {dr_criterion_pass_rate}"
 
     for model_name in auc_scores:
         print(f"AUC of {model_name} is {auc_scores[model_name]}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from obp.utils import sample_action_fast, softmax
+
+
+def test_sample_action_fast():
+    n_rounds = 10
+    n_actions = 5
+    n_sim = 100000
+
+    true_probs = softmax(np.random.normal(size=(n_rounds, n_actions)))
+    sampled_action_list = list()
+    for _ in np.arange(n_sim):
+        sampled_action_list.append(sample_action_fast(true_probs)[:, np.newaxis])
+
+    sampled_action_arr = np.concatenate(sampled_action_list, 1)
+    for i in np.arange(n_rounds):
+        sampled_action_counts = np.unique(sampled_action_arr[i], return_counts=True)[1]
+        empirical_probs = sampled_action_counts / n_sim
+        assert np.isclose(true_probs[i], empirical_probs, rtol=5e-2, atol=1e-3).all()


### PR DESCRIPTION
## new features

- add the following two arguments to `obp.dataset.SyntheticBanditDataset`
    - `reward_std`: Standard deviation of the reward distribution.
    - `tau`: A temperature hyperparameer to control the behavior policy.

these arguments are helpful to modify the synthetic data that will be generated.

- add `obp.utils.sample_action_fast` function. This will make it fast to sample actions from a behavior policy when generating synthetic bandit data.

- add corresponding tests 