### PR TITLE
Feature Implement QLearner

### DIFF
--- a/obp/__init__.py
+++ b/obp/__init__.py
@@ -1,1 +1,10 @@
-from .version import __version__  # noqa
+from obp import dataset
+from obp import ope
+from obp import policy
+from obp import simulator
+from obp import types
+from obp import utils
+from obp.version import __version__  # noqa
+
+
+__all__ = ["dataset", "ope", "policy", "simulator", "types", "utils", "version"]

--- a/obp/dataset/real.py
+++ b/obp/dataset/real.py
@@ -248,7 +248,7 @@ class OpenBanditDataset(BaseRealBanditDataset):
                 min_val=0.0,
                 max_val=1.0,
             )
-            n_rounds_train = np.int(self.n_rounds * (1.0 - test_size))
+            n_rounds_train = np.int32(self.n_rounds * (1.0 - test_size))
             bandit_feedback_train = dict(
                 n_rounds=n_rounds_train,
                 n_actions=self.n_actions,

--- a/obp/dataset/real.py
+++ b/obp/dataset/real.py
@@ -199,11 +199,13 @@ class OpenBanditDataset(BaseRealBanditDataset):
         self.context = pd.get_dummies(
             self.data.loc[:, user_cols], drop_first=True
         ).values
-        item_feature_0 = self.item_context["item_feature_0"]
-        item_feature_cat = self.item_context.drop("item_feature_0", 1).apply(
-            LabelEncoder().fit_transform
-        )
-        self.action_context = pd.concat([item_feature_cat, item_feature_0], 1).values
+        item_feature_0 = self.item_context["item_feature_0"].to_frame()
+        item_feature_cat = self.item_context.drop(
+            columns=["item_id", "item_feature_0"], axis=1
+        ).apply(LabelEncoder().fit_transform)
+        self.action_context = pd.concat(
+            objs=[item_feature_cat, item_feature_0], axis=1
+        ).values
 
     def obtain_batch_bandit_feedback(
         self, test_size: float = 0.3, is_timeseries_split: bool = False

--- a/obp/dataset/synthetic_continuous.py
+++ b/obp/dataset/synthetic_continuous.py
@@ -148,7 +148,7 @@ class SyntheticContinuousBanditDataset(BaseBanditDataset):
         Calculate context-free expected rewards given only continuous action values.
         This is just an example synthetic (expected) reward function.
         """
-        return 2 * np.power(action, 1.5) - (5 * action)
+        return 2 * np.power(np.abs(action), 1.5) - (5 * action)
 
     def obtain_batch_bandit_feedback(
         self,

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -1433,7 +1433,7 @@ def linear_behavior_policy_logit(
         Controls the random seed in sampling dataset.
 
     tau: int or float, default=1.0
-        A temperature parameter, controlling the randomness of the action choice by scaling thescores before applying softmax.
+        A temperature parameter, controlling the randomness of the action choice by scaling the scores before applying softmax.
         As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
     Returns

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -1433,7 +1433,7 @@ def linear_behavior_policy_logit(
         Controls the random seed in sampling dataset.
 
     tau: int or float, default=1.0
-        A temperature parameter, controlling the randomness of the action choice.
+        A temperature parameter, controlling the randomness of the action choice by scaling thescores before applying softmax.
         As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
     Returns

--- a/obp/ope/meta.py
+++ b/obp/ope/meta.py
@@ -407,7 +407,7 @@ class OffPolicyEvaluation:
         )
         plt.xlabel("OPE Estimators", fontsize=25)
         plt.ylabel(
-            f"Estimated Policy Value (± {np.int(100*(1 - alpha))}% CI)", fontsize=20
+            f"Estimated Policy Value (± {np.int32(100*(1 - alpha))}% CI)", fontsize=20
         )
         plt.yticks(fontsize=15)
         plt.xticks(fontsize=25 - 2 * len(self.ope_estimators))
@@ -639,7 +639,8 @@ class OffPolicyEvaluation:
             )
             ax.set_title(estimator_name.upper(), fontsize=20)
             ax.set_ylabel(
-                f"Estimated Policy Value (± {np.int(100*(1 - alpha))}% CI)", fontsize=20
+                f"Estimated Policy Value (± {np.int32(100*(1 - alpha))}% CI)",
+                fontsize=20,
             )
             plt.yticks(fontsize=15)
             plt.xticks(fontsize=25 - 2 * len(policy_name_list))

--- a/obp/ope/meta_continuous.py
+++ b/obp/ope/meta_continuous.py
@@ -424,7 +424,7 @@ class ContinuousOffPolicyEvaluation:
         )
         plt.xlabel("OPE Estimators", fontsize=25)
         plt.ylabel(
-            f"Estimated Policy Value (± {np.int(100*(1 - alpha))}% CI)", fontsize=20
+            f"Estimated Policy Value (± {np.int32(100*(1 - alpha))}% CI)", fontsize=20
         )
         plt.yticks(fontsize=15)
         plt.xticks(fontsize=25 - 2 * len(self.ope_estimators))
@@ -657,7 +657,8 @@ class ContinuousOffPolicyEvaluation:
             )
             ax.set_title(estimator_name.upper(), fontsize=20)
             ax.set_ylabel(
-                f"Estimated Policy Value (± {np.int(100*(1 - alpha))}% CI)", fontsize=20
+                f"Estimated Policy Value (± {np.int32(100*(1 - alpha))}% CI)",
+                fontsize=20,
             )
             plt.yticks(fontsize=15)
             plt.xticks(fontsize=25 - 2 * len(policy_name_list))

--- a/obp/ope/meta_slate.py
+++ b/obp/ope/meta_slate.py
@@ -407,7 +407,7 @@ class SlateOffPolicyEvaluation:
         )
         plt.xlabel("OPE Estimators", fontsize=25)
         plt.ylabel(
-            f"Estimated Policy Value (± {np.int(100*(1 - alpha))}% CI)", fontsize=20
+            f"Estimated Policy Value (± {np.int32(100*(1 - alpha))}% CI)", fontsize=20
         )
         plt.yticks(fontsize=15)
         plt.xticks(fontsize=25 - 2 * len(self.ope_estimators))

--- a/obp/policy/__init__.py
+++ b/obp/policy/__init__.py
@@ -13,8 +13,8 @@ from obp.policy.logistic import LogisticTS
 from obp.policy.logistic import LogisticUCB
 from obp.policy.logistic import MiniBatchLogisticRegression
 from obp.policy.offline import IPWLearner
-from obp.policy.offline import QLearner
 from obp.policy.offline import NNPolicyLearner
+from obp.policy.offline import QLearner
 from obp.policy.offline_continuous import ContinuousNNPolicyLearner
 
 

--- a/obp/policy/__init__.py
+++ b/obp/policy/__init__.py
@@ -13,6 +13,7 @@ from obp.policy.logistic import LogisticTS
 from obp.policy.logistic import LogisticUCB
 from obp.policy.logistic import MiniBatchLogisticRegression
 from obp.policy.offline import IPWLearner
+from obp.policy.offline import QLearner
 from obp.policy.offline import NNPolicyLearner
 from obp.policy.offline_continuous import ContinuousNNPolicyLearner
 
@@ -34,5 +35,6 @@ __all__ = [
     "MiniBatchLogisticRegression",
     "IPWLearner",
     "NNPolicyLearner",
+    "QLearner",
     "ContinuousNNPolicyLearner",
 ]

--- a/obp/policy/offline.py
+++ b/obp/policy/offline.py
@@ -274,7 +274,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
             Context vectors for new data.
 
         tau: int or float, default=1.0
-            A temperature parameter, controlling the randomness of the action choice by scaling thescores before applying softmax.
+            A temperature parameter, controlling the randomness of the action choice by scaling the scores before applying softmax.
             As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
         random_state: int, default=None
@@ -328,7 +328,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
 
         tau: int or float, default=1.0
             A temperature parameter, controlling the randomness of the action choice
-            by scaling thescores before applying softmax.
+            by scaling the scores before applying softmax.
             As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
         Returns
@@ -548,7 +548,7 @@ class QLearner(BaseOfflinePolicyLearner):
 
         tau: int or float, default=1.0
             A temperature parameter, controlling the randomness of the action choice
-            by scaling thescores before applying softmax.
+            by scaling the scores before applying softmax.
             As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
         random_state: int, default=None
@@ -599,7 +599,7 @@ class QLearner(BaseOfflinePolicyLearner):
 
         tau: int or float, default=1.0
             A temperature parameter, controlling the randomness of the action choice
-            by scaling thescores before applying softmax.
+            by scaling the scores before applying softmax.
             As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
         Returns
@@ -1310,7 +1310,7 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
 
         tau: int or float, default=1.0
             A temperature parameter, controlling the randomness of the action choice
-            by scaling thescores before applying softmax.
+            by scaling the scores before applying softmax.
             As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
         random_state: int, default=None

--- a/obp/policy/offline.py
+++ b/obp/policy/offline.py
@@ -35,7 +35,7 @@ from .base import BaseOfflinePolicyLearner
 
 @dataclass
 class IPWLearner(BaseOfflinePolicyLearner):
-    """Off-policy learner with Inverse Probability Weighting.
+    """Off-policy learner based on Inverse Probability Weighting.
 
     Parameters
     -----------
@@ -220,7 +220,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
         return action_dist
 
     def predict_score(self, context: np.ndarray) -> np.ndarray:
-        """Predict non-negative scores for all possible products of action and position.
+        """Predict non-negative scores for all possible action and position.
 
         Parameters
         -----------
@@ -265,7 +265,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
         :math:`f: \\mathcal{X} \\times \\mathcal{A} \\times \\mathcal{K} \\rightarrow \\mathbb{R}_{+}`
         is a scoring function which is now implemented in the `predict_score` method.
         :math:`\\gamma_{x,a}` is a random variable sampled from the Gumbel distribution.
-        By sorting the actions based on :math:`\\s (x,a)` for each context, we can sample a ranking from
+        By sorting the actions based on :math:`\\s (x,a)` for each context, we can efficiently sample a ranking from
         the Plackett-Luce ranking distribution.
 
         Parameters
@@ -274,7 +274,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
             Context vectors for new data.
 
         tau: int or float, default=1.0
-            A temperature parameter, controlling the randomness of the action choice.
+            A temperature parameter, controlling the randomness of the action choice by scaling thescores before applying softmax.
             As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
         random_state: int, default=None
@@ -283,7 +283,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
         Returns
         -----------
         action: array-like, shape (n_rounds_of_new_data, n_actions, len_list)
-            Ranking of actions sampled by the Gumbel softmax trick as follows.
+            Ranking of actions sampled by the Gumbel softmax trick.
 
         """
         check_array(array=context, name="context", expected_dim=2)
@@ -327,7 +327,8 @@ class IPWLearner(BaseOfflinePolicyLearner):
             Context vectors for new data.
 
         tau: int or float, default=1.0
-            A temperature parameter, controlling the randomness of the action choice.
+            A temperature parameter, controlling the randomness of the action choice
+            by scaling thescores before applying softmax.
             As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
         Returns
@@ -349,7 +350,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
 
 @dataclass
 class QLearner(BaseOfflinePolicyLearner):
-    """Off-policy learner with Direct Method.
+    """Off-policy learner based on Direct Method.
 
     Parameters
     -----------
@@ -466,9 +467,7 @@ class QLearner(BaseOfflinePolicyLearner):
             \\hat{a}_i \\in \\arg \\max_{a \\in \\mathcal{A}} \\hat{q}(x_i, a)
 
         where :math:`\\hat{q}(x,a)` is an estimator for the q function :math:`\\q(x,a) := \\mathbb{E} [r \\mid x, a]`.
-        Note that the action set predicted by this `predict` method can contain duplicate items.
-
-        Action set predicted by this `predict` method can contain duplicate items.
+        Note that action sets predicted by this `predict` method can contain duplicate items.
         If you want a non-repetitive action set, then please use the `sample_action` method.
 
         Parameters
@@ -500,7 +499,7 @@ class QLearner(BaseOfflinePolicyLearner):
         return action_dist
 
     def predict_score(self, context: np.ndarray) -> np.ndarray:
-        """Predict the expected reward for all possible products of action and position.
+        """Predict the expected reward for all possible action and position.
 
         Parameters
         -----------
@@ -539,7 +538,7 @@ class QLearner(BaseOfflinePolicyLearner):
         :math:`\\hat{q}: \\mathcal{X} \\times \\mathcal{A} \\times \\mathcal{K} \\rightarrow \\mathbb{R}_{+}`
         is a q function estimator, which is now implemented in the `predict_score` method.
         :math:`\\gamma_{x,a}` is a random variable sampled from the Gumbel distribution.
-        By sorting the actions based on :math:`\\s (x,a)` for each context, we can sample a ranking from
+        By sorting the actions based on :math:`\\s (x,a)` for each context, we can efficiently sample a ranking from
         the Plackett-Luce ranking distribution.
 
         Parameters
@@ -548,7 +547,8 @@ class QLearner(BaseOfflinePolicyLearner):
             Context vectors for new data.
 
         tau: int or float, default=1.0
-            A temperature parameter, controlling the randomness of the action choice.
+            A temperature parameter, controlling the randomness of the action choice
+            by scaling thescores before applying softmax.
             As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
         random_state: int, default=None
@@ -557,7 +557,7 @@ class QLearner(BaseOfflinePolicyLearner):
         Returns
         -----------
         sampled_action: array-like, shape (n_rounds_of_new_data, n_actions, len_list)
-            Ranking of action sampled from the Plackett-Luce ranking distribution by the Gumbel softmax trick.
+            Ranking of actions sampled from the Plackett-Luce ranking distribution by the Gumbel softmax trick.
 
         """
         check_array(array=context, name="context", expected_dim=2)
@@ -598,7 +598,8 @@ class QLearner(BaseOfflinePolicyLearner):
             Context vectors for new data.
 
         tau: int or float, default=1.0
-            A temperature parameter, controlling the randomness of the action choice.
+            A temperature parameter, controlling the randomness of the action choice
+            by scaling thescores before applying softmax.
             As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
         Returns
@@ -1299,7 +1300,7 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
         :math:`f: \\mathcal{X} \\times \\mathcal{A} \\times \\mathcal{K} \\rightarrow \\mathbb{R}_{+}`
         is a scoring function which is now implemented in the `predict_score` method.
         :math:`\\gamma_{x,a}` is a random variable sampled from the Gumbel distribution.
-        By sorting the actions based on :math:`\\s (x,a)` for each context, we can sample a ranking from
+        By sorting the actions based on :math:`\\s (x,a)` for each context, we can efficiently sample a ranking from
         the Plackett-Luce ranking distribution.
 
         Parameters
@@ -1308,7 +1309,8 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
             Context vectors for new data.
 
         tau: int or float, default=1.0
-            A temperature parameter, controlling the randomness of the action choice.
+            A temperature parameter, controlling the randomness of the action choice
+            by scaling thescores before applying softmax.
             As :math:`\\tau \\rightarrow \\infty`, the algorithm will select arms uniformly at random.
 
         random_state: int, default=None
@@ -1317,7 +1319,7 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
         Returns
         -----------
         sampled_action: array-like, shape (n_rounds_of_new_data, n_actions, len_list)
-            Ranking of action sampled from the Plackett-Luce ranking distribution by the Gumbel softmax trick.
+            Ranking of actions sampled from the Plackett-Luce ranking distribution by the Gumbel softmax trick.
 
         """
         check_array(array=context, name="context", expected_dim=2)

--- a/obp/policy/offline.py
+++ b/obp/policy/offline.py
@@ -24,7 +24,8 @@ from torch.nn.functional import mse_loss
 import torch.optim as optim
 from tqdm import tqdm
 
-from ..ope import RegressionModel
+from obp.ope import RegressionModel
+
 from ..utils import check_array
 from ..utils import check_bandit_feedback_inputs
 from ..utils import check_tensor
@@ -165,7 +166,7 @@ class IPWLearner(BaseOfflinePolicyLearner):
                 "and please use `obp.policy.NNPolicyLearner` instead."
             )
         if pscore is None:
-            n_actions = np.int(action.max() + 1)
+            n_actions = np.int32(action.max() + 1)
             pscore = np.ones_like(action) / n_actions
         if self.len_list == 1:
             position = np.zeros_like(action, dtype=int)
@@ -439,7 +440,7 @@ class QLearner(BaseOfflinePolicyLearner):
             position=position,
         )
         if pscore is None:
