### PR TITLE
Add factual rewards to synthetic data generation and enable online bandit simulations

### DIFF
--- a/obp/dataset/synthetic_multi.py
+++ b/obp/dataset/synthetic_multi.py
@@ -305,7 +305,8 @@ class SyntheticMultiLoggersBanditDataset(SyntheticBanditDataset):
             pi_b_avg += rho * softmax(beta * pi_b_logits)
 
         # sample rewards based on the context and action
-        rewards = self.sample_reward_given_expected_reward(expected_reward_, actions)
+        factual_reward = self.sample_reward_given_expected_reward(expected_reward_)
+        rewards = factual_reward[np.arange(actions.shape[0]), actions]
 
         return dict(
             n_rounds=n_rounds,
@@ -316,6 +317,7 @@ class SyntheticMultiLoggersBanditDataset(SyntheticBanditDataset):
             action=actions,
             position=None,  # position effect is not considered in synthetic data
             reward=rewards,
+            factual_reward=factual_reward,
             expected_reward=expected_reward_,
             stratum_idx=stratum_idx,
             pi_b=pi_b[:, :, np.newaxis],

--- a/obp/dataset/synthetic_slate.py
+++ b/obp/dataset/synthetic_slate.py
@@ -965,7 +965,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
         else:
             n_batch = (
                 n_rounds * n_enumerated_slate_actions * self.len_list - 1
-            ) // 10**7 + 1
+            ) // 10 ** 7 + 1
             batch_size = (n_rounds - 1) // n_batch + 1
             n_batch = (n_rounds - 1) // batch_size + 1
 
@@ -1078,7 +1078,7 @@ class SyntheticSlateBanditDataset(BaseBanditDataset):
                 .flatten()
             )
             random_pscore = np.ones(context.shape[0] * self.len_list) / (
-                self.n_unique_action**self.len_list
+                self.n_unique_action ** self.len_list
             )
         else:
             random_pscore_cascade = (

--- a/obp/ope/estimators.py
+++ b/obp/ope/estimators.py
@@ -566,7 +566,7 @@ class InverseProbabilityWeighting(BaseOffPolicyEstimator):
                 iw=iw,
                 iw_hat=np.minimum(iw, self.lambda_),
             )
-        estimated_mse_score = sample_variance + (bias_term**2)
+        estimated_mse_score = sample_variance + (bias_term ** 2)
 
         return estimated_mse_score
 
@@ -1253,7 +1253,7 @@ class DoublyRobust(BaseOffPolicyEstimator):
                 iw_hat=np.minimum(iw, self.lambda_),
                 q_hat=estimated_rewards_by_reg_model[np.arange(n), action, position],
             )
-        estimated_mse_score = sample_variance + (bias_term**2)
+        estimated_mse_score = sample_variance + (bias_term ** 2)
 
         return estimated_mse_score
 
@@ -1557,7 +1557,7 @@ class SwitchDoublyRobust(DoublyRobust):
                 iw_hat=iw * np.array(iw <= self.lambda_, dtype=int),
                 q_hat=estimated_rewards_by_reg_model[np.arange(n), action, position],
             )
-        estimated_mse_score = sample_variance + (bias_term**2)
+        estimated_mse_score = sample_variance + (bias_term ** 2)
 
         return estimated_mse_score
 
@@ -1668,7 +1668,7 @@ class DoublyRobustWithShrinkage(DoublyRobust):
         n = action.shape[0]
         iw = action_dist[np.arange(n), action, position] / pscore
         if self.lambda_ < np.inf:
-            iw_hat = (self.lambda_ * iw) / (iw**2 + self.lambda_)
+            iw_hat = (self.lambda_ * iw) / (iw ** 2 + self.lambda_)
         else:
             iw_hat = iw
 
@@ -1751,7 +1751,7 @@ class DoublyRobustWithShrinkage(DoublyRobust):
         # estimate the (high probability) upper bound of the bias of DRos
         iw = action_dist[np.arange(n), action, position] / pscore
         if self.lambda_ < np.inf:
-            iw_hat = (self.lambda_ * iw) / (iw**2 + self.lambda_)
+            iw_hat = (self.lambda_ * iw) / (iw ** 2 + self.lambda_)
         else:
             iw_hat = iw
         if use_bias_upper_bound:
@@ -1769,7 +1769,7 @@ class DoublyRobustWithShrinkage(DoublyRobust):
                 iw_hat=iw_hat,
                 q_hat=estimated_rewards_by_reg_model[np.arange(n), action, position],
             )
-        estimated_mse_score = sample_variance + (bias_term**2)
+        estimated_mse_score = sample_variance + (bias_term ** 2)
 
         return estimated_mse_score
 
@@ -1951,7 +1951,7 @@ class SubGaussianInverseProbabilityWeighting(InverseProbabilityWeighting):
                 iw=iw,
                 iw_hat=iw_hat,
             )
-        estimated_mse_score = sample_variance + (bias_term**2)
+        estimated_mse_score = sample_variance + (bias_term ** 2)
 
         return estimated_mse_score
 
