### PR TITLE
Fix type hint

### DIFF
--- a/obp/policy/offline_continuous.py
+++ b/obp/policy/offline_continuous.py
@@ -526,7 +526,7 @@ class ContinuousNNPolicyLearner(BaseContinuousOfflinePolicyLearner):
         reward: torch.Tensor,
         pscore: torch.Tensor,
         action_by_current_policy: torch.Tensor,
-    ) -> float:
+    ) -> torch.Tensor:
         """Estimate the policy gradient.
 
         Parameters


### PR DESCRIPTION
Signed-off-by: Daiki Katsuragawa <50144563+daikikatsuragawa@users.noreply.github.com>


I read that the return type of `_estimate_policy_gradient` is not `float` but `torch.Tensor` (array-like).

I checked with mypy in an experiment.

```sh
mypy --ignore-missing-imports --disallow-untyped-def --warn-unreachable obp
```

Then the following error occurs.

```sh
obp/policy/offline_continuous.py:481: error: "float" has no attribute "mean"  [attr-defined]
obp/policy/offline_continuous.py:504: error: "float" has no attribute "mean"  [attr-defined]
```

This means that `float` is specified as the return type of `_estimate_policy_gradient`, but float has no method named `mean`.