-            n_actions = np.int(action.max() + 1)
+            n_actions = np.int32(action.max() + 1)
             pscore = np.ones_like(action) / n_actions
         if self.len_list == 1:
             position = np.zeros_like(action, dtype=int)

--- a/obp/simulator/simulator.py
+++ b/obp/simulator/simulator.py
@@ -4,15 +4,21 @@
 """Bandit Simulator."""
 from copy import deepcopy
 from typing import Callable
+from typing import Union
 
 import numpy as np
 from tqdm import tqdm
 
+from ..policy import BaseContextFreePolicy
+from ..policy import BaseContextualPolicy
 from ..policy.policy_type import PolicyType
 from ..types import BanditFeedback
-from ..types import BanditPolicy
 from ..utils import check_bandit_feedback_inputs
 from ..utils import convert_to_action_dist
+
+
+# bandit policy type
+BanditPolicy = Union[BaseContextFreePolicy, BaseContextualPolicy]
 
 
 def run_bandit_simulation(

--- a/obp/types.py
+++ b/obp/types.py
@@ -7,12 +7,6 @@ from typing import Union
 
 import numpy as np
 
-from .policy import BaseContextFreePolicy
-from .policy import BaseContextualPolicy
-
 
 # dataset
 BanditFeedback = Dict[str, Union[int, np.ndarray]]
-
-# policy
-BanditPolicy = Union[BaseContextFreePolicy, BaseContextualPolicy]

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -794,7 +794,7 @@ def check_rips_inputs(
 
 def sigmoid(x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
     """Calculate sigmoid function."""
-    return np.exp(np.minimum(x, 0)) / 1.0 / (1.0 + np.exp(-np.abs(x)))
+    return np.exp(np.minimum(x, 0)) / (1.0 + np.exp(-np.abs(x)))
 
 
 def softmax(x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -794,7 +794,7 @@ def check_rips_inputs(
 
 def sigmoid(x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
     """Calculate sigmoid function."""
-    return 1.0 / (1.0 + np.exp(-x))
+    return np.exp(np.minimum(x, 0)) / 1.0 / (1.0 + np.exp(-np.abs(x)))
 
 
 def softmax(x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:

--- a/tests/dataset/test_multiclass.py
+++ b/tests/dataset/test_multiclass.py
@@ -20,12 +20,12 @@ def test_invalid_initialization(raw_data):
     # invalid alpha_b
     with pytest.raises(ValueError):
         MultiClassToBanditReduction(
-            X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=-0.3
+            X=X, y=y, base_classifier_b=LogisticRegression(max_iter=10000), alpha_b=-0.3
         )
 
     with pytest.raises(ValueError):
         MultiClassToBanditReduction(
-            X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=1.3
+            X=X, y=y, base_classifier_b=LogisticRegression(max_iter=10000), alpha_b=1.3
         )
 
     # invalid classifier
@@ -40,7 +40,7 @@ def test_split_train_eval(raw_data):
 
     eval_size = 1000
     mcbr = MultiClassToBanditReduction(
-        X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=0.3
+        X=X, y=y, base_classifier_b=LogisticRegression(max_iter=10000), alpha_b=0.3
     )
     mcbr.split_train_eval(eval_size=eval_size)
 
@@ -51,7 +51,7 @@ def test_obtain_batch_bandit_feedback(raw_data):
     X, y = raw_data
 
     mcbr = MultiClassToBanditReduction(
-        X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=0.3
+        X=X, y=y, base_classifier_b=LogisticRegression(max_iter=10000), alpha_b=0.3
     )
     mcbr.split_train_eval()
     bandit_feedback = mcbr.obtain_batch_bandit_feedback()
@@ -70,7 +70,7 @@ def test_obtain_action_dist_by_eval_policy(raw_data):
 
     eval_size = 1000
     mcbr = MultiClassToBanditReduction(
-        X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=0.3
+        X=X, y=y, base_classifier_b=LogisticRegression(max_iter=10000), alpha_b=0.3
     )
     mcbr.split_train_eval(eval_size=eval_size)
 
@@ -95,7 +95,7 @@ def test_calc_ground_truth_policy_value(raw_data):
 
     eval_size = 1000
     mcbr = MultiClassToBanditReduction(
-        X=X, y=y, base_classifier_b=LogisticRegression(), alpha_b=0.3
+        X=X, y=y, base_classifier_b=LogisticRegression(max_iter=10000), alpha_b=0.3
     )
     mcbr.split_train_eval(eval_size=eval_size)
 

--- a/tests/policy/test_offline.py
+++ b/tests/policy/test_offline.py
@@ -5,8 +5,8 @@ from sklearn.linear_model import LogisticRegression
 import torch
 
 from obp.policy.offline import IPWLearner
-from obp.policy.offline import QLearner
 from obp.policy.offline import NNPolicyLearner
+from obp.policy.offline import QLearner
 from obp.policy.policy_type import PolicyType
 
 

--- a/tests/policy/test_offline_learner_performance.py
+++ b/tests/policy/test_offline_learner_performance.py
@@ -81,7 +81,7 @@ offline_experiment_configurations = [
         "random_forest",
     ),
     (
-        400,
+        800,
         10,
         10,
         "lightgbm",
@@ -142,7 +142,7 @@ class UniformSampleWeightLearner(BaseOfflinePolicyLearner):
     ) -> None:
 
         if pscore is None:
-            n_actions = np.int(action.max() + 1)
+            n_actions = np.int32(action.max() + 1)
             pscore = np.ones_like(action) / n_actions
         if position is None or self.len_list == 1:
             position = np.zeros_like(action, dtype=int)
@@ -176,7 +176,7 @@ class UniformSampleWeightLearner(BaseOfflinePolicyLearner):
     "n_rounds, n_actions, dim_context, base_model_for_evaluation_policy, base_model_for_reg_model",
     offline_experiment_configurations,
 )
-def test_offline_ipwlearner_performance(
+def test_offline_policy_learner_performance(
     n_rounds: int,
     n_actions: int,
     dim_context: int,
@@ -192,173 +192,23 @@ def test_offline_ipwlearner_performance(
             behavior_policy_function=linear_behavior_policy,
             random_state=i,
         )
-        # define evaluation policy using IPWLearner
+        # sample new training and test sets of synthetic logged bandit feedback
+        bandit_feedback_train = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
+        bandit_feedback_test = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
+
+        # defining policy learners
         ipw_policy = IPWLearner(
             n_actions=dataset.n_actions,
             base_classifier=base_model_dict[base_model_for_evaluation_policy](
                 **hyperparams[base_model_for_evaluation_policy]
             ),
         )
-        # baseline method 1. RandomPolicy
-        random_policy = RandomPolicy(n_actions=dataset.n_actions)
-        # baseline method 2. UniformSampleWeightLearner
-        uniform_sample_weight_policy = UniformSampleWeightLearner(
-            n_actions=dataset.n_actions,
-            base_classifier=base_model_dict[base_model_for_evaluation_policy](
-                **hyperparams[base_model_for_evaluation_policy]
-            ),
-        )
-        # sample new training and test sets of synthetic logged bandit feedback
-        bandit_feedback_train = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
-        bandit_feedback_test = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
-        # train the evaluation policy on the training set of the synthetic logged bandit feedback
-        ipw_policy.fit(
-            context=bandit_feedback_train["context"],
-            action=bandit_feedback_train["action"],
-            reward=bandit_feedback_train["reward"],
-            pscore=bandit_feedback_train["pscore"],
-        )
-        uniform_sample_weight_policy.fit(
-            context=bandit_feedback_train["context"],
-            action=bandit_feedback_train["action"],
-            reward=bandit_feedback_train["reward"],
-            pscore=bandit_feedback_train["pscore"],
-        )
-        # predict the action decisions for the test set of the synthetic logged bandit feedback
-        ipw_action_dist = ipw_policy.predict(
-            context=bandit_feedback_test["context"],
-        )
-        random_action_dist = random_policy.predict(
-            context=bandit_feedback_test["context"],
-        )
-        uniform_sample_weight_action_dist = uniform_sample_weight_policy.predict(
-            context=bandit_feedback_test["context"],
-        )
-        # get the ground truth policy value for each learner
-        gt_ipw_learner = dataset.calc_ground_truth_policy_value(
-            expected_reward=bandit_feedback_test["expected_reward"],
-            action_dist=ipw_action_dist,
-        )
-        gt_random_policy = dataset.calc_ground_truth_policy_value(
-            expected_reward=bandit_feedback_test["expected_reward"],
-            action_dist=random_action_dist,
-        )
-        gt_uniform_sample_weight_learner = dataset.calc_ground_truth_policy_value(
-            expected_reward=bandit_feedback_test["expected_reward"],
-            action_dist=uniform_sample_weight_action_dist,
-        )
-
-        return gt_ipw_learner, gt_random_policy, gt_uniform_sample_weight_learner
-
-    n_runs = 10
-    processed = Parallel(
-        n_jobs=-1,
-        verbose=0,
-    )([delayed(process)(i) for i in np.arange(n_runs)])
-    list_gt_ipw, list_gt_random, list_gt_uniform = [], [], []
-    for i, ground_truth_policy_values in enumerate(processed):
-        gt_ipw, gt_random, gt_uniform = ground_truth_policy_values
-        list_gt_ipw.append(gt_ipw)
-        list_gt_random.append(gt_random)
-        list_gt_uniform.append(gt_uniform)
-
-    assert np.mean(list_gt_ipw) > np.mean(list_gt_random)
-    assert np.mean(list_gt_ipw) > np.mean(list_gt_uniform)
-
-
-@pytest.mark.parametrize(
-    "n_rounds, n_actions, dim_context, base_model_for_evaluation_policy, base_model_for_reg_model",
-    offline_experiment_configurations,
-)
-def test_offline_qlearner_performance(
-    n_rounds: int,
-    n_actions: int,
-    dim_context: int,
-    base_model_for_evaluation_policy: str,
-    base_model_for_reg_model: str,
-) -> None:
-    def process(i: int):
-        # synthetic data generator
-        dataset = SyntheticBanditDataset(
-            n_actions=n_actions,
-            dim_context=dim_context,
-            reward_function=logistic_reward_function,
-            behavior_policy_function=linear_behavior_policy,
-            random_state=i,
-        )
-        # define evaluation policy using IPWLearner
         q_policy = QLearner(
             n_actions=dataset.n_actions,
             base_model=base_model_dict[base_model_for_evaluation_policy](
                 **hyperparams[base_model_for_evaluation_policy]
             ),
         )
-        # baseline method 1. RandomPolicy
-        random_policy = RandomPolicy(n_actions=dataset.n_actions)
-        # sample new training and test sets of synthetic logged bandit feedback
-        bandit_feedback_train = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
-        bandit_feedback_test = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
-        # train the evaluation policy on the training set of the synthetic logged bandit feedback
-        q_policy.fit(
-            context=bandit_feedback_train["context"],
-            action=bandit_feedback_train["action"],
-            reward=bandit_feedback_train["reward"],
-            pscore=bandit_feedback_train["pscore"],
-        )
-        # predict the action decisions for the test set of the synthetic logged bandit feedback
-        q_action_dist = q_policy.predict(
-            context=bandit_feedback_test["context"],
-        )
-        random_action_dist = random_policy.predict(
-            context=bandit_feedback_test["context"],
-        )
-        # get the ground truth policy value for each learner
-        gt_q_learner = dataset.calc_ground_truth_policy_value(
-            expected_reward=bandit_feedback_test["expected_reward"],
-            action_dist=q_action_dist,
-        )
-        gt_random_policy = dataset.calc_ground_truth_policy_value(
-            expected_reward=bandit_feedback_test["expected_reward"],
-            action_dist=random_action_dist,
-        )
-
-        return gt_q_learner, gt_random_policy
-
-    n_runs = 10
-    processed = Parallel(
-        n_jobs=-1,
-        verbose=0,
-    )([delayed(process)(i) for i in np.arange(n_runs)])
-    list_gt_q, list_gt_random = [], []
-    for i, ground_truth_policy_values in enumerate(processed):
-        gt_q, gt_random = ground_truth_policy_values
-        list_gt_q.append(gt_q)
-        list_gt_random.append(gt_random)
-
-    assert np.mean(list_gt_q) > np.mean(list_gt_random)
-
-
-@pytest.mark.parametrize(
-    "n_rounds, n_actions, dim_context, base_model_for_evaluation_policy, base_model_for_reg_model",
-    offline_experiment_configurations,
-)
-def test_offline_nn_policy_learner_performance(
-    n_rounds: int,
-    n_actions: int,
-    dim_context: int,
-    base_model_for_evaluation_policy: str,
-    base_model_for_reg_model: str,
-) -> None:
-    def process(i: int):
-        # synthetic data generator
-        dataset = SyntheticBanditDataset(
-            n_actions=n_actions,
-            dim_context=dim_context,
-            reward_function=logistic_reward_function,
-            behavior_policy_function=linear_behavior_policy,
-            random_state=i,
-        )
-        # define evaluation policy using NNPolicyLearner
         nn_policy = NNPolicyLearner(
             n_actions=dataset.n_actions,
             dim_context=dim_context,
@@ -373,10 +223,20 @@ def test_offline_nn_policy_learner_performance(
                 **hyperparams[base_model_for_evaluation_policy]
             ),
         )
-        # sample new training and test sets of synthetic logged bandit feedback
-        bandit_feedback_train = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
-        bandit_feedback_test = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
-        # train the evaluation policy on the training set of the synthetic logged bandit feedback
+
+        # policy training
+        ipw_policy.fit(
+            context=bandit_feedback_train["context"],
+            action=bandit_feedback_train["action"],
+            reward=bandit_feedback_train["reward"],
+            pscore=bandit_feedback_train["pscore"],
+        )
+        q_policy.fit(
+            context=bandit_feedback_train["context"],
+            action=bandit_feedback_train["action"],
+            reward=bandit_feedback_train["reward"],
+            pscore=bandit_feedback_train["pscore"],
+        )
         nn_policy.fit(
             context=bandit_feedback_train["context"],
             action=bandit_feedback_train["action"],
@@ -389,8 +249,15 @@ def test_offline_nn_policy_learner_performance(
             reward=bandit_feedback_train["reward"],
             pscore=bandit_feedback_train["pscore"],
         )
-        # predict the action decisions for the test set of the synthetic logged bandit feedback
-        nn_policy_action_dist = nn_policy.predict(
+
+        # prediction/making decisions
+        ipw_action_dist = ipw_policy.predict(
+            context=bandit_feedback_test["context"],
+        )
+        q_action_dist = q_policy.predict(
+            context=bandit_feedback_test["context"],
+        )
+        nn_action_dist = nn_policy.predict(
             context=bandit_feedback_test["context"],
         )
         random_action_dist = random_policy.predict(
@@ -399,10 +266,19 @@ def test_offline_nn_policy_learner_performance(
         uniform_sample_weight_action_dist = uniform_sample_weight_policy.predict(
             context=bandit_feedback_test["context"],
         )
-        # get the ground truth policy value for each learner
-        gt_nn_policy_learner = dataset.calc_ground_truth_policy_value(
+
+        # evaluation
+        gt_ipw_learner = dataset.calc_ground_truth_policy_value(
             expected_reward=bandit_feedback_test["expected_reward"],
-            action_dist=nn_policy_action_dist,
+            action_dist=ipw_action_dist,
+        )
+        gt_q_learner = dataset.calc_ground_truth_policy_value(
+            expected_reward=bandit_feedback_test["expected_reward"],
+            action_dist=q_action_dist,
+        )
+        gt_nn_learner = dataset.calc_ground_truth_policy_value(
+            expected_reward=bandit_feedback_test["expected_reward"],
+            action_dist=nn_action_dist,
         )
         gt_random_policy = dataset.calc_ground_truth_policy_value(
             expected_reward=bandit_feedback_test["expected_reward"],
@@ -413,19 +289,46 @@ def test_offline_nn_policy_learner_performance(
             action_dist=uniform_sample_weight_action_dist,
         )
 
-        return gt_nn_policy_learner, gt_random_policy, gt_uniform_sample_weight_learner
+        return (
+            gt_ipw_learner,
+            gt_q_learner,
+            gt_nn_learner,
+            gt_random_policy,
+            gt_uniform_sample_weight_learner,
+        )
 
     n_runs = 10
     processed = Parallel(
-        n_jobs=1,  # PyTorch uses multiple threads
+        n_jobs=-1,
         verbose=0,
     )([delayed(process)(i) for i in np.arange(n_runs)])
-    list_gt_nn_policy, list_gt_random, list_gt_uniform = [], [], []
-    for i, ground_truth_policy_values in enumerate(processed):
-        gt_nn_policy, gt_random, gt_uniform = ground_truth_policy_values
-        list_gt_nn_policy.append(gt_nn_policy)
+    list_gt_ipw = list()
+    list_gt_q = list()
+    list_gt_nn = list()
+    list_gt_random = list()
+    list_gt_unif_ipw = list()
+    for i, gt_policy_values in enumerate(processed):
+        gt_ipw, gt_q, gt_nn, gt_random, gt_unif_ipw = gt_policy_values
+        list_gt_ipw.append(gt_ipw)
+        list_gt_q.append(gt_q)
+        list_gt_nn.append(gt_nn)
         list_gt_random.append(gt_random)
-        list_gt_uniform.append(gt_uniform)
+        list_gt_unif_ipw.append(gt_unif_ipw)
 
-    assert np.mean(list_gt_nn_policy) > np.mean(list_gt_random)
-    assert np.mean(list_gt_nn_policy) > np.mean(list_gt_uniform)
+    # baseline learner performance
+    print(f"Performance of Random is {np.mean(list_gt_random)}")
+    print(
+        f"Performance of IPWLearner with Uniform Weight is {np.mean(list_gt_unif_ipw)}"
+    )
+    # ipw learner performance
+    print(f"Performance of IPWLearner is {np.mean(list_gt_ipw)}")
+    assert np.mean(list_gt_ipw) > np.mean(list_gt_random)
+    assert np.mean(list_gt_ipw) > np.mean(list_gt_unif_ipw)
+    # q learner performance
+    print(f"Performance of QLearner is {np.mean(list_gt_q)}")
+    assert np.mean(list_gt_q) > np.mean(list_gt_random)
+    assert np.mean(list_gt_q) > np.mean(list_gt_unif_ipw)
+    # nn policy learner performance
+    print(f"Performance of NNPolicyLearner is {np.mean(list_gt_nn)}")
+    assert np.mean(list_gt_nn) > np.mean(list_gt_random)
+    assert np.mean(list_gt_nn) > np.mean(list_gt_unif_ipw)


### PR DESCRIPTION
## New Features

- implement QLearner in the policy module, which first estimates the expected reward function (or the q function) from the logged bandit data, and then use that estimator to make new decisions on the test data (such as via argmax or softmax)
- See example 1 of in Appendix A of https://arxiv.org/pdf/2002.08536v2.pdf for the definition of QLearner implemented here
- add some tests corresponds to the inputs and performance of the QLearner class in `tests/policy`
- implement "Gumbel softmax trick" (see Section 4.1 of https://arxiv.org/pdf/2105.00855.pdf) in IPWLearner/QLearner/NNPolicyLearner (of `obp.policy`) to efficiently sample a ranking of actions from the plucket luce ranking distribution

## Minor Fix
- unify some test functions to delete repetitive training of a same policy in `tests/policy/test_offline_learner_performance.py` to reduce the time needed to run the tests
- fix some numpy/pandas/sklearn warnings (now the tests will run without any warnings)