@@ -2153,7 +2153,7 @@ class SubGaussianDoublyRobust(DoublyRobust):
                 iw_hat=iw_hat,
                 q_hat=estimated_rewards_by_reg_model[np.arange(n), action, position],
             )
-        estimated_mse_score = sample_variance + (bias_term**2)
+        estimated_mse_score = sample_variance + (bias_term ** 2)
 
         return estimated_mse_score
 

--- a/obp/ope/estimators_continuous.py
+++ b/obp/ope/estimators_continuous.py
@@ -27,13 +27,13 @@ def triangular_kernel(u: np.ndarray) -> np.ndarray:
 
 def gaussian_kernel(u: np.ndarray) -> np.ndarray:
     """Calculate gaussian kernel function."""
-    return np.exp(-(u**2) / 2) / np.sqrt(2 * np.pi)
+    return np.exp(-(u ** 2) / 2) / np.sqrt(2 * np.pi)
 
 
 def epanechnikov_kernel(u: np.ndarray) -> np.ndarray:
     """Calculate epanechnikov kernel function."""
     clipped_u = np.clip(u, -1.0, 1.0)
-    return 0.75 * (1 - clipped_u**2)
+    return 0.75 * (1 - clipped_u ** 2)
 
 
 def cosine_kernel(u: np.ndarray) -> np.ndarray:

--- a/obp/ope/helper.py
+++ b/obp/ope/helper.py
@@ -110,7 +110,7 @@ def estimate_high_probability_upper_bound_bias(
     )
     n = reward.shape[0]
     bias_upper_bound = estimated_bias
-    bias_upper_bound += sqrt((2 * (iw**2).mean() * log(2 / delta)) / n)
+    bias_upper_bound += sqrt((2 * (iw ** 2).mean() * log(2 / delta)) / n)
     bias_upper_bound += (2 * iw.max() * log(2 / delta)) / (3 * n)
 
     return bias_upper_bound

--- a/obp/policy/logistic.py
+++ b/obp/policy/logistic.py
@@ -233,7 +233,7 @@ class LogisticUCB(BaseLogisticPolicy):
         ).flatten()
         std = np.array(
             [
-                np.sqrt(np.sum((model._q ** (-1)) * (context**2)))
+                np.sqrt(np.sum((model._q ** (-1)) * (context ** 2)))
                 for model in self.model_list
             ]
         ).flatten()
@@ -347,7 +347,7 @@ class MiniBatchLogisticRegression:
             options={"maxiter": 20, "disp": False},
         ).x
         P = (1 + np.exp(1 + X.dot(self._m))) ** (-1)
-        self._q = self._q + (P * (1 - P)).dot(X**2)
+        self._q = self._q + (P * (1 - P)).dot(X ** 2)
 
     def sd(self) -> np.ndarray:
         """Standard deviation for the coefficient vector."""

--- a/obp/policy/offline.py
+++ b/obp/policy/offline.py
@@ -1263,7 +1263,7 @@ class NNPolicyLearner(BaseOfflinePolicyLearner):
 
         elif self.off_policy_objective == "ipw-os":
             iw = current_pi[idx_tensor, action] / pscore
-            iw_ = (self.lambda_ - (iw**2)) / ((iw**2 + self.lambda_) ** 2)
+            iw_ = (self.lambda_ - (iw ** 2)) / ((iw ** 2 + self.lambda_) ** 2)
             iw_ *= self.lambda_ * iw
             estimated_policy_grad_arr = iw_ * reward
             estimated_policy_grad_arr *= log_prob[idx_tensor, action]

--- a/obp/policy/offline_continuous.py
+++ b/obp/policy/offline_continuous.py
@@ -554,7 +554,7 @@ class ContinuousNNPolicyLearner(BaseContinuousOfflinePolicyLearner):
         """
 
         def gaussian_kernel(u: torch.Tensor) -> torch.Tensor:
-            return torch.exp(-(u**2) / 2) / ((2 * np.pi) ** 0.5)
+            return torch.exp(-(u ** 2) / 2) / ((2 * np.pi) ** 0.5)
 
         if self.output_space is not None:
             action_by_current_policy = torch.clamp(

--- a/obp/utils.py
+++ b/obp/utils.py
@@ -210,10 +210,11 @@ def check_bandit_feedback_inputs(
     action: np.ndarray,
     reward: np.ndarray,
     expected_reward: Optional[np.ndarray] = None,
+    factual_reward: Optional[np.ndarray] = None,
     position: Optional[np.ndarray] = None,
     pscore: Optional[np.ndarray] = None,
     action_context: Optional[np.ndarray] = None,
-) -> Optional[ValueError]:
+) -> None:
     """Check inputs for bandit learning or simulation.
 
     Parameters
