### PR TITLE
Add Gaussian Noise Option to SyntheticBanditDataset

### DIFF
--- a/obp/policy/offline.py
+++ b/obp/policy/offline.py
@@ -441,6 +441,7 @@ class QLearner(BaseOfflinePolicyLearner):
                 raise ValueError("When `self.len_list > 1`, `position` must be given.")
 
         unif_action_dist = np.ones((context.shape[0], self.n_actions, self.len_list))
+        unif_action_dist /= self.n_actions
         self.q_estimator.fit(
             context=context,
             action=action,


### PR DESCRIPTION
- Enable to choose `reward_noise_distribution="normal"` and `reward_noise_distribution="truncated_normal"` when using `obp.dataset.SyntheticBanditDataset` with `reward_type="continuous"`. Before this, the truncated normal noise was the only option, which is not flexible for OPE experiments. 

- fix a bug of `obp.policy.QLearner` when `fitting_method="iw"`