### PR TITLE
Add error to detect negative rewards in IPWLearner

### DIFF
--- a/obp/dataset/synthetic_continuous.py
+++ b/obp/dataset/synthetic_continuous.py
@@ -240,12 +240,11 @@ class SyntheticContinuousBanditDataset(BaseBanditDataset):
 
         """
         check_array(array=context, name="context", expected_dim=2)
+        check_array(array=action, name="action", expected_dim=1)
         if context.shape[1] != self.dim_context:
             raise ValueError(
                 "Expected `context.shape[1] == self.dim_context`, found it False"
             )
-        if not isinstance(action, np.ndarray) or action.ndim != 1:
-            raise ValueError("action must be 1D array")
         if context.shape[0] != action.shape[0]:
             raise ValueError(
                 "Expected `context.shape[0] == action.shape[0]`, but found it False"

--- a/obp/policy/base.py
+++ b/obp/policy/base.py
@@ -209,7 +209,7 @@ class BaseOfflinePolicyLearner(metaclass=ABCMeta):
 
         if self.n_actions < self.len_list:
             raise ValueError(
-                f"n_actions >= len_list should hold, but n_actions is {self.n_actions} and len_list is {self.len_list}"
+                f"Expected `n_actions >= len_list`, but got n_actions={self.n_actions} < len_list={self.len_list}"
             )
 
     @property

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -216,7 +216,8 @@ def check_bandit_feedback_inputs(
             context.shape[0] == action.shape[0] == reward.shape[0] == pscore.shape[0]
         ):
             raise ValueError(
-                "Expected `action.shape[0] == reward.shape[0] == pscore.shape[0]`, but found it False"
+                "Expected `context.shape[0] == action.shape[0] == reward.shape[0] == pscore.shape[0]`"
+                ", but found it False"
             )
         if np.any(pscore <= 0):
             raise ValueError("pscore must be positive")
@@ -227,14 +228,16 @@ def check_bandit_feedback_inputs(
             context.shape[0] == action.shape[0] == reward.shape[0] == position.shape[0]
         ):
             raise ValueError(
-                "context, action, reward, and position must have the same number of samples."
+                "Expected `context.shape[0] == action.shape[0] == reward.shape[0] == position.shape[0]`"
+                ", but found it False"
             )
         if not (np.issubdtype(position.dtype, np.integer) and position.min() >= 0):
             raise ValueError("position elements must be non-negative integers")
     else:
         if not (context.shape[0] == action.shape[0] == reward.shape[0]):
             raise ValueError(
-                "context, action, and reward must have the same number of samples."
+                "Expected `context.shape[0] == action.shape[0] == reward.shape[0]`"
+                ", but found it False"
             )
     if action_context is not None:
         check_array(array=action_context, name="action_context", expected_dim=2)
@@ -444,7 +447,8 @@ def check_continuous_ope_inputs(
             != action_by_evaluation_policy.shape[0]
         ):
             raise ValueError(
-                "Expected `estimated_rewards_by_reg_model.shape[0] == action_by_evaluation_policy.shape[0]`, but found if False"
+                "Expected `estimated_rewards_by_reg_model.shape[0] == action_by_evaluation_policy.shape[0]`"
+                ", but found if False"
             )
 
     # action, reward
@@ -457,7 +461,8 @@ def check_continuous_ope_inputs(
         check_array(array=reward, name="reward", expected_dim=1)
         if not (action_by_behavior_policy.shape[0] == reward.shape[0]):
             raise ValueError(
-                "Expected `action_by_behavior_policy.shape[0] == reward.shape[0]`, but found it False"
+                "Expected `action_by_behavior_policy.shape[0] == reward.shape[0]`,"
+                "but found it False"
             )
         if not (
             action_by_behavior_policy.shape[0] == action_by_evaluation_policy.shape[0]
@@ -548,7 +553,8 @@ def _check_slate_ope_inputs(
         == evaluation_policy_pscore.shape[0]
     ):
         raise ValueError(
-            f"slate_id, position, reward, {pscore_type}, and evaluation_policy_{pscore_type} must have the same number of samples."
+            f"slate_id, position, reward, {pscore_type}, and evaluation_policy_{pscore_type}"
+            "must have the same number of samples."
         )
 
 
@@ -805,7 +811,8 @@ def check_ope_inputs_tensor(
     if estimated_rewards_by_reg_model is not None:
         if estimated_rewards_by_reg_model.shape != action_dist.shape:
             raise ValueError(
-                "Expected `estimated_rewards_by_reg_model.shape == action_dist.shape`, but found it False"
+                "Expected `estimated_rewards_by_reg_model.shape == action_dist.shape`,"
+                "but found it False"
             )
 
     # action, reward
@@ -831,7 +838,8 @@ def check_ope_inputs_tensor(
             raise ValueError("pscore must be 1-dimensional")
         if not (action.shape[0] == reward.shape[0] == pscore.shape[0]):
             raise ValueError(
-                "Expected `action.shape[0] == reward.shape[0] == pscore.shape[0]`, but found it False"
+                "Expected `action.shape[0] == reward.shape[0] == pscore.shape[0]`,"
+                "but found it False"
             )
         if torch.any(pscore <= 0):
             raise ValueError("pscore must be positive")

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -204,7 +204,8 @@ def check_bandit_feedback_inputs(
             == expected_reward.shape[0]
         ):
             raise ValueError(
-                "context, action, reward, and expected_reward must have the same number of samples."
+                "Expected `context.shape[0] == action.shape[0] == reward.shape[0] == expected_reward.shape[0]`"
+                ", but found it False"
             )
         if action.max() >= expected_reward.shape[1]:
             raise ValueError(
@@ -461,15 +462,15 @@ def check_continuous_ope_inputs(
         check_array(array=reward, name="reward", expected_dim=1)
         if not (action_by_behavior_policy.shape[0] == reward.shape[0]):
             raise ValueError(
-                "Expected `action_by_behavior_policy.shape[0] == reward.shape[0]`,"
-                "but found it False"
+                "Expected `action_by_behavior_policy.shape[0] == reward.shape[0]`"
+                ", but found it False"
             )
         if not (
             action_by_behavior_policy.shape[0] == action_by_evaluation_policy.shape[0]
         ):
             raise ValueError(
                 "Expected `action_by_behavior_policy.shape[0] == action_by_evaluation_policy.shape[0]`"
-                "but found it False"
+                ", but found it False"
             )
 
     # pscore
@@ -553,7 +554,7 @@ def _check_slate_ope_inputs(
         == evaluation_policy_pscore.shape[0]
     ):
         raise ValueError(
-            f"slate_id, position, reward, {pscore_type}, and evaluation_policy_{pscore_type}"
+            f"slate_id, position, reward, {pscore_type}, and evaluation_policy_{pscore_type} "
             "must have the same number of samples."
         )
 
@@ -811,8 +812,8 @@ def check_ope_inputs_tensor(
     if estimated_rewards_by_reg_model is not None:
         if estimated_rewards_by_reg_model.shape != action_dist.shape:
             raise ValueError(
-                "Expected `estimated_rewards_by_reg_model.shape == action_dist.shape`,"
-                "but found it False"
+                "Expected `estimated_rewards_by_reg_model.shape == action_dist.shape`"
+                ", but found it False"
             )
 
     # action, reward
@@ -838,8 +839,8 @@ def check_ope_inputs_tensor(
             raise ValueError("pscore must be 1-dimensional")
         if not (action.shape[0] == reward.shape[0] == pscore.shape[0]):
             raise ValueError(
-                "Expected `action.shape[0] == reward.shape[0] == pscore.shape[0]`,"
-                "but found it False"
+                "Expected `action.shape[0] == reward.shape[0] == pscore.shape[0]`"
+                ", but found it False"
             )
         if torch.any(pscore <= 0):
             raise ValueError("pscore must be positive")

--- a/tests/ope/test_regression_models.py
+++ b/tests/ope/test_regression_models.py
@@ -270,7 +270,7 @@ invalid_input_of_fitting_regression_models = [
         generate_action_dist(n_rounds, n_actions, len_list),
         3,
         1,
-        "Expected `action.shape[0]",
+        "Expected `context.shape[0]",
     ),
     (
         np.random.uniform(size=(n_rounds, 7)),
@@ -382,7 +382,7 @@ invalid_input_of_fitting_regression_models = [
         None,
         3,
         1,
-        "context, action, and reward must have the same number of samples",
+        "Expected `context.shape[0]",
     ),
     (
         np.random.uniform(size=(n_rounds, 7)),
@@ -398,7 +398,7 @@ invalid_input_of_fitting_regression_models = [
         generate_action_dist(n_rounds, n_actions, len_list),
         3,
         1,
-        "Expected `action.shape[0]",
+        "Expected `context.shape[0]",
     ),
     (
         np.random.uniform(size=(n_rounds, 7)),

--- a/tests/ope/test_regression_models.py
+++ b/tests/ope/test_regression_models.py
@@ -334,7 +334,7 @@ invalid_input_of_fitting_regression_models = [
         None,
         3,
         1,
-        "context, action, reward, and position must have the same number of samples.",
+        "Expected `context.shape[0]",
     ),
     (
         np.random.uniform(size=(n_rounds, 7)),

--- a/tests/policy/test_offline.py
+++ b/tests/policy/test_offline.py
@@ -12,51 +12,39 @@ from obp.ope.estimators import InverseProbabilityWeighting
 base_classifier = LogisticRegression()
 base_regressor = LinearRegression()
 
-# n_actions, len_list, dim_context, base_classifier, description
-invalid_input_of_nn_policy_learner_init = [
+# n_actions, len_list, base_classifier, description
+invalid_input_of_ipw_learner_init = [
     (
         0,  #
         1,
-        2,
         base_classifier,
         "n_actions must be an integer larger than 1",
     ),
     (
         10,
         -1,  #
-        2,
         base_classifier,
         "len_list must be a positive integer",
     ),
     (
         10,
         20,  #
-        2,
         base_classifier,
         "Expected `n_actions",
     ),
-    (
-        10,
-        1,
-        -1,  #
-        base_classifier,
-        "dim_context must be a positive integer",
-    ),
-    (10, 1, 2, base_regressor, "base_classifier must be a classifier"),  #
+    (10, 1, base_regressor, "base_classifier must be a classifier"),
 ]
 
-valid_input_of_nn_policy_learner_init = [
+valid_input_of_ipw_learner_init = [
     (
         10,
         1,
-        2,
         None,
         "valid input",
     ),
     (
         10,
         1,
-        2,
         base_classifier,
         "valid input",
     ),
@@ -64,13 +52,12 @@ valid_input_of_nn_policy_learner_init = [
 
 
 @pytest.mark.parametrize(
-    "n_actions, len_list, dim_context, base_classifier, description",
-    invalid_input_of_nn_policy_learner_init,
+    "n_actions, len_list, base_classifier, description",
+    invalid_input_of_ipw_learner_init,
 )
 def test_ipw_learner_init_using_invalid_inputs(
     n_actions,
     len_list,
-    dim_context,
     base_classifier,
     description,
 ):
@@ -78,26 +65,23 @@ def test_ipw_learner_init_using_invalid_inputs(
         _ = IPWLearner(
             n_actions=n_actions,
             len_list=len_list,
-            dim_context=dim_context,
             base_classifier=base_classifier,
         )
 
 
 @pytest.mark.parametrize(
-    "n_actions, len_list, dim_context, base_classifier, description",
-    valid_input_of_nn_policy_learner_init,
+    "n_actions, len_list, base_classifier, description",
+    valid_input_of_ipw_learner_init,
 )
 def test_ipw_learner_init_using_valid_inputs(
     n_actions,
     len_list,
-    dim_context,
     base_classifier,
     description,
 ):
     ipw_learner = IPWLearner(
         n_actions=n_actions,
         len_list=len_list,
-        dim_context=dim_context,
         base_classifier=base_classifier,
     )
     # policy_type

--- a/tests/policy/test_offline.py
+++ b/tests/policy/test_offline.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import LogisticRegression, LinearRegression
 import torch
 
 from obp.policy.offline import IPWLearner
@@ -9,44 +9,108 @@ from obp.policy.policy_type import PolicyType
 from obp.ope.estimators import InverseProbabilityWeighting
 
 
-def test_base_opl_init():
-    # n_actions
-    with pytest.raises(ValueError):
-        IPWLearner(n_actions=1)
+base_classifier = LogisticRegression()
+base_regressor = LinearRegression()
 
-    with pytest.raises(ValueError):
-        IPWLearner(n_actions="3")
+# n_actions, len_list, dim_context, base_classifier, description
+invalid_input_of_nn_policy_learner_init = [
+    (
+        0,  #
+        1,
+        2,
+        base_classifier,
+        "n_actions must be an integer larger than 1",
+    ),
+    (
+        10,
+        -1,  #
+        2,
+        base_classifier,
+        "len_list must be a positive integer",
+    ),
+    (
+        10,
+        20,  #
+        2,
+        base_classifier,
+        "Expected `n_actions",
+    ),
+    (
+        10,
+        1,
+        -1,  #
+        base_classifier,
+        "dim_context must be a positive integer",
+    ),
+    (10, 1, 2, base_regressor, "base_classifier must be a classifier"),  #
+]
 
-    # len_list
-    with pytest.raises(ValueError):
-        IPWLearner(n_actions=2, len_list=0)
+valid_input_of_nn_policy_learner_init = [
+    (
+        10,
+        1,
+        2,
+        None,
+        "valid input",
+    ),
+    (
+        10,
+        1,
+        2,
+        base_classifier,
+        "valid input",
+    ),
+]
 
-    with pytest.raises(ValueError):
-        IPWLearner(n_actions=2, len_list="3")
 
+@pytest.mark.parametrize(
+    "n_actions, len_list, dim_context, base_classifier, description",
+    invalid_input_of_nn_policy_learner_init,
+)
+def test_ipw_learner_init_using_invalid_inputs(
+    n_actions,
+    len_list,
+    dim_context,
+    base_classifier,
+    description,
+):
+    with pytest.raises(ValueError, match=f"{description}*"):
+        _ = IPWLearner(
+            n_actions=n_actions,
+            len_list=len_list,
+            dim_context=dim_context,
+            base_classifier=base_classifier,
+        )
+
+
+@pytest.mark.parametrize(
+    "n_actions, len_list, dim_context, base_classifier, description",
+    valid_input_of_nn_policy_learner_init,
+)
+def test_ipw_learner_init_using_valid_inputs(
+    n_actions,
+    len_list,
+    dim_context,
+    base_classifier,
+    description,
+):
+    ipw_learner = IPWLearner(
+        n_actions=n_actions,
+        len_list=len_list,
+        dim_context=dim_context,
+        base_classifier=base_classifier,
+    )
     # policy_type
-    assert IPWLearner(n_actions=2).policy_type == PolicyType.OFFLINE
-
-    # invalid relationship between n_actions and len_list
-    with pytest.raises(ValueError):
-        IPWLearner(n_actions=5, len_list=10)
-
-    with pytest.raises(ValueError):
-        IPWLearner(n_actions=2, len_list=3)
+    assert ipw_learner.policy_type == PolicyType.OFFLINE
 
 
-def test_ipw_learner_init():
+def test_ipw_learner_init_base_classifier_list():
     # base classifier
     len_list = 2
     learner1 = IPWLearner(n_actions=2, len_list=len_list)
     assert isinstance(learner1.base_classifier, LogisticRegression)
     for i in range(len_list):
         assert isinstance(learner1.base_classifier_list[i], LogisticRegression)
-
-    with pytest.raises(ValueError):
-        from sklearn.linear_model import LinearRegression
-
-        IPWLearner(n_actions=2, base_classifier=LinearRegression())
 
     from sklearn.naive_bayes import GaussianNB
 
@@ -73,25 +137,50 @@ def test_ipw_learner_create_train_data_for_opl():
 
 
 def test_ipw_learner_fit():
-    context = np.array([1.0, 1.0, 1.0, 1.0]).reshape(2, -1)
-    action = np.array([0, 1])
-    reward = np.array([1.0, 0.0])
-    position = np.array([0, 0])
-    learner = IPWLearner(n_actions=2, len_list=1)
-    learner.fit(context=context, action=action, reward=reward, position=position)
+    n_rounds = 1000
+    dim_context = 5
+    n_actions = 3
+    len_list = 2
+    context = np.ones((n_rounds, dim_context))
+    action = np.random.choice(np.arange(len_list, dtype=int), size=n_rounds)
+    reward = np.random.choice(np.arange(2), size=n_rounds)
+    position = np.random.choice(np.arange(len_list, dtype=int), size=n_rounds)
 
     # inconsistency with the shape
-    with pytest.raises(ValueError):
-        learner = IPWLearner(n_actions=2, len_list=2)
-        variant_context = np.array([1.0, 1.0, 1.0, 1.0])
+    desc = "Expected `context.shape[0]"
+    with pytest.raises(ValueError, match=f"{desc}*"):
+        learner = IPWLearner(n_actions=n_actions, len_list=len_list)
+        variant_context = np.random.normal(size=(n_rounds + 1, n_actions))
         learner.fit(
-            context=variant_context, action=action, reward=reward, position=position
+            context=variant_context,
+            action=action,
+            reward=reward,
+            position=position,
         )
 
     # len_list > 2, but position is not set
-    with pytest.raises(ValueError):
-        learner = IPWLearner(n_actions=2, len_list=2)
+    desc = "When `self.len_list=1"
+    with pytest.raises(ValueError, match=f"{desc}*"):
+        learner = IPWLearner(n_actions=n_actions, len_list=len_list)
         learner.fit(context=context, action=action, reward=reward)
+
+    # position must be non-negative
+    desc = "position elements must be non-negative integers"
+    with pytest.raises(ValueError, match=f"{desc}*"):
+        negative_position = position - 1
+        learner = IPWLearner(n_actions=n_actions, len_list=len_list)
+        learner.fit(
+            context=context, action=action, reward=reward, position=negative_position
+        )
+
+    # IPWLearner cannot handle negative rewards
+    desc = "A negative value is found in"
+    with pytest.raises(ValueError, match=f"{desc}*"):
+        negative_reward = reward - 1.0
+        learner = IPWLearner(n_actions=n_actions, len_list=len_list)
+        learner.fit(
+            context=context, action=action, reward=negative_reward, position=position
+        )
 
 
 def test_ipw_learner_predict():
@@ -99,7 +188,8 @@ def test_ipw_learner_predict():
     len_list = 1
 
     # shape error
-    with pytest.raises(ValueError):
+    desc = "context must be 2D array"
+    with pytest.raises(ValueError, match=f"{desc}*"):
         context = np.array([1.0, 1.0])
         learner = IPWLearner(n_actions=n_actions, len_list=len_list)
         learner.predict(context=context)
@@ -133,11 +223,12 @@ def test_ipw_learner_sample_action():
     learner = IPWLearner(n_actions=n_actions, len_list=len_list)
     learner.fit(context=context, action=action, reward=reward, position=position)
 
-    with pytest.raises(ValueError):
+    desc = "context must be 2D array"
+    with pytest.raises(ValueError, match=f"{desc}*"):
         invalid_type_context = [1.0, 2.0]
         learner.sample_action(context=invalid_type_context)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"{desc}*"):
         invalid_ndim_context = np.array([1.0, 2.0, 3.0, 4.0])
         learner.sample_action(context=invalid_ndim_context)
 
@@ -1009,7 +1100,8 @@ def test_nn_policy_learner_fit():
     ipw = InverseProbabilityWeighting()
 
     # inconsistency with the shape
-    with pytest.raises(ValueError):
+    desc = "Expected `context.shape[0]"
+    with pytest.raises(ValueError, match=f"{desc}*"):
         learner = NNPolicyLearner(
             n_actions=2,
             dim_context=2,
@@ -1021,7 +1113,8 @@ def test_nn_policy_learner_fit():
         )
 
     # inconsistency between dim_context and context
-    with pytest.raises(ValueError):
+    desc = "Expected `context.shape[1]"
+    with pytest.raises(ValueError, match=f"{desc}*"):
         learner = NNPolicyLearner(
             n_actions=2,
             dim_context=3,
@@ -1041,7 +1134,8 @@ def test_nn_policy_learner_predict():
     ipw = InverseProbabilityWeighting()
 
     # shape error
-    with pytest.raises(ValueError):
+    desc = "context must be 2D array"
+    with pytest.raises(ValueError, match=f"{desc}*"):
         learner = NNPolicyLearner(
             n_actions=n_actions,
             len_list=len_list,
@@ -1053,7 +1147,8 @@ def test_nn_policy_learner_predict():
         learner.predict(context=invalid_context)
 
     # inconsistency between dim_context and context
-    with pytest.raises(ValueError):
+    desc = "Expected `context.shape[1]"
+    with pytest.raises(ValueError, match=f"{desc}*"):
         learner = NNPolicyLearner(
             n_actions=n_actions,
             len_list=len_list,
@@ -1093,7 +1188,8 @@ def test_nn_policy_learner_sample_action():
     ipw = InverseProbabilityWeighting()
 
     # shape error
-    with pytest.raises(ValueError):
+    desc = "context must be 2D array"
+    with pytest.raises(ValueError, match=f"{desc}*"):
         learner = NNPolicyLearner(
             n_actions=n_actions,
             len_list=len_list,
@@ -1105,7 +1201,8 @@ def test_nn_policy_learner_sample_action():
         learner.sample_action(context=invalid_context)
 
     # inconsistency between dim_context and context
-    with pytest.raises(ValueError):
+    desc = "Expected `context.shape[1]"
+    with pytest.raises(ValueError, match=f"{desc}*"):
         learner = NNPolicyLearner(
             n_actions=n_actions,
             len_list=len_list,
@@ -1143,7 +1240,8 @@ def test_nn_policy_learner_predict_proba():
     ipw = InverseProbabilityWeighting()
 
     # shape error
-    with pytest.raises(ValueError):
+    desc = "context must be 2D array"
+    with pytest.raises(ValueError, match=f"{desc}*"):
         learner = NNPolicyLearner(
             n_actions=n_actions,
             len_list=len_list,
@@ -1155,7 +1253,8 @@ def test_nn_policy_learner_predict_proba():
         learner.predict_proba(context=invalid_context)
 
     # inconsistency between dim_context and context
-    with pytest.raises(ValueError):
+    desc = "Expected `context.shape[1]"
+    with pytest.raises(ValueError, match=f"{desc}*"):
         learner = NNPolicyLearner(
             n_actions=n_actions,
             len_list=len_list,


### PR DESCRIPTION
## updates

- add `ValueError` to detect negative reward inputs for `obp.policy.IPWLearner`. When there are some negative rewards, `obp.policy.NNPolicyLearner` should be used instead.
- Fix some error messages and test scripts