@@ -229,6 +230,9 @@ def check_bandit_feedback_inputs(
 
     expected_reward: array-like, shape (n_rounds, n_actions), default=None
         Expected reward of each data, i.e., :math:`\\mathbb{E}[r_i|x_i,a_i]`.
+
+    factual_reward: array-like, shape (n_rounds, n_actions), default=None
+        Full information rewards for each action sampled from the `expected_reward`.
 
     position: array-like, shape (n_rounds,), default=None
         Indices to differentiate positions in a recommendation interface where the actions are presented.
@@ -266,6 +270,22 @@ def check_bandit_feedback_inputs(
     else:
         if not (np.issubdtype(action.dtype, np.integer) and action.min() >= 0):
             raise ValueError("`action` elements must be non-negative integers")
+    if factual_reward is not None:
+        check_array(array=factual_reward, name="expected_reward", expected_dim=2)
+        if not (
+            context.shape[0]
+            == action.shape[0]
+            == reward.shape[0]
+            == factual_reward.shape[0]
+        ):
+            raise ValueError(
+                "Expected `context.shape[0] == action.shape[0] == reward.shape[0] == factual_reward.shape[0]`"
+                ", but found it False"
+            )
+        if not (np.all(np.choose(action, factual_reward.T) == reward)):
+            raise ValueError(
+                "`factual_reward` should match the `reward` values for each taken action."
+            )
     if pscore is not None:
         check_array(array=pscore, name="pscore", expected_dim=1)
         if not (

--- a/tests/ope/conftest.py
+++ b/tests/ope/conftest.py
@@ -149,6 +149,7 @@ def feedback_key_set() -> Set[str]:
         "action_context",
         "context",
         "expected_reward",
+        "factual_reward",
         "n_actions",
         "n_rounds",
         "position",

--- a/tests/simulator/test_simulator.py
+++ b/tests/simulator/test_simulator.py
@@ -1,0 +1,73 @@
+import re
+
+import pytest
+from obp.policy.linear import LinTS
+
+from obp.policy.contextfree import EpsilonGreedy
+from obp.dataset.synthetic import logistic_reward_function
+from obp.dataset import SyntheticBanditDataset
+from obp.policy.policy_type import PolicyType
+from obp.simulator import run_bandit_simulation
+
+
+def test_run_bandit_simulation_updates_at_each_taken_action():
+    n_rounds = 100
+
+    dataset = SyntheticBanditDataset(
+        n_actions=3,
+        dim_context=5,
+        reward_type="binary",
+        reward_function=logistic_reward_function,
+        random_state=12345,
+    )
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
+
+    epsilon_greedy = EpsilonGreedy(n_actions=3)
+    _ = run_bandit_simulation(bandit_feedback=bandit_feedback, policy=epsilon_greedy)
+
+    assert epsilon_greedy.n_trial == n_rounds
+
+
+def test_run_bandit_simulation_handles_context_in_simulations():
+    n_rounds = 100
+
+    dataset = SyntheticBanditDataset(
+        n_actions=3,
+        dim_context=5,
+        reward_type="binary",
+        reward_function=logistic_reward_function,
+        random_state=12345,
+    )
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
+
+    lin_ts = LinTS(
+        dim=dataset.dim_context, n_actions=dataset.n_actions, random_state=12345
+    )
+    _ = run_bandit_simulation(bandit_feedback=bandit_feedback, policy=lin_ts)
+
+    assert lin_ts.n_trial == n_rounds
+
+
+def test_run_bandit_simulation_raises_on_unknown_policy():
+    n_rounds = 1
+
+    dataset = SyntheticBanditDataset(
+        n_actions=3,
+    )
+    bandit_feedback = dataset.obtain_batch_bandit_feedback(n_rounds=n_rounds)
+
+    class OfflineEpsilon(EpsilonGreedy):
+        @property
+        def policy_type(self) -> PolicyType:
+            return PolicyType.OFFLINE
+
+    epsilon_greedy = OfflineEpsilon(n_actions=3)
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            r"Policy type PolicyType.OFFLINE of policy egreedy_1.0 is " r"unsupported"
+        ),
+    ):
+        _ = run_bandit_simulation(
+            bandit_feedback=bandit_feedback, policy=epsilon_greedy
+        )


### PR DESCRIPTION
### Why
As an applied researcher on applications of bandits, I want to be able to compare various bandits algorithms in simulation. 

### About the change
The current implementation of the bandit simulations use a synthetic bandits feedback log under the assumption of some logging policy. While training an online policy (eg. epsilon greedy), the policy is only updated when the taken action of the online policy is identical to the action taken by the (synthetic) logging policy. This might make sense when we want to optimise the bandit policy using logged data, however, this does not seem sensible when we are using a simulated data anyway. 

For this reason we've made the following changes to simulation aspect of the framework
* A `factual_reward` field was added to the `SyntheticBanditDataset`, which is a full-information sampled reward from the `expected_reward` in the same dataset. 
* `run_bandit_simulation` is modified to use `factual_reward` to update bandit policies. Updates happen each trial, regardless of whether the action is identical to the logged action.

### Remarks
I understand that with this change I might break some explicit assumptions that were made for the `run_bandit_simulation` method. I'm happy to be advised on how my change breaks these assumptions and how best to proceed